### PR TITLE
fix: 修 CI clippy 爆红 + 本地 gate 对齐 CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,17 +154,20 @@ This project uses modern development toolchain to ensure code quality and consis
 ### Quality Check Commands
 
 ```bash
-# Frontend code checks
 cd lol-record-analysis-tauri
-npm run lint          # ESLint check
-npm run format        # Prettier formatting
-npm run typecheck     # TypeScript type check
 
-# Backend code checks (requires Windows environment)
-cd src-tauri
-cargo fmt             # Formatting
-cargo clippy          # Lint check
+# One-shot gate — runs before every commit (mirrors CI exactly)
+npm run check         # format + lint + typecheck + cargo fmt --check + clippy --all-targets --all-features -Dwarnings
+npm run test          # vitest
+
+# Individual steps (if you want to run them piecemeal)
+npm run lint          # ESLint
+npm run format        # Prettier
+npm run typecheck     # vue-tsc
+cd src-tauri && cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -Dwarnings
 ```
+
+> `npm run check` is the canonical pre-commit gate. It matches the flags used by `.github/workflows/quality-checks.yml` — if it passes locally, CI will pass.
 
 For detailed code quality standards and contribution guidelines, please refer to:
 - [Code Quality Standards](./CODE_QUALITY.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,17 +154,20 @@
 ### 质量检查命令
 
 ```bash
-# 前端代码检查
 cd lol-record-analysis-tauri
-npm run lint          # ESLint 检查
-npm run format        # Prettier 格式化
-npm run typecheck     # TypeScript 类型检查
 
-# 后端代码检查 (需要 Windows 环境)
-cd src-tauri
-cargo fmt             # 格式化
-cargo clippy          # Lint 检查
+# 一键 gate —— 提交前跑这个就够了（和 CI 完全对齐）
+npm run check         # format + lint + typecheck + cargo fmt --check + clippy --all-targets --all-features -Dwarnings
+npm run test          # vitest
+
+# 按步骤单独跑（需要时）
+npm run lint          # ESLint
+npm run format        # Prettier
+npm run typecheck     # vue-tsc
+cd src-tauri && cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -Dwarnings
 ```
+
+> `npm run check` 是提交前的权威闸门，参数和 `.github/workflows/quality-checks.yml` 完全一致 —— 本地过了，CI 就不会再红。
 
 详细的代码质量标准和贡献指南，请参阅：
 - [代码质量标准](./CODE_QUALITY.md)

--- a/lol-record-analysis-tauri/package.json
+++ b/lol-record-analysis-tauri/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts,.vue --fix",
     "typecheck": "vue-tsc --noEmit --composite false",
     "check": "npm run format && npm run lint && npm run typecheck && npm run check:rust",
-    "check:rust": "cd src-tauri && cargo fmt --check && cargo clippy -- -Dwarnings",
+    "check:rust": "cd src-tauri && cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -Dwarnings",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -608,13 +608,8 @@ fn extract_game_metric(game: &crate::lcu::api::match_history::Game, metric: &str
                 (stats.kills + stats.assists) as f64 / stats.deaths as f64
             }
         }
-        "win" => {
-            if stats.win {
-                1.0
-            } else {
-                0.0
-            }
-        }
+        "win" if stats.win => 1.0,
+        "win" => 0.0,
         "gold" => stats.gold_earned as f64,
         "cs" => stats.total_minions_killed as f64, // + neutral?
         "damage" => stats.total_damage_dealt_to_champions as f64,

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
@@ -883,6 +883,6 @@ mod tests {
 
         let weight = map.get("weightedpopoffs").expect("weightedpopoffs present");
         assert_eq!(weight.0, "你的冷却时间已缩短。");
-        assert!(map.get("summoners_rift").is_none()); // 无关键不入
+        assert!(!map.contains_key("summoners_rift")); // 无关键不入
     }
 }


### PR DESCRIPTION
根因：package.json 的 check:rust 只跑 `cargo clippy -- -Dwarnings`， 不带 --all-targets，漏过了 test 代码；CI 用的是 --all-targets --all-features， 于是 test 里的 clippy lint 只在 CI 爆。

- asset.rs: `map.get(k).is_none()` → `!map.contains_key(k)` (unnecessary_get_then_check)
- user_tag_config.rs: 嵌套 if 折叠成 pattern guard (collapsible_match)
- package.json check:rust: 加 --all-targets --all-features，和 CI 完全一致
- README / README.zh-CN: 推荐用 `npm run check` 作为提交前的权威 gate