### PR TITLE
feat: 斗魂竞技场（CHERRY 多小队）适配 + bump 1.8.0

### DIFF
--- a/docs/superpowers/specs/2026-05-10-arena-multiteam-support-design.md
+++ b/docs/superpowers/specs/2026-05-10-arena-multiteam-support-design.md
@@ -1,0 +1,320 @@
+# 斗魂竞技场（多小队模式）适配 — 设计
+
+> 状态：设计稿，待实施
+> 日期：2026-05-10
+> 作者：wnzzer
+
+## 1. 背景
+
+现有对局页 `Gaming.vue` 与详情页 `MatchDetailModal.vue` 均按 5v5 二元队伍（我方 / 敌方）设计。在斗魂竞技场（CHERRY，queueId=1700）下：
+
+- 对局页"敌方"列空白，14 名对手不可见。
+- 详情页 16 名玩家被合并成 2 团 8 人显示。
+- 名次（1~8）信息丢失。
+
+需要支持斗魂的 **8 队 × 2 人** 模式，并保持对未来类似多队模式（例如假想的 5 队 × 3 人）的兼容性。
+
+## 2. 数据接口验证（已通过 `examples/probe_arena.rs` 实地拉取真实 JSON）
+
+### 2.1 `lol-gameflow/v1/session`（对局页源）
+
+| 字段 | 5v5 | CHERRY |
+|---|---|---|
+| `gameData.queue.gameMode` | `CLASSIC` 等 | **`CHERRY`** |
+| `gameData.queue.id` | 420/430/450 | **1700** |
+| `gameData.queue.numPlayersPerTeam` | 5 | **16** |
+| `gameData.teamOne.length` | 5 | **16** |
+| `gameData.teamTwo.length` | 5 | **0** |
+
+CHERRY 下 LCU 把全部 16 人塞进 `teamOne`，`teamTwo` 为空。
+`OnePlayer` 多了 `teamParticipantId` 字段（值 1~12+，**非连续**），同 ID 是同小队两人——**但仅作弱信号**，最终小队号以详情字段为准。
+
+### 2.2 `lol-match-history/v1/games/{id}` 与战绩列表（详情/列表源）
+
+每个 `participants[i].stats` 都包含：
+
+```jsonc
+{
+  "playerSubteamId": 1,      // 1~8（CHERRY）；0（非 CHERRY）
+  "subteamPlacement": 3       // 1~8 名次（CHERRY）；0（非 CHERRY）
+}
+```
+
+`teamId` 在 CHERRY 下虽然仍是 100/200，但**与小队无关**，不可用于分组。
+
+### 2.3 当前后端漏字段
+
+- `src-tauri/src/lcu/api/model.rs::Stats` —— 缺 `player_subteam_id` / `subteam_placement`。
+- `src-tauri/src/lcu/api/session.rs::OnePlayer` —— 缺 `team_participant_id`（可选，非关键）。
+
+## 3. 设计目标
+
+1. 对局页 / 详情页在 CHERRY 模式下**正确**显示 8 个小队、各 2 人，名次可见。
+2. 5v5 既有体验**零回归**。
+3. 数据模型与组件结构**对未来 3v3v3v3 类多队模式开放**——不再硬编码 `teamOne` / `teamTwo`。
+4. 后端 / 前端类型契约**单一来源**，不出现"双轨字段"。
+
+## 4. 数据契约：统一为多小队模型
+
+将"两队"概念升级为"一组小队（subteams）"。5v5 即 2 个 subteam，CHERRY 即 8 个 subteam。
+
+### 4.1 后端 Rust（`session.rs`）
+
+```rust
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionData {
+    pub phase: String,
+    #[serde(rename = "type")]
+    pub queue_type: String,
+    pub type_cn: String,
+    pub queue_id: i32,
+    pub game_mode: String,           // 新增："CLASSIC" / "CHERRY" / ...
+    pub is_multi_team: bool,         // 新增：true = 多小队模式（CHERRY 等）
+    pub my_subteam_id: i32,          // 新增：当前用户所在的 subteamId（CHERRY=1~8；CLASSIC=1 即 team_one、2 即 team_two）
+    pub subteams: Vec<Subteam>,      // 新增：统一表达
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Subteam {
+    pub subteam_id: i32,             // 1~N（CLASSIC: 1/2；CHERRY: 1~8）
+    pub players: Vec<SessionSummoner>,
+}
+```
+
+**为什么不保留 `team_one` / `team_two` 兼容**：保留会形成"5v5 用旧字段、CHERRY 用新字段"的双轨，AI 服务、组件 props、事件监听都得双跑分支。一次性迁到 `subteams` 模型，5v5 退化为 `subteams.length === 2`，逻辑统一。
+
+**Stats 补字段**（`lcu/api/model.rs`）：
+
+```rust
+#[serde(rename = "playerSubteamId", default)] pub player_subteam_id: i32,
+#[serde(rename = "subteamPlacement", default)] pub subteam_placement: i32,
+```
+
+### 4.2 前端 TS（`types/domain/gaming.ts` & `match.ts`）
+
+```ts
+export interface Subteam {
+  subteamId: number
+  players: SessionSummoner[]
+}
+
+export interface SessionData {
+  phase: string
+  type: string
+  typeCn: string
+  queueId: number
+  gameMode: string
+  isMultiTeam: boolean
+  mySubteamId: number
+  subteams: Subteam[]
+}
+```
+
+`ParticipantStats` 加：
+
+```ts
+playerSubteamId: number    // CHERRY 1~8；其它 0
+subteamPlacement: number   // CHERRY 1~8；其它 0
+```
+
+### 4.3 事件流变化
+
+旧：`session-player-update-team-one` / `session-player-update-team-two`。
+新：合并为单一 `session-player-update`，payload 携带 `subteamId`：
+
+```rust
+struct PlayerUpdate {
+    subteam_id: i32,
+    index: usize,
+    total: usize,
+    player: SessionSummoner,
+}
+```
+
+`useSessionSync` 用 `subteamId` 找到对应 subteam 写入。
+
+## 5. 后端处理逻辑（`command/session.rs`）
+
+### 5.1 主流程改造
+
+```text
+拉 session →
+  if gameMode == "CHERRY":
+      走 CHERRY 分支（分小队）
+  else:
+      走 CLASSIC 分支（保持现状，最后包成 subteams[2]）
+→ 推 basic-info → 并行获取每个 subteam 的玩家详情 → 推 player-update → 完成
+```
+
+### 5.2 CHERRY 分支
+
+1. 不做 `need_swap`（teamTwo 必空）。
+2. 不做位置排序（CHERRY 全是 `NONE`）。
+3. 用每个玩家在**最近一场对局详情**里的 `playerSubteamId` 作为权威小队号。
+   - 第一阶段（basic-info 推送时）：尚无对局详情，回退用 `teamParticipantId` 的等价类（同 ID 视为同小队），以"临时 subteamId"建组——只供占位 UI 即时渲染。
+   - 第二阶段（详情拉到后）：用 `playerSubteamId` 重组，emit `session-subteams-resolved` 事件，前端按权威 ID 重排。
+4. `my_subteam_id`：扫描 `subteams` 找到包含 my puuid 的小队 id。
+
+> **Q: 为什么不用 `teamParticipantId` 直接当小队号？**
+> 实测它跨小队不连续（出现 1/3/4/5/6/7/8/9/10/11/12 等），且会漏掉单人对局阶段的对手数据。`playerSubteamId` 是引擎权威字段，对应"队伍1~8"的 UI 概念，要靠它做最终落定。
+
+### 5.3 CLASSIC 分支（无功能改动）
+
+照旧逻辑产出 `team_one` / `team_two`，最后包装：
+
+```rust
+SessionData {
+  is_multi_team: false,
+  my_subteam_id: 1,
+  subteams: vec![
+    Subteam { subteam_id: 1, players: team_one },
+    Subteam { subteam_id: 2, players: team_two },
+  ],
+  ...
+}
+```
+
+预组队检测 `add_pre_group_markers` 改造：从遍历 `team_one` / `team_two` 改为遍历 `subteams`。CHERRY 下"同 subteam 两人"本身就是预组队，但不再用 `preGroupMarkers` 标，改用 subteam 框头自然展示——避免重复标。`add_pre_group_markers` 仅在 `is_multi_team == false` 时执行。
+
+## 6. 前端 UI
+
+### 6.1 对局页 `Gaming.vue`
+
+新增组件 `<SubteamGrid>`：
+
+```text
+┌──────────── Gaming Page ─────────────────────────┐
+│  CLASSIC 模式：                                  │
+│    [我方 Subteam (5)]   [敌方 Subteam (5)]       │
+│                                                  │
+│  CHERRY 模式（4 列 × 2 行 网格）：               │
+│    ┌─队伍1─┐ ┌─队伍2─┐ ┌─队伍3─┐ ┌─队伍4─┐    │
+│    │ P1 P2 │ │ P3 P4 │ │ P5 P6 │ │ P7 P8 │    │
+│    └───────┘ └───────┘ └───────┘ └───────┘    │
+│    ┌─队伍5★┐ ┌─队伍6─┐ ┌─队伍7─┐ ┌─队伍8─┐    │
+│    │ P9 P10│ │P11 P12│ │P13 P14│ │P15 P16│    │
+│    └───────┘ └───────┘ └───────┘ └───────┘    │
+│       ★ = 我所在的小队（绿框 + "我方"标识）    │
+└──────────────────────────────────────────────────┘
+```
+
+#### 6.1.1 SubteamCard 组件
+
+- 输入：`subteam: Subteam`、`isMine: boolean`
+- 框头：`队伍 {{ subteamId }}` + 我方时加 `<n-tag type="primary">我方</n-tag>` 高亮（沿用现有 `team-label-blue` 配色）
+- 框身：垂直摆 2 张 PlayerCard
+- 自适应：CHERRY 下 PlayerCard 改用紧凑变体（详见 6.1.2），其它模式保持现状
+
+#### 6.1.2 PlayerCard 紧凑变体
+
+CHERRY 下卡片宽度变窄（约 25vw），需要：
+
+- `right-section`（PlayerStatsCard）改为可折叠或并到底部小字
+- `PlayerHistoryGrid` 缩为 2 列 × 2 行（4 局）
+- 不显示"近期数据"右侧栏（KDA/胜率改用顶部 inline 标签）
+
+新增 prop `density: 'normal' | 'compact'`，PlayerCard 内部按 density 切样式。CLASSIC 模式继续传 `normal`，CHERRY 模式传 `compact`。
+
+### 6.2 详情页 `MatchDetailModal.vue` / `useMatchDetailPlayers.ts`
+
+`teamSections` 计算改造：
+
+```ts
+const isCherry = computed(() => game.value?.gameMode === 'CHERRY')
+
+const groups = computed(() => {
+  if (isCherry.value) {
+    // 按 playerSubteamId 分组，subteamPlacement 排序
+    const map = new Map<number, DetailPlayer[]>()
+    for (const p of detailPlayers.value) {
+      const sid = p.stats.playerSubteamId
+      if (!map.has(sid)) map.set(sid, [])
+      map.get(sid)!.push(p)
+    }
+    return [...map.entries()]
+      .map(([subteamId, players]) => ({
+        groupId: subteamId,
+        players,
+        title: `队伍${subteamId}`,
+        placement: players[0]?.stats.subteamPlacement ?? 0,
+        won: players[0]?.stats.win ?? false,  // 直接复用引擎给的 win 字段，不自定义阈值
+        ...
+      }))
+      .sort((a, b) => a.placement - b.placement)
+  } else {
+    // 现有 teamId 分组逻辑
+    ...
+  }
+})
+```
+
+CHERRY 下小队头多一个名次徽标：`第 X 名 / 8`，颜色按名次区间映射（1~2 金、3~4 银、5~6 铜、7~8 灰）。
+
+### 6.3 战绩列表卡片 `RecordCard.vue`
+
+最低改动：CHERRY 局右侧"胜利/失败"换成"第 X 名"角标，颜色同上。
+
+## 7. AI 分析适配（`services/ai/snapshot.ts`）
+
+`analyzeGameWithAIStream` 当前以 `teamOne` / `teamTwo` 为模型构造 prompt。改造：
+
+```ts
+if (sessionData.isMultiTeam) {
+  // 用 subteams 数组 + mySubteamId 重新组织 prompt：
+  // "我方小队（队伍 X）的两名玩家、其它 7 个对手小队的玩家分组列出"
+} else {
+  // 旧逻辑
+}
+```
+
+## 8. 边界情况
+
+| 场景 | 处理 |
+|---|---|
+| 玩家中途离队（subteam 只剩 1 人） | UI 第二格显示"已离开" 占位 |
+| 选英雄阶段（CHERRY 是否走 ChampSelect 待实测；本次探针在 PreEndOfGame 阶段，未触达 champ-select 端点） | 实施时先实测：若有，按 `teamParticipantId` 临时分组；若无，对局页直接走 `phase != "InProgress"` 的 loading 占位 |
+| 隐藏战绩 | 已有 `isHiddenRecord` 占位逻辑保留 |
+| `playerSubteamId == 0` 出现在 CHERRY 详情 | 视为数据异常，并入 `subteamId=0` "未分组" 兜底，UI 显示警告 tag，不阻塞渲染 |
+| 假想未来 3v3v3v3 模式 | 数据模型不变，UI 自适应 `subteams.length` 动态网格（3 列 × 2 行 / 5 列 × 1 行） |
+
+## 9. 测试计划
+
+### 9.1 后端单元测试（`command/session.rs`）
+
+- `should_build_subteams_from_classic_session`：CLASSIC session → 2 subteams，my_subteam_id 正确
+- `should_build_subteams_from_cherry_session`：CHERRY session 16 人 → 按 playerSubteamId 分 8 组
+- `should_handle_cherry_with_partial_subteam`：某 subteam 仅 1 人时不崩
+- `should_skip_pre_group_markers_in_cherry`：CHERRY 模式不跑预组队检测
+
+### 9.2 前端单元测试
+
+- `useMatchDetailPlayers.spec.ts`：CHERRY game → 8 组 subteam，按 placement 升序
+- `useSessionSync.spec.ts`：处理 player-update 事件按 subteamId 写入
+
+### 9.3 手测脚本
+
+- 真实环境跑斗魂排队 → 验证对局页选英雄阶段渲染
+- 进入对局 → 验证 8 个 subteam 正确分组、自我高亮
+- 对局结束 → 验证名次显示
+- 切到 5v5 排位 → 验证零回归
+
+## 10. 实施顺序（粗略）
+
+1. 数据契约：Rust `Stats` + `SessionData` + `OnePlayer`，TS 类型同步
+2. 后端 `command/session.rs` 重构（CLASSIC 分支保等价、CHERRY 新分支）
+3. 前端 `useSessionSync` 适配新事件流
+4. PlayerCard 紧凑变体
+5. SubteamCard / SubteamGrid 组件 + Gaming.vue 接入
+6. `useMatchDetailPlayers` CHERRY 分组
+7. RecordCard 名次角标
+8. AI snapshot 适配
+9. 单测
+10. 手测 + 文档（CLAUDE.md 增加 multi-team 规约）
+
+## 11. 不在本次范围
+
+- 斗魂海克斯天赋（augment）UI 已有的 `usesAugments` 逻辑沿用，不改动。
+- 斗魂排位（queueId=1710 等）单独记分逻辑，下次迭代再做。
+- 详情页"整局 AI 分析"在 CHERRY 模式下的 prompt 模板调整，下次迭代。

--- a/lol-record-analysis-tauri/src-tauri/examples/probe_arena.rs
+++ b/lol-record-analysis-tauri/src-tauri/examples/probe_arena.rs
@@ -1,0 +1,197 @@
+//! 临时探针：复用现有 LCU 鉴权，把斗魂相关的原始 JSON 落盘，方便看真实 schema。
+//! 输出目录：<repo>/.claude/plans/arena-probe/
+//!
+//! 运行：cargo run -p lol-record-analysis-app --example probe_arena
+
+use lol_record_analysis_app_lib::lcu::util::http::lcu_get;
+use serde_json::Value;
+use std::path::PathBuf;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let out = repo_root()
+        .join(".claude")
+        .join("plans")
+        .join("arena-probe");
+    std::fs::create_dir_all(&out).map_err(|e| format!("mkdir failed: {e}"))?;
+    println!("output dir: {}", out.display());
+
+    // 1) gameflow session
+    match lcu_get::<Value>("lol-gameflow/v1/session").await {
+        Ok(v) => write_json(&out.join("session.json"), &v)?,
+        Err(e) => println!("[session] skip: {e}"),
+    }
+
+    // 2) champ-select session（斗魂排队/选英雄阶段）
+    match lcu_get::<Value>("lol-champ-select/v1/session").await {
+        Ok(v) => write_json(&out.join("champ-select.json"), &v)?,
+        Err(e) => println!("[champ-select] skip: {e}"),
+    }
+
+    // 2.1) lobby & 相关——可能有 subteamIndex 直接给 1-8
+    for uri in [
+        "lol-lobby/v2/lobby",
+        "lol-lobby/v2/lobby/members",
+        "lol-lobby/v2/party-active",
+        "lol-lobby/v1/parties",
+        "lol-lobby/v1/lobby",
+        "lol-lobby-team-builder/v1/matchmaking",
+        "lol-end-of-game/v1/gameclient-eog-stats-block",
+    ] {
+        match lcu_get::<Value>(uri).await {
+            Ok(v) => {
+                let safe = uri.replace('/', "_");
+                write_json(&out.join(format!("{safe}.json")), &v)?;
+            }
+            Err(e) => println!("[{uri}] skip: {e}"),
+        }
+    }
+
+    // 2.2) lol-cherry/... 试探：任何斗魂专属端点？
+    for uri in [
+        "lol-cherry/v1/state",
+        "lol-cherry/v1/lobby-state",
+        "lol-cherry/v1/team-builder",
+        "lol-cherry/v1/subteams",
+    ] {
+        match lcu_get::<Value>(uri).await {
+            Ok(v) => {
+                let safe = uri.replace('/', "_");
+                write_json(&out.join(format!("{safe}.json")), &v)?;
+            }
+            Err(e) => println!("[{uri}] skip: {e}"),
+        }
+    }
+
+    // 2.3) game flow / spectator 上报当前游戏 metadata，可能含 subteam 信息
+    for uri in [
+        "lol-gameflow/v1/early-exit-notifications/missions",
+        "lol-spectator/v1/spectate/launch",
+        "lol-end-of-game/v1/eog-stats-block",
+        "lol-end-of-game/v1/champion-mastery-updates",
+        "lol-game-rules/v1/active-game-rules",
+        "lol-game-queues/v1/queues",
+        "lol-game-data/assets/v1/cherry-augments.json",
+    ] {
+        match lcu_get::<Value>(uri).await {
+            Ok(v) => {
+                let safe = uri.replace('/', "_");
+                write_json(&out.join(format!("{safe}.json")), &v)?;
+            }
+            Err(e) => println!("[{uri}] skip: {e}"),
+        }
+    }
+
+    // 2.4) 列出 LCU 全量 swagger schema（如果可用），里面有所有 endpoint 名字
+    for uri in ["help?format=Full", "help?format=Console"] {
+        match lcu_get::<Value>(uri).await {
+            Ok(v) => {
+                let safe = uri.replace(['/', '?', '='], "_");
+                write_json(&out.join(format!("{safe}.json")), &v)?;
+                break; // 一个就够了，太大
+            }
+            Err(e) => println!("[{uri}] skip: {e}"),
+        }
+    }
+
+    // 3) 当前召唤师
+    let me: Value = match lcu_get("lol-summoner/v1/current-summoner").await {
+        Ok(v) => v,
+        Err(e) => return Err(format!("get current-summoner failed: {e}")),
+    };
+    write_json(&out.join("me.json"), &me)?;
+    let puuid = me
+        .get("puuid")
+        .and_then(|v| v.as_str())
+        .ok_or("no puuid")?
+        .to_string();
+
+    // 4) 最近 10 场对局列表
+    let matches_uri = format!(
+        "lol-match-history/v1/products/lol/{}/matches?begIndex=0&endIndex=9",
+        puuid
+    );
+    let matches: Value = match lcu_get(&matches_uri).await {
+        Ok(v) => v,
+        Err(e) => return Err(format!("get matches failed: {e}")),
+    };
+    write_json(&out.join("matches.json"), &matches)?;
+
+    // 5) 找一场斗魂（1700/1710/1810/1820）拉详情
+    let arena_queues = [1700, 1710, 1810, 1820];
+    let games = matches
+        .pointer("/games/games")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let arena_game = games.into_iter().find(|g| {
+        g.get("queueId")
+            .and_then(|q| q.as_i64())
+            .map(|q| arena_queues.contains(&(q as i32)))
+            .unwrap_or(false)
+    });
+
+    if let Some(g) = arena_game {
+        let game_id = g
+            .get("gameId")
+            .and_then(|v| v.as_i64())
+            .ok_or("no gameId")?;
+        let queue_id = g.get("queueId").and_then(|v| v.as_i64()).unwrap_or(0);
+        println!("found arena game: gameId={game_id} queueId={queue_id}");
+        let detail: Value = lcu_get(&format!("lol-match-history/v1/games/{}", game_id))
+            .await
+            .map_err(|e| format!("get arena detail failed: {e}"))?;
+        write_json(&out.join("arena-detail.json"), &detail)?;
+    } else {
+        println!("no arena game in last 10");
+    }
+
+    // 6) 顺手存一场普通排位/匹配作对照
+    let normal_queues = [420, 430, 440, 450, 700];
+    let games2 = matches
+        .pointer("/games/games")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let normal_game = games2.into_iter().find(|g| {
+        g.get("queueId")
+            .and_then(|q| q.as_i64())
+            .map(|q| normal_queues.contains(&(q as i32)))
+            .unwrap_or(false)
+    });
+    if let Some(g) = normal_game {
+        let game_id = g
+            .get("gameId")
+            .and_then(|v| v.as_i64())
+            .ok_or("no gameId")?;
+        let queue_id = g.get("queueId").and_then(|v| v.as_i64()).unwrap_or(0);
+        println!("found normal game: gameId={game_id} queueId={queue_id}");
+        let detail: Value = lcu_get(&format!("lol-match-history/v1/games/{}", game_id))
+            .await
+            .map_err(|e| format!("get normal detail failed: {e}"))?;
+        write_json(&out.join("normal-detail.json"), &detail)?;
+    }
+
+    println!("done");
+    Ok(())
+}
+
+fn write_json(path: &std::path::Path, v: &Value) -> Result<(), String> {
+    let s = serde_json::to_string_pretty(v).map_err(|e| e.to_string())?;
+    std::fs::write(path, s).map_err(|e| format!("write {} failed: {e}", path.display()))?;
+    println!("wrote {}", path.display());
+    Ok(())
+}
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR 指向 src-tauri，向上一级回到 lol-record-analysis-tauri，再上一级到仓库根
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest)
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap()
+        .to_path_buf()
+}

--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -18,9 +18,8 @@
 //!     ▼
 //! session-basic-info        # 基础信息（玩家列表、英雄等）
 //!     │
-//!     ├──▶ session-player-update-team-one   # 我方玩家逐个更新
-//!     │
-//!     └──▶ session-player-update-team-two   # 敌方玩家逐个更新
+//!     ▼
+//! session-player-update     # 各小队玩家逐个更新（payload 含 subteamId 字段）
 //!     │
 //!     ▼
 //! session-pre-group         # 预组队标记
@@ -45,7 +44,7 @@
 //! invoke('get_session_data').then(() => {
 //!     // 监听事件获取数据
 //!     listen('session-basic-info', (event) => { ... });
-//!     listen('session-player-update-team-one', (event) => { ... });
+//!     listen('session-player-update', (event) => { /* payload: { subteamId, index, total, player } */ });
 //!     listen('session-complete', (event) => { ... });
 //! });
 //! ```
@@ -62,7 +61,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tauri::{AppHandle, Emitter};
 
-/// 对局会话的完整展示数据，包含阶段、队列、双方队伍及每个玩家的汇总信息。
+/// 对局会话的完整展示数据，包含阶段、队列、所有小队及每个玩家的汇总信息。
 ///
 /// # 字段说明
 ///
@@ -70,29 +69,32 @@ use tauri::{AppHandle, Emitter};
 /// - `queue_type`: 队列类型代码
 /// - `type_cn`: 队列类型中文名称
 /// - `queue_id`: 队列 ID
-/// - `team_one`: 我方队伍（左侧）
-/// - `team_two`: 敌方队伍（右侧）
-///
-/// # 队伍说明
-///
-/// `team_one` 始终表示"我方"（当前登录用户所在队伍），`team_two` 表示"敌方"。
-/// 后端会根据当前用户的 PUUID 自动交换 LCU 返回的队伍数据。
+/// - `game_mode`: LCU 给的 gameMode（如 "CLASSIC" / "CHERRY"）
+/// - `is_multi_team`: 是否多小队模式（CHERRY 等 N 队混战）
+/// - `my_subteam_id`: 当前用户所在的 subteamId（CLASSIC: 1=team_one；CHERRY: 1~8）
+/// - `subteams`: 所有小队，CLASSIC 长度 2，CHERRY 长度 1~8
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionData {
-    /// 当前游戏阶段
     pub phase: String,
-    /// 队列类型代码
     #[serde(rename = "type")]
     pub queue_type: String,
-    /// 队列类型中文名称
     pub type_cn: String,
-    /// 队列 ID
     pub queue_id: i32,
-    /// 我方队伍（左侧）
-    pub team_one: Vec<SessionSummoner>,
-    /// 敌方队伍（右侧）
-    pub team_two: Vec<SessionSummoner>,
+    pub game_mode: String,
+    pub is_multi_team: bool,
+    pub my_subteam_id: i32,
+    pub subteams: Vec<Subteam>,
+}
+
+/// 一个小队的展示数据：编号 + 玩家列表。
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Subteam {
+    /// 小队 ID（CLASSIC: 1=我方、2=敌方；CHERRY: 1~8）
+    pub subteam_id: i32,
+    /// 小队成员
+    pub players: Vec<SessionSummoner>,
 }
 
 /// 会话中单名玩家的展示数据：英雄、召唤师、战绩、段位、用户标签、预组队标记等。
@@ -164,11 +166,10 @@ pub struct PreGroupMarker {
 /// # 事件序列
 ///
 /// 1. `session-basic-info`: 基础信息（玩家列表、英雄）
-/// 2. `session-player-update-team-one`: 我方玩家逐个更新
-/// 3. `session-player-update-team-two`: 敌方玩家逐个更新
-/// 4. `session-pre-group`: 预组队标记信息
-/// 5. `session-complete`: 完整数据（最终事件）
-/// 6. `session-error`: 错误事件（发生错误时）
+/// 2. `session-player-update`: 各小队玩家逐个更新（payload 含 `subteamId` 字段）
+/// 3. `session-pre-group`: 预组队标记信息
+/// 4. `session-complete`: 完整数据（最终事件）
+/// 5. `session-error`: 错误事件（发生错误时）
 #[tauri::command]
 pub async fn get_session_data(app_handle: AppHandle) -> Result<(), String> {
     log::info!("get_session_data called");
@@ -219,7 +220,6 @@ pub async fn get_session_data(app_handle: AppHandle) -> Result<(), String> {
 async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
     let my_summoner = Summoner::get_my_summoner().await?;
 
-    // 判断状态，若没有在游戏中，直接返回空数据
     let phase = get_phase().await?;
     let valid_phases = ["ChampSelect", "InProgress", "PreEndOfGame", "EndOfGame"];
     if !valid_phases.contains(&phase.as_str()) {
@@ -233,11 +233,9 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
 
     let mut session = Session::get_session().await?;
 
-    // 判断是否在选英雄阶段
     if phase == "ChampSelect" {
         match get_champion_select_session().await {
             Ok(select_session) => {
-                // 转换类型：从 champion_select::OnePlayer 到 session::OnePlayer
                 session.game_data.team_one = select_session
                     .my_team
                     .into_iter()
@@ -245,15 +243,19 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
                         champion_id: p.champion_id,
                         puuid: p.puuid,
                         selected_position: String::new(),
+                        team_participant_id: 0,
                     })
                     .collect();
-                session.game_data.team_two.clear(); // 选英雄阶段看不到对手
+                session.game_data.team_two.clear();
             }
             Err(e) => {
                 log::warn!("Failed to get champion select session: {}", e);
             }
         }
     }
+
+    let game_mode = session.game_data.queue.game_mode.clone();
+    let is_multi_team = game_mode == "CHERRY";
 
     let mut session_data = SessionData {
         phase: session.phase.clone(),
@@ -263,17 +265,77 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
             .unwrap_or(&"其他")
             .to_string(),
         queue_id: session.game_data.queue.id,
-        team_one: Vec::new(),
-        team_two: Vec::new(),
+        game_mode: game_mode.clone(),
+        is_multi_team,
+        my_subteam_id: 0,
+        subteams: Vec::new(),
     };
 
-    // 我方始终在左（team_one）、敌方在右（team_two）。通过 LCU 当前召唤师 my_summoner 判断，
-    // 若当前用户不在 team_one 则交换 team_one/team_two，避免数据错位。
+    if is_multi_team {
+        build_cherry_subteams(&mut session, &mut session_data, &my_summoner.puuid).await?;
+    } else {
+        build_classic_subteams(&mut session, &mut session_data, &my_summoner.puuid);
+    }
+
+    let mode = session.game_data.queue.id;
+
+    push_basic_info(&mut session_data, &app_handle).await?;
+
+    for subteam_idx in 0..session_data.subteams.len() {
+        let subteam_id = session_data.subteams[subteam_idx].subteam_id;
+        let players_meta: Vec<crate::lcu::api::session::OnePlayer> = session_data.subteams
+            [subteam_idx]
+            .players
+            .iter()
+            .map(|p| crate::lcu::api::session::OnePlayer {
+                champion_id: p.champion_id,
+                puuid: p.summoner.puuid.clone(),
+                selected_position: String::new(),
+                team_participant_id: 0,
+            })
+            .collect();
+
+        let mut filled: Vec<SessionSummoner> = Vec::with_capacity(players_meta.len());
+        process_subteam_parallel(&players_meta, &mut filled, mode, &app_handle, subteam_id).await?;
+        session_data.subteams[subteam_idx].players = filled;
+    }
+
+    if !is_multi_team {
+        add_pre_group_markers(&mut session_data);
+    }
+
+    let mut markers: HashMap<String, PreGroupMarker> = HashMap::new();
+    for subteam in &session_data.subteams {
+        for p in &subteam.players {
+            if !p.pre_group_markers.name.is_empty() {
+                markers.insert(p.summoner.puuid.clone(), p.pre_group_markers.clone());
+            }
+        }
+    }
+
+    if !markers.is_empty() {
+        app_handle
+            .emit("session-pre-group", &markers)
+            .map_err(|e| e.to_string())?;
+    }
+
+    insert_meet_gamers_record(&mut session_data, &my_summoner.puuid);
+    delete_meet_gamers_record(&mut session_data);
+
+    app_handle
+        .emit("session-complete", &session_data)
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+/// CLASSIC（5v5 等）模式分组：保留原有 swap + selections 补全 + 位置排序逻辑，最后包成 subteams[2]。
+fn build_classic_subteams(session: &mut Session, session_data: &mut SessionData, my_puuid: &str) {
     let need_swap = !session
         .game_data
         .team_one
         .iter()
-        .any(|p| p.puuid == my_summoner.puuid);
+        .any(|p| p.puuid == *my_puuid);
 
     if need_swap {
         std::mem::swap(
@@ -282,9 +344,6 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
         );
     }
 
-    // LCU 有时某队少返回 1 人（如二队只有 4 个），用 playerChampionSelections 补全为 5 人。 这是因为隐藏了用户名 隐藏战绩是可以看的
-    // selections 顺序固定为 [LCU 一队 5 人, LCU 二队 5 人]。若上面做过 need_swap，
-    // 则当前 team_one=原 LCU 二队、team_two=原 LCU 一队，补全时需对调取用的区间。
     let selections = &session.game_data.player_champion_selections;
     if selections.len() == 10 {
         let (first_five, second_five) = if need_swap {
@@ -298,7 +357,8 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
                 .map(|s| crate::lcu::api::session::OnePlayer {
                     champion_id: s.champion_id,
                     puuid: s.puuid.clone(),
-                    selected_position: String::new(), // Default for champion selection
+                    selected_position: String::new(),
+                    team_participant_id: 0,
                 })
                 .collect();
         }
@@ -309,14 +369,13 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
                     champion_id: s.champion_id,
                     puuid: s.puuid.clone(),
                     selected_position: String::new(),
+                    team_participant_id: 0,
                 })
                 .collect();
         }
     }
 
-    // 排序逻辑：根据 selected_position 对队伍进行排序
-    // 顺序：TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY, 其他
-    fn get_position_weight(pos: &str) -> i32 {
+    fn position_weight(pos: &str) -> i32 {
         match pos {
             "TOP" => 1,
             "JUNGLE" => 2,
@@ -326,213 +385,215 @@ async fn process_session_data(app_handle: AppHandle) -> Result<(), String> {
             _ => 99,
         }
     }
-
     session
         .game_data
         .team_one
-        .sort_by_key(|p| get_position_weight(&p.selected_position));
+        .sort_by_key(|p| position_weight(&p.selected_position));
     session
         .game_data
         .team_two
-        .sort_by_key(|p| get_position_weight(&p.selected_position));
+        .sort_by_key(|p| position_weight(&p.selected_position));
 
-    let mode = session.game_data.queue.id;
+    let make_placeholder = |team: &[crate::lcu::api::session::OnePlayer]| -> Vec<SessionSummoner> {
+        team.iter()
+            .map(|p| SessionSummoner {
+                champion_id: p.champion_id,
+                champion_key: format!("champion_{}", p.champion_id),
+                summoner: Summoner {
+                    puuid: p.puuid.clone(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .collect()
+    };
 
-    // 推送基础信息
-    push_basic_info(&session, &mut session_data, &app_handle).await?;
+    session_data.subteams = vec![
+        Subteam {
+            subteam_id: 1,
+            players: make_placeholder(&session.game_data.team_one),
+        },
+        Subteam {
+            subteam_id: 2,
+            players: make_placeholder(&session.game_data.team_two),
+        },
+    ];
+    session_data.my_subteam_id = 1;
+}
 
-    log::info!(
-        "正在处理队伍一（我方），人数: {}",
-        session.game_data.team_one.len()
-    );
-    // 并行处理队伍一（我方）
-    process_team_parallel(
-        &session.game_data.team_one,
-        &mut session_data.team_one,
-        mode,
-        &app_handle,
-        true, // is_team_one
-    )
-    .await?;
+/// CHERRY/斗魂分支：优先用 EOG 实时端点拿权威 1~8 小队号，否则回退到 lobby tpid。
+///
+/// **数据来源优先级**：
+/// 1. `lol-end-of-game/v1/gameclient-eog-stats-block` —— InProgress / PreEndOfGame /
+///    EndOfGame 阶段返回 16 个玩家的 `puuid + subteamId(1~8)`，权威配对。
+/// 2. fallback: `gameflow/session.teamOne` 的 `teamParticipantId` —— champ-select /
+///    lobby 阶段或 EOG 端点不可用时使用，按 tpid 分组（可能稀疏，单人对会显示已离开）。
+async fn build_cherry_subteams(
+    session: &mut Session,
+    session_data: &mut SessionData,
+    my_puuid: &str,
+) -> Result<(), String> {
+    let mut all_players: Vec<crate::lcu::api::session::OnePlayer> = Vec::new();
+    all_players.append(&mut session.game_data.team_one);
+    all_players.append(&mut session.game_data.team_two);
 
-    log::info!(
-        "正在处理队伍二（敌方），人数: {}",
-        session.game_data.team_two.len()
-    );
-    // 并行处理队伍二（敌方）
-    process_team_parallel(
-        &session.game_data.team_two,
-        &mut session_data.team_two,
-        mode,
-        &app_handle,
-        false, // is_team_one
-    )
-    .await?;
+    if all_players.is_empty() {
+        all_players = session
+            .game_data
+            .player_champion_selections
+            .iter()
+            .map(|s| crate::lcu::api::session::OnePlayer {
+                champion_id: s.champion_id,
+                puuid: s.puuid.clone(),
+                selected_position: String::new(),
+                team_participant_id: 0,
+            })
+            .collect();
+    }
 
-    // 标记预组队
-    add_pre_group_markers(&mut session_data);
+    // 尝试拉 EOG 实时端点拿权威 puuid → subteamId 映射
+    let eog_subteam_map: Option<std::collections::HashMap<String, i32>> =
+        match crate::lcu::api::eog_stats::EogStatsBlock::get().await {
+            Ok(eog) => {
+                let map: std::collections::HashMap<String, i32> = eog
+                    .stats_block
+                    .players
+                    .into_iter()
+                    .filter(|p| !p.puuid.is_empty() && p.subteam_id > 0)
+                    .map(|p| (p.puuid, p.subteam_id))
+                    .collect();
+                if map.is_empty() {
+                    None
+                } else {
+                    log::info!(
+                        "[CHERRY] EOG endpoint available, {} authoritative subteam mappings",
+                        map.len()
+                    );
+                    Some(map)
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "[CHERRY] EOG endpoint unavailable, fallback to teamParticipantId: {}",
+                    e
+                );
+                None
+            }
+        };
 
-    // ... (rest of the function remains same)
-    // 推送预组队信息
-    let mut markers: HashMap<String, PreGroupMarker> = HashMap::new();
-    for p in &session_data.team_one {
-        if !p.pre_group_markers.name.is_empty() {
-            markers.insert(p.summoner.puuid.clone(), p.pre_group_markers.clone());
+    let used_eog = eog_subteam_map.is_some();
+
+    use std::collections::BTreeMap;
+    let mut grouped: BTreeMap<i32, Vec<crate::lcu::api::session::OnePlayer>> = BTreeMap::new();
+    for p in all_players {
+        // 优先用 EOG 的权威 subteamId；缺失时回退到 tpid
+        let key = eog_subteam_map
+            .as_ref()
+            .and_then(|m| m.get(&p.puuid).copied())
+            .unwrap_or(p.team_participant_id);
+        grouped.entry(key).or_default().push(p);
+    }
+
+    // 排序：我方先（false < true），其它按原 key 升序
+    let mut entries: Vec<(i32, Vec<crate::lcu::api::session::OnePlayer>)> =
+        grouped.into_iter().collect();
+    entries.sort_by_key(|(key, group)| {
+        let is_other = !group.iter().any(|p| p.puuid == *my_puuid);
+        (is_other, *key)
+    });
+
+    let to_summoner = |p: &crate::lcu::api::session::OnePlayer| SessionSummoner {
+        champion_id: p.champion_id,
+        champion_key: format!("champion_{}", p.champion_id),
+        summoner: Summoner {
+            puuid: p.puuid.clone(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let mut subteams: Vec<Subteam> = Vec::with_capacity(entries.len());
+    let mut my_subteam_id = 0;
+    for (i, (orig_key, group)) in entries.into_iter().enumerate() {
+        // EOG 可用 → 保留权威 key（与游戏内"队伍 X"一致）；
+        // EOG 不可用 → 重映射 1..N（避免稀疏 tpid 显示成"队伍 13"）。
+        let subteam_id = if used_eog { orig_key } else { (i as i32) + 1 };
+        if group.iter().any(|p| p.puuid == *my_puuid) {
+            my_subteam_id = subteam_id;
         }
-    }
-    for p in &session_data.team_two {
-        if !p.pre_group_markers.name.is_empty() {
-            markers.insert(p.summoner.puuid.clone(), p.pre_group_markers.clone());
-        }
-    }
-
-    if !markers.is_empty() {
-        app_handle
-            .emit("session-pre-group", &markers)
-            .map_err(|e| e.to_string())?;
+        subteams.push(Subteam {
+            subteam_id,
+            players: group.iter().map(to_summoner).collect(),
+        });
     }
 
-    // 处理遇到过的玩家标签
-    insert_meet_gamers_record(&mut session_data, &my_summoner.puuid);
-
-    // 删除 Tag 标记（减少数据量）
-    delete_meet_gamers_record(&mut session_data);
-
-    // 发送完成事件
-    app_handle
-        .emit("session-complete", &session_data)
-        .map_err(|e| e.to_string())?;
-
+    session_data.subteams = subteams;
+    session_data.my_subteam_id = my_subteam_id;
     Ok(())
 }
 
-/// 并发获取基础队伍信息（召唤师名称、英雄等）。
-///
-/// 这是第一阶段的数据获取，只包含基础信息，用于快速展示。
-///
-/// # 参数
-///
-/// - `session`: LCU 会话数据
-/// - `session_data`: 输出数据结构
-/// - `app_handle`: Tauri 应用句柄
-///
-/// # 返回值
-///
-/// - `Ok(())`: 基础信息已推送
-/// - `Err(String)`: 处理错误
-///
-/// # 推送事件
-///
-/// - `session-basic-info`: 包含基础信息的 SessionData
 async fn push_basic_info(
-    session: &Session,
     session_data: &mut SessionData,
     app_handle: &AppHandle,
 ) -> Result<(), String> {
-    async fn get_basic_team(team: &[crate::lcu::api::session::OnePlayer]) -> Vec<SessionSummoner> {
-        let futures = team.iter().map(|player| async move {
-            if player.puuid.is_empty() {
-                return SessionSummoner {
-                    champion_id: player.champion_id,
-                    champion_key: format!("champion_{}", player.champion_id),
-                    summoner: Summoner::default(),
-                    match_history: MatchHistory::default(),
-                    user_tag: UserTag::default(),
-                    rank: Rank::default(),
-                    meet_games: Vec::new(),
-                    pre_group_markers: PreGroupMarker::default(),
-                    is_loading: false,
-                };
-            }
-            let summoner = Summoner::get_summoner_by_puuid(&player.puuid)
-                .await
-                .unwrap_or_default();
-
-            SessionSummoner {
-                champion_id: player.champion_id,
-                champion_key: format!("champion_{}", player.champion_id),
-                summoner,
-                match_history: MatchHistory::default(),
-                user_tag: UserTag::default(),
-                rank: Rank::default(),
-                meet_games: Vec::new(),
-                pre_group_markers: PreGroupMarker::default(),
-                is_loading: true,
+    async fn fill_team(team: &mut Vec<SessionSummoner>) {
+        let futures = team.iter().map(|placeholder| {
+            let puuid = placeholder.summoner.puuid.clone();
+            let champion_id = placeholder.champion_id;
+            async move {
+                if puuid.is_empty() {
+                    return SessionSummoner {
+                        champion_id,
+                        champion_key: format!("champion_{}", champion_id),
+                        is_loading: false,
+                        ..Default::default()
+                    };
+                }
+                let summoner = Summoner::get_summoner_by_puuid(&puuid)
+                    .await
+                    .unwrap_or_default();
+                SessionSummoner {
+                    champion_id,
+                    champion_key: format!("champion_{}", champion_id),
+                    summoner,
+                    is_loading: true,
+                    ..Default::default()
+                }
             }
         });
-
-        futures::future::join_all(futures).await
+        *team = futures::future::join_all(futures).await;
     }
 
-    session_data.team_one = get_basic_team(&session.game_data.team_one).await;
-    session_data.team_two = get_basic_team(&session.game_data.team_two).await;
+    for subteam in &mut session_data.subteams {
+        fill_team(&mut subteam.players).await;
+    }
 
     app_handle
         .emit("session-basic-info", &session_data)
         .map_err(|e| e.to_string())?;
 
-    // 清空数据以便后续处理
-    session_data.team_one.clear();
-    session_data.team_two.clear();
-
+    // 不要在这里清空 subteams.players——后续 process_subteam_parallel 会用
+    // 当前 placeholder（championId / puuid）来构造每个小队的 meta 列表，最后整体覆盖。
     Ok(())
 }
 
-/// 并行处理队伍的公共函数。
-///
-/// 并发获取队伍中所有玩家的详细信息（战绩、段位、标签等），并逐个推送更新事件。
-///
-/// # 参数
-///
-/// - `team`: LCU 队伍玩家列表
-/// - `result`: 输出结果列表
-/// - `mode`: 当前队列模式 ID
-/// - `app_handle`: Tauri 应用句柄
-/// - `is_team_one`: 是否为我方队伍（影响事件名称）
-///
-/// # 返回值
-///
-/// - `Ok(())`: 处理完成
-/// - `Err(String)`: 处理错误
-///
-/// # 推送事件
-///
-/// - `session-player-update-team-one`: 我方玩家更新
-/// - `session-player-update-team-two`: 敌方玩家更新
-///
-/// # 获取数据
-///
-/// 对每个玩家获取：
-/// 1. 召唤师信息
-/// 2. 近期战绩（通过配置决定数量）
-/// 3. 用户标签（KDA、胜率等计算数据）
-/// 4. 排位段位
-async fn process_team_parallel(
-    team: &[crate::lcu::api::session::OnePlayer],
+async fn process_subteam_parallel(
+    players: &[crate::lcu::api::session::OnePlayer],
     result: &mut Vec<SessionSummoner>,
     mode: i32,
     app_handle: &AppHandle,
-    is_team_one: bool,
+    subteam_id: i32,
 ) -> Result<(), String> {
-    // 定义获取单个玩家信息的异步任务
-    let futures = team.iter().enumerate().map(|(_index, player)| async move {
-        // 无 puuid（隐藏战绩）仍推送占位
+    let futures = players.iter().map(|player| async move {
         if player.puuid.is_empty() {
-            log::debug!("索引 {} 的玩家 PUUID 为空，跳过获取", _index);
             return SessionSummoner {
                 champion_id: player.champion_id,
                 champion_key: format!("champion_{}", player.champion_id),
-                summoner: Summoner::default(),
-                match_history: MatchHistory::default(),
-                user_tag: UserTag::default(),
-                rank: Rank::default(),
-                meet_games: Vec::new(),
-                pre_group_markers: PreGroupMarker::default(),
                 is_loading: false,
+                ..Default::default()
             };
         }
 
-        // 读取配置（轻量操作，在 join 前执行）
         let count = match crate::config::get_config("matchHistoryCount").await {
             Ok(crate::config::Value::Integer(v)) => v as i32,
             Ok(crate::config::Value::String(s)) => s.parse().unwrap_or(4),
@@ -540,16 +601,11 @@ async fn process_team_parallel(
         };
         let puuid = player.puuid.clone();
 
-        // 并行获取召唤师信息、战绩、段位
         let (summoner, match_history, rank) = tokio::join!(
             async {
-                match Summoner::get_summoner_by_puuid(&puuid).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        log::warn!("Failed to get summoner for {}: {}", puuid, e);
-                        Summoner::default()
-                    }
-                }
+                Summoner::get_summoner_by_puuid(&puuid)
+                    .await
+                    .unwrap_or_default()
             },
             async {
                 match MatchHistory::get_match_history_by_puuid(&puuid, 0, count - 1).await {
@@ -557,10 +613,7 @@ async fn process_team_parallel(
                         mh.enrich_info_cn().ok();
                         mh
                     }
-                    Err(e) => {
-                        log::warn!("Failed to get match history for {}: {}", puuid, e);
-                        MatchHistory::default()
-                    }
+                    Err(_) => MatchHistory::default(),
                 }
             },
             async {
@@ -569,50 +622,41 @@ async fn process_team_parallel(
                         r.enrich_cn_info();
                         r
                     }
-                    Err(e) => {
-                        log::warn!("Failed to get rank for {}: {}", puuid, e);
-                        Rank::default()
-                    }
+                    Err(_) => Rank::default(),
                 }
             }
         );
 
-        // 获取用户标签（可能依赖 match_history 数据，顺序执行）
-        let user_tag = match crate::command::user_tag::get_user_tag_by_puuid(&puuid, mode).await {
-            Ok(tag) => tag,
-            Err(e) => {
-                log::warn!("Failed to get user tag for {}: {}", puuid, e);
-                // 创建一个默认的 UserTag
-                UserTag {
-                    recent_data: crate::command::user_tag::RecentData {
-                        kda: 0.0,
-                        kills: 0.0,
-                        deaths: 0.0,
-                        assists: 0.0,
-                        select_mode: mode,
-                        select_mode_cn: QUEUE_ID_TO_CN
-                            .get(&(mode as u32))
-                            .unwrap_or(&"未知模式")
-                            .to_string(),
-                        select_wins: 0,
-                        select_losses: 0,
-                        group_rate: 0,
-                        average_gold: 0,
-                        gold_rate: 0,
-                        average_damage_dealt_to_champions: 0,
-                        damage_dealt_to_champions_rate: 0,
-                        friend_and_dispute: Default::default(),
-                        one_game_players_map: None,
-                    },
-                    tag: Vec::new(),
-                }
-            }
-        };
+        let user_tag = crate::command::user_tag::get_user_tag_by_puuid(&puuid, mode)
+            .await
+            .unwrap_or_else(|_| UserTag {
+                recent_data: crate::command::user_tag::RecentData {
+                    kda: 0.0,
+                    kills: 0.0,
+                    deaths: 0.0,
+                    assists: 0.0,
+                    select_mode: mode,
+                    select_mode_cn: QUEUE_ID_TO_CN
+                        .get(&(mode as u32))
+                        .unwrap_or(&"未知模式")
+                        .to_string(),
+                    select_wins: 0,
+                    select_losses: 0,
+                    group_rate: 0,
+                    average_gold: 0,
+                    gold_rate: 0,
+                    average_damage_dealt_to_champions: 0,
+                    damage_dealt_to_champions_rate: 0,
+                    friend_and_dispute: Default::default(),
+                    one_game_players_map: None,
+                },
+                tag: Vec::new(),
+            });
 
         SessionSummoner {
             champion_id: player.champion_id,
             champion_key: format!("champion_{}", player.champion_id),
-            summoner: summoner.clone(),
+            summoner,
             match_history,
             user_tag,
             rank,
@@ -622,154 +666,77 @@ async fn process_team_parallel(
         }
     });
 
-    // 并行执行所有任务
     let fetched_players = futures::future::join_all(futures).await;
 
-    // 将结果添加到 result 并推送事件
     for (index, session_summoner) in fetched_players.into_iter().enumerate() {
         result.push(session_summoner.clone());
 
-        let event_name = if is_team_one {
-            "session-player-update-team-one"
-        } else {
-            "session-player-update-team-two"
-        };
-
         #[derive(Serialize)]
         struct PlayerUpdate {
+            #[serde(rename = "subteamId")]
+            subteam_id: i32,
             index: usize,
             total: usize,
             player: SessionSummoner,
-            is_team_one: bool,
         }
 
         let update = PlayerUpdate {
+            subteam_id,
             index,
-            total: team.len(),
+            total: players.len(),
             player: session_summoner,
-            is_team_one,
         };
 
-        if let Err(e) = app_handle.emit(event_name, &update) {
+        if let Err(e) = app_handle.emit("session-player-update", &update) {
             log::error!("Failed to emit player update event: {}", e);
-        } else {
-            // log::info!("Emitted player update: {} of {}", index + 1, team.len());
         }
     }
 
     Ok(())
 }
 
-/// 标记预组队队友。
-///
-/// 分析每个玩家的历史对局记录，检测可能预组队的玩家群体。
-///
-/// # 参数
-///
-/// - `session_data`: 会话数据，将被修改添加预组队标记
-///
-/// # 检测逻辑
-///
-/// 1. 遍历每个玩家的 `one_game_players_map`（历史同场玩家）
-/// 2. 筛选出也在当前对局中的玩家
-/// 3. 统计同队次数（`is_my_team = true`）
-/// 4. 同队次数 >= 3 视为可能预组队
-/// 5. 合并重叠的队伍（去除子集）
-/// 6. 为检测到的预组队分配标记
-///
-/// # 标记分配
-///
-/// 最多支持 4 个预组队标记：
-/// - 队伍1: success（绿色）
-/// - 队伍2: warning（黄色）
-/// - 队伍3: error（红色）
-/// - 队伍4: info（蓝色）
 fn add_pre_group_markers(session_data: &mut SessionData) {
     let friend_threshold = 3;
     let team_min_sum = 2;
     let mut all_maybe_teams: Vec<Vec<String>> = Vec::new();
 
-    // 获取当前对局所有人的 PUUID
     let mut current_game_puuids: HashMap<String, bool> = HashMap::new();
-    let team_one_puuids: Vec<String> = session_data
-        .team_one
+    let subteam_puuids: Vec<Vec<String>> = session_data
+        .subteams
         .iter()
-        .map(|s| s.summoner.puuid.clone())
-        .collect();
-    let team_two_puuids: Vec<String> = session_data
-        .team_two
-        .iter()
-        .map(|s| s.summoner.puuid.clone())
+        .map(|s| s.players.iter().map(|p| p.summoner.puuid.clone()).collect())
         .collect();
 
-    for puuid in &team_one_puuids {
-        current_game_puuids.insert(puuid.clone(), true);
+    for puuids in &subteam_puuids {
+        for puuid in puuids {
+            current_game_puuids.insert(puuid.clone(), true);
+        }
     }
-    for puuid in &team_two_puuids {
-        current_game_puuids.insert(puuid.clone(), true);
-    }
 
-    // 处理 TeamOne（我方）
-    for session_summoner in &session_data.team_one {
-        let mut the_teams = Vec::new();
-
-        if let Some(ref one_game_players_map) =
-            session_summoner.user_tag.recent_data.one_game_players_map
-        {
-            for (puuid, play_record_arr) in one_game_players_map {
-                // 如果不在当前对局中，跳过这个玩家的统计
-                if !current_game_puuids.contains_key(puuid) {
-                    continue;
-                }
-
-                let team_count = play_record_arr
-                    .iter()
-                    .filter(|record| record.is_my_team)
-                    .count();
-
-                if team_count >= friend_threshold {
-                    the_teams.push(puuid.clone());
+    for subteam in &session_data.subteams {
+        for session_summoner in &subteam.players {
+            let mut the_teams = Vec::new();
+            if let Some(ref one_game_players_map) =
+                session_summoner.user_tag.recent_data.one_game_players_map
+            {
+                for (puuid, play_record_arr) in one_game_players_map {
+                    if !current_game_puuids.contains_key(puuid) {
+                        continue;
+                    }
+                    let team_count = play_record_arr.iter().filter(|r| r.is_my_team).count();
+                    if team_count >= friend_threshold {
+                        the_teams.push(puuid.clone());
+                    }
                 }
             }
-        }
-
-        if !the_teams.is_empty() {
-            all_maybe_teams.push(the_teams);
-        }
-    }
-
-    // 处理 TeamTwo（敌方）
-    for session_summoner in &session_data.team_two {
-        let mut the_teams = Vec::new();
-
-        if let Some(ref one_game_players_map) =
-            session_summoner.user_tag.recent_data.one_game_players_map
-        {
-            for (puuid, play_record_arr) in one_game_players_map {
-                if !current_game_puuids.contains_key(puuid) {
-                    continue;
-                }
-
-                let team_count = play_record_arr
-                    .iter()
-                    .filter(|record| record.is_my_team)
-                    .count();
-
-                if team_count >= friend_threshold {
-                    the_teams.push(puuid.clone());
-                }
+            if !the_teams.is_empty() {
+                all_maybe_teams.push(the_teams);
             }
         }
-
-        if !the_teams.is_empty() {
-            all_maybe_teams.push(the_teams);
-        }
     }
 
-    // 合并队伍，去除子集
     let merged_teams = remove_subsets(&all_maybe_teams);
 
-    // 标记预组队信息
     let pre_group_maker_consts = [
         PreGroupMarker {
             name: "队伍1".to_string(),
@@ -793,31 +760,21 @@ fn add_pre_group_markers(session_data: &mut SessionData) {
 
     for team in merged_teams {
         let mut marked = false;
-        let intersection_team_one = intersection(&team, &team_one_puuids);
-        let intersection_team_two = intersection(&team, &team_two_puuids);
-
-        if intersection_team_one.len() >= team_min_sum {
-            for session_summoner in &mut session_data.team_one {
-                if one_in_arr(&session_summoner.summoner.puuid, &intersection_team_one)
-                    && session_summoner.pre_group_markers.name.is_empty()
-                {
-                    session_summoner.pre_group_markers =
-                        pre_group_maker_consts[const_index].clone();
-                    marked = true;
+        for (subteam_idx, st_puuids) in subteam_puuids.iter().enumerate() {
+            let inter = intersection(&team, st_puuids);
+            if inter.len() >= team_min_sum {
+                for s in &mut session_data.subteams[subteam_idx].players {
+                    if one_in_arr(&s.summoner.puuid, &inter) && s.pre_group_markers.name.is_empty()
+                    {
+                        s.pre_group_markers = pre_group_maker_consts[const_index].clone();
+                        marked = true;
+                    }
                 }
-            }
-        } else if intersection_team_two.len() >= team_min_sum {
-            for session_summoner in &mut session_data.team_two {
-                if one_in_arr(&session_summoner.summoner.puuid, &intersection_team_two)
-                    && session_summoner.pre_group_markers.name.is_empty()
-                {
-                    session_summoner.pre_group_markers =
-                        pre_group_maker_consts[const_index].clone();
-                    marked = true;
+                if marked {
+                    break; // 保留原 if/else if 语义：单组只标第一个匹配的小队
                 }
             }
         }
-
         if marked {
             const_index += 1;
             if const_index >= pre_group_maker_consts.len() {
@@ -827,58 +784,33 @@ fn add_pre_group_markers(session_data: &mut SessionData) {
     }
 }
 
-/// 插入遇到过的玩家记录。
-///
-/// 将当前用户与每个玩家的历史对局记录填充到 `meet_games` 字段。
-///
-/// # 参数
-///
-/// - `session_data`: 会话数据
-/// - `my_puuid`: 当前用户的 PUUID
 fn insert_meet_gamers_record(session_data: &mut SessionData, my_puuid: &str) {
-    // 获取自己的 SessionSummoner 并克隆 one_game_players_map 以避免借用冲突
     let my_one_game_players_map = session_data
-        .team_one
+        .subteams
         .iter()
+        .flat_map(|s| s.players.iter())
         .find(|s| s.summoner.puuid == my_puuid)
         .and_then(|s| s.user_tag.recent_data.one_game_players_map.clone());
 
     if let Some(my_map) = my_one_game_players_map {
-        // 遍历并修改我方
-        for session_summoner in &mut session_data.team_one {
-            if session_summoner.summoner.puuid == my_puuid {
-                continue;
-            }
-            if let Some(games) = my_map.get(&session_summoner.summoner.puuid) {
-                session_summoner.meet_games = games.clone();
-            }
-        }
-
-        // 遍历并修改敌方
-        for session_summoner in &mut session_data.team_two {
-            if session_summoner.summoner.puuid == my_puuid {
-                continue;
-            }
-            if let Some(games) = my_map.get(&session_summoner.summoner.puuid) {
-                session_summoner.meet_games = games.clone();
+        for subteam in &mut session_data.subteams {
+            for s in &mut subteam.players {
+                if s.summoner.puuid == my_puuid {
+                    continue;
+                }
+                if let Some(games) = my_map.get(&s.summoner.puuid) {
+                    s.meet_games = games.clone();
+                }
             }
         }
     }
 }
 
-/// 删除 Tag 标记中的 OneGamePlayersMap（减少传输数据量）。
-///
-/// 在发送最终数据前清理不需要的大字段，减少 IPC 传输开销。
-///
-/// # 参数
-///
-/// - `session_data`: 会话数据
 fn delete_meet_gamers_record(session_data: &mut SessionData) {
-    for session_summoner in &mut session_data.team_one {
-        session_summoner.user_tag.recent_data.one_game_players_map = None;
-    }
-    for session_summoner in &mut session_data.team_two {
-        session_summoner.user_tag.recent_data.one_game_players_map = None;
+    for subteam in &mut session_data.subteams {
+        for s in &mut subteam.players {
+            s.user_tag.recent_data.one_game_players_map = None;
+        }
     }
 }
 
@@ -967,4 +899,249 @@ fn intersection(arr1: &[String], arr2: &[String]) -> Vec<String> {
 /// - `false`: 元素不在数组中
 fn one_in_arr(e: &str, arr: &[String]) -> bool {
     arr.iter().any(|elem| elem == e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lcu::api::session::{GameData, OnePlayer, Queue, Session};
+
+    fn make_session_classic() -> Session {
+        Session {
+            phase: "InProgress".into(),
+            game_data: GameData {
+                game_id: 1,
+                is_custom_game: false,
+                queue: Queue {
+                    queue_type: "RANKED_SOLO_5x5".into(),
+                    id: 420,
+                    game_mode: "CLASSIC".into(),
+                },
+                player_champion_selections: vec![],
+                team_one: (1..=5)
+                    .map(|i| OnePlayer {
+                        champion_id: i,
+                        puuid: format!("ally-{}", i),
+                        selected_position: "TOP".into(),
+                        team_participant_id: 0,
+                    })
+                    .collect(),
+                team_two: (6..=10)
+                    .map(|i| OnePlayer {
+                        champion_id: i,
+                        puuid: format!("enemy-{}", i),
+                        selected_position: "TOP".into(),
+                        team_participant_id: 0,
+                    })
+                    .collect(),
+            },
+        }
+    }
+
+    #[test]
+    fn classic_should_build_two_subteams_with_my_subteam_one() {
+        let mut session = make_session_classic();
+        let mut data = SessionData {
+            game_mode: "CLASSIC".into(),
+            ..Default::default()
+        };
+        build_classic_subteams(&mut session, &mut data, "ally-1");
+        assert_eq!(data.subteams.len(), 2);
+        assert_eq!(data.subteams[0].subteam_id, 1);
+        assert_eq!(data.subteams[1].subteam_id, 2);
+        assert_eq!(data.my_subteam_id, 1);
+        assert!(data.subteams[0]
+            .players
+            .iter()
+            .any(|p| p.summoner.puuid == "ally-1"));
+    }
+
+    #[test]
+    fn classic_should_swap_when_user_in_team_two() {
+        let mut session = make_session_classic();
+        let mut data = SessionData {
+            game_mode: "CLASSIC".into(),
+            ..Default::default()
+        };
+        build_classic_subteams(&mut session, &mut data, "enemy-7");
+        assert!(data.subteams[0]
+            .players
+            .iter()
+            .any(|p| p.summoner.puuid == "enemy-7"));
+        assert_eq!(data.my_subteam_id, 1);
+    }
+
+    fn make_session_cherry() -> Session {
+        // 8 个 subteam × 2 人 = 16，全部塞 team_one
+        let mut team_one = Vec::new();
+        for tpid in 1..=8 {
+            for slot in 0..2 {
+                team_one.push(OnePlayer {
+                    champion_id: tpid * 10 + slot,
+                    puuid: format!("p-{}-{}", tpid, slot),
+                    selected_position: "NONE".into(),
+                    team_participant_id: tpid,
+                });
+            }
+        }
+        Session {
+            phase: "InProgress".into(),
+            game_data: GameData {
+                game_id: 2,
+                is_custom_game: false,
+                queue: Queue {
+                    queue_type: "CHERRY".into(),
+                    id: 1700,
+                    game_mode: "CHERRY".into(),
+                },
+                player_champion_selections: vec![],
+                team_one,
+                team_two: vec![],
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn cherry_should_split_into_eight_subteams_of_two() {
+        let mut session = make_session_cherry();
+        let mut data = SessionData {
+            game_mode: "CHERRY".into(),
+            is_multi_team: true,
+            ..Default::default()
+        };
+        build_cherry_subteams(&mut session, &mut data, "p-3-0")
+            .await
+            .unwrap();
+        assert_eq!(data.subteams.len(), 8);
+        for s in &data.subteams {
+            assert_eq!(s.players.len(), 2);
+        }
+        // my_puuid p-3-0 应在某个 subteam 里
+        let mine = data
+            .subteams
+            .iter()
+            .find(|s| s.players.iter().any(|p| p.summoner.puuid == "p-3-0"))
+            .expect("my subteam");
+        assert_eq!(data.my_subteam_id, mine.subteam_id);
+    }
+
+    #[tokio::test]
+    async fn cherry_should_handle_partial_subteam() {
+        // 只剩 3 人，分成 2 + 1
+        let mut session = Session {
+            phase: "InProgress".into(),
+            game_data: GameData {
+                game_id: 3,
+                is_custom_game: false,
+                queue: Queue {
+                    queue_type: "CHERRY".into(),
+                    id: 1700,
+                    game_mode: "CHERRY".into(),
+                },
+                player_champion_selections: vec![],
+                team_one: vec![
+                    OnePlayer {
+                        champion_id: 1,
+                        puuid: "a".into(),
+                        selected_position: "".into(),
+                        team_participant_id: 1,
+                    },
+                    OnePlayer {
+                        champion_id: 2,
+                        puuid: "b".into(),
+                        selected_position: "".into(),
+                        team_participant_id: 1,
+                    },
+                    OnePlayer {
+                        champion_id: 3,
+                        puuid: "c".into(),
+                        selected_position: "".into(),
+                        team_participant_id: 4,
+                    },
+                ],
+                team_two: vec![],
+            },
+        };
+        let mut data = SessionData {
+            game_mode: "CHERRY".into(),
+            is_multi_team: true,
+            ..Default::default()
+        };
+        build_cherry_subteams(&mut session, &mut data, "a")
+            .await
+            .unwrap();
+        assert_eq!(data.subteams.len(), 2);
+        assert_eq!(data.subteams[0].players.len(), 2);
+        assert_eq!(data.subteams[1].players.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cherry_should_preserve_sparse_tpids_without_synthetic_pairing() {
+        // 腾讯客户端真实数据：4 个完整对 + 8 个单人 → 12 个 raw 组
+        // 不强行合并单人——保留 12 个 subteam（4 个 2 人 + 8 个 1 人）
+        let mut team_one = Vec::new();
+        for tpid in [1, 4, 6, 7] {
+            for slot in 0..2 {
+                team_one.push(OnePlayer {
+                    champion_id: tpid * 10 + slot,
+                    puuid: format!("paired-{}-{}", tpid, slot),
+                    selected_position: "NONE".into(),
+                    team_participant_id: tpid,
+                });
+            }
+        }
+        for tpid in [3, 5, 8, 9, 10, 11, 12, 13] {
+            team_one.push(OnePlayer {
+                champion_id: tpid * 10,
+                puuid: format!("solo-{}", tpid),
+                selected_position: "NONE".into(),
+                team_participant_id: tpid,
+            });
+        }
+        let mut session = Session {
+            phase: "InProgress".into(),
+            game_data: GameData {
+                game_id: 4,
+                is_custom_game: false,
+                queue: Queue {
+                    queue_type: "CHERRY".into(),
+                    id: 1700,
+                    game_mode: "CHERRY".into(),
+                },
+                player_champion_selections: vec![],
+                team_one,
+                team_two: vec![],
+            },
+        };
+        let mut data = SessionData {
+            game_mode: "CHERRY".into(),
+            is_multi_team: true,
+            ..Default::default()
+        };
+        build_cherry_subteams(&mut session, &mut data, "paired-1-0")
+            .await
+            .unwrap();
+        // 不合并：每个 raw tpid 保留为独立 subteam
+        assert_eq!(data.subteams.len(), 12);
+        // 我方排第一
+        assert_eq!(data.my_subteam_id, 1);
+        assert!(data.subteams[0]
+            .players
+            .iter()
+            .any(|p| p.summoner.puuid == "paired-1-0"));
+        assert_eq!(data.subteams[0].players.len(), 2);
+        // 4 个完整对（含我方）+ 8 个单人
+        let pair_count = data
+            .subteams
+            .iter()
+            .filter(|s| s.players.len() == 2)
+            .count();
+        let solo_count = data
+            .subteams
+            .iter()
+            .filter(|s| s.players.len() == 1)
+            .count();
+        assert_eq!(pair_count, 4);
+        assert_eq!(solo_count, 8);
+    }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api.rs
@@ -5,6 +5,7 @@
 
 pub mod asset;
 pub mod champion_select;
+pub mod eog_stats;
 pub mod game_detail;
 pub mod lobby;
 pub mod match_history;

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/eog_stats.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/eog_stats.rs
@@ -1,0 +1,54 @@
+//! # 当前对局结算预统计 API
+//!
+//! 对应 `lol-end-of-game/v1/gameclient-eog-stats-block`：在 InProgress / PreEndOfGame
+//! 阶段实时返回当前对局所有玩家的 PUUID、英雄、KDA 与 **`subteamId`（CHERRY 1~8）**。
+//!
+//! 主要用途：CHERRY 模式下用于把 lobby 阶段稀疏的 `teamParticipantId`
+//! 修正为权威 1~8 小队号。
+
+use serde::{Deserialize, Serialize};
+
+/// 实时结算统计 block。
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EogStatsBlock {
+    pub game_id: i64,
+    pub game_mode: String,
+    pub queue_id: i32,
+    #[serde(rename = "queueType")]
+    pub queue_type: String,
+    pub stats_block: StatsBlock,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StatsBlock {
+    pub game_length_seconds: i32,
+    pub players: Vec<EogPlayer>,
+}
+
+/// 单个玩家的 EOG 数据。仅保留需要的字段；其它由 LCU 多余字段会被 serde 忽略。
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EogPlayer {
+    /// 注意 LCU 这里键名是大写 `PUUID`，不是 camelCase
+    #[serde(rename = "PUUID", default)]
+    pub puuid: String,
+    #[serde(default)]
+    pub champion_id: i32,
+    /// CHERRY/斗魂模式：1~8，玩家所属小队 ID
+    #[serde(default)]
+    pub subteam_id: i32,
+    /// CHERRY/斗魂模式：1~8，小队当前/最终名次
+    #[serde(default)]
+    pub subteam_standing: i32,
+}
+
+impl EogStatsBlock {
+    /// 拉取 `lol-end-of-game/v1/gameclient-eog-stats-block`。
+    ///
+    /// 仅 InProgress / PreEndOfGame / EndOfGame 阶段返回有效数据；其它阶段返回错误。
+    pub async fn get() -> Result<Self, String> {
+        crate::lcu::util::http::lcu_get("lol-end-of-game/v1/gameclient-eog-stats-block").await
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/model.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/model.rs
@@ -107,10 +107,57 @@ pub struct Stats {
     pub damage_taken_rate: i32,
     #[serde(rename = "healRate", default)]
     pub heal_rate: i32,
+    /// CHERRY/斗魂模式：1~8 表示玩家所属小队 ID；非 CHERRY 局为 0
+    #[serde(rename = "playerSubteamId", default)]
+    pub player_subteam_id: i32,
+    /// CHERRY/斗魂模式：1~8 表示该小队的最终名次（1=冠军）；非 CHERRY 局为 0
+    #[serde(rename = "subteamPlacement", default)]
+    pub subteam_placement: i32,
 }
 
 /// 参与者身份：关联到 Player（账号/召唤师信息）。
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ParticipantIdentity {
     pub player: Player,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_deserialize_arena_subteam_fields() {
+        let json = r#"{
+            "win": true,
+            "item0": 0, "item1": 0, "item2": 0, "item3": 0, "item4": 0, "item5": 0, "item6": 0,
+            "perkPrimaryStyle": 0, "perkSubStyle": 0,
+            "kills": 5, "deaths": 2, "assists": 8,
+            "goldEarned": 12000, "goldSpent": 11000,
+            "totalDamageDealtToChampions": 30000, "totalDamageDealt": 100000,
+            "totalDamageTaken": 20000, "totalHeal": 7000,
+            "totalMinionsKilled": 0,
+            "playerSubteamId": 3,
+            "subteamPlacement": 5
+        }"#;
+        let stats: Stats = serde_json::from_str(json).unwrap();
+        assert_eq!(stats.player_subteam_id, 3);
+        assert_eq!(stats.subteam_placement, 5);
+    }
+
+    #[test]
+    fn should_default_subteam_fields_when_absent() {
+        let json = r#"{
+            "win": true,
+            "item0": 0, "item1": 0, "item2": 0, "item3": 0, "item4": 0, "item5": 0, "item6": 0,
+            "perkPrimaryStyle": 0, "perkSubStyle": 0,
+            "kills": 0, "deaths": 0, "assists": 0,
+            "goldEarned": 0, "goldSpent": 0,
+            "totalDamageDealtToChampions": 0, "totalDamageDealt": 0,
+            "totalDamageTaken": 0, "totalHeal": 0,
+            "totalMinionsKilled": 0
+        }"#;
+        let stats: Stats = serde_json::from_str(json).unwrap();
+        assert_eq!(stats.player_subteam_id, 0);
+        assert_eq!(stats.subteam_placement, 0);
+    }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/session.rs
@@ -35,21 +35,26 @@ pub struct GameData {
 
 /// 队列类型与 ID（如排位/匹配）。
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")] // Apply camelCase deserialization to Queue fields
+#[serde(rename_all = "camelCase")]
 pub struct Queue {
-    #[serde(rename = "type")] // 'type' is a Rust keyword, so explicitly rename
+    #[serde(rename = "type")]
     pub queue_type: String,
     pub id: i32,
+    #[serde(default)]
+    pub game_mode: String,
 }
 
 /// 会话中单名玩家：英雄 ID 与 PUUID。
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")] // Apply camelCase deserialization to OnePlayer fields
+#[serde(rename_all = "camelCase")]
 pub struct OnePlayer {
     pub champion_id: i32,
     pub puuid: String,
     #[serde(default)]
     pub selected_position: String,
+    /// CHERRY 模式下的 lobby 阶段编号；同 ID 的玩家是同小队（仅作弱信号，最终以 stats.playerSubteamId 为准）
+    #[serde(default)]
+    pub team_participant_id: i32,
 }
 
 impl Session {

--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "lol-record-analysis-app",
-  "version": "1.7.6",
+  "version": "1.8.0",
   "identifier": "com.lol-record-analysis-tauri.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -4,11 +4,14 @@
     :class="[
       { 'light-mode-strip': settingsStore.theme?.name === 'Light' },
       props.team === 'blue' && 'player-card-team-blue',
-      props.team === 'red' && 'player-card-team-red'
+      props.team === 'red' && 'player-card-team-red',
+      props.team === 'mine' && 'player-card-team-mine',
+      props.team === 'enemy' && 'player-card-team-enemy',
+      `player-card-density-${props.density}`
     ]"
     size="small"
     :bordered="true"
-    content-style="padding: 8px;"
+    content-style="padding: 6px;"
   >
     <div v-if="sessionSummoner.isLoading" key="loading-known" class="loading-container">
       <div class="custom-spin"></div>
@@ -193,10 +196,11 @@ interface Props {
   imgUrl: string
   tierCn: string
   queueId: number
-  team?: 'blue' | 'red'
+  team?: 'blue' | 'red' | 'mine' | 'enemy' | undefined
+  density?: 'normal' | 'compact'
 }
 
-const props = withDefaults(defineProps<Props>(), { team: undefined })
+const props = withDefaults(defineProps<Props>(), { team: undefined, density: 'normal' })
 
 const settingsStore = useSettingsStore()
 const isDark = computed(
@@ -405,5 +409,33 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   background: rgba(251, 191, 36, 0.1) !important;
   color: #d97706 !important;
   border: 1px solid rgba(251, 191, 36, 0.2) !important;
+}
+
+.player-card-team-mine {
+  border-left: 2px solid var(--team-blue);
+  border-color: var(--border-subtle);
+  border-left-color: rgba(34, 197, 94, 0.7);
+}
+
+.player-card-team-enemy {
+  border-left: 2px solid var(--team-red);
+  border-color: var(--border-subtle);
+  border-left-color: rgba(239, 68, 68, 0.5);
+}
+
+.player-card-density-compact .right-section {
+  display: none;
+}
+
+.player-card-density-compact .left-section {
+  gap: 4px;
+}
+
+.player-card-density-compact :deep(.player-history-grid) {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.player-card-density-compact .info-wrapper :deep(.n-button) {
+  font-size: 12px;
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -87,6 +87,8 @@ defineProps<{ games: Game[] }>()
   font-size: 12px;
   min-width: 60px;
   text-align: center;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .kill {

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="subteam-card" :class="{ 'subteam-card-mine': isMine }">
+    <div class="subteam-card-header">
+      <span class="subteam-card-title">队伍 {{ subteam.subteamId }}</span>
+      <n-tag v-if="isMine" size="small" type="success" :bordered="false">我方</n-tag>
+    </div>
+    <div class="subteam-card-body">
+      <PlayerCard
+        v-for="(p, i) of subteam.players"
+        :key="`subteam-${subteam.subteamId}-${i}-${p.summoner.puuid}`"
+        :session-summoner="p"
+        :type-cn="typeCn"
+        :mode-type="modeType"
+        :queue-id="queueId"
+        :img-url="tiersBySubteam[subteam.subteamId]?.[i]?.imgUrl ?? ''"
+        :tier-cn="tiersBySubteam[subteam.subteamId]?.[i]?.tierCn ?? '无'"
+        :team="isMine ? 'mine' : 'enemy'"
+        :density="density"
+      />
+      <div v-for="i in placeholderCount" :key="`placeholder-${i}`" class="subteam-card-empty">
+        <span>已离开</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { NTag } from 'naive-ui'
+import PlayerCard from './PlayerCard.vue'
+import type { Subteam } from '@renderer/types/domain/gaming'
+import type { TierDisplay } from '@renderer/composables/useSessionTiers'
+
+interface Props {
+  subteam: Subteam
+  isMine: boolean
+  expectedSize: number
+  typeCn: string
+  modeType: string
+  queueId: number
+  tiersBySubteam: Record<number, TierDisplay[]>
+  density: 'normal' | 'compact'
+}
+
+const props = withDefaults(defineProps<Props>(), { density: 'normal' })
+const placeholderCount = computed(() =>
+  Math.max(0, props.expectedSize - props.subteam.players.length)
+)
+</script>
+
+<style scoped>
+.subteam-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  border-radius: var(--radius-md);
+  background: var(--glass-bg-mid);
+  border: 1px solid var(--glass-border);
+  min-height: 0;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.subteam-card-mine {
+  border-color: rgba(34, 197, 94, 0.6);
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.3);
+}
+
+.subteam-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+}
+
+.subteam-card-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.subteam-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.subteam-card-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
+  font-size: 11px;
+  min-height: 60px;
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -722,6 +722,7 @@ watch(
   border-radius: 10px;
   overflow: hidden;
   background: rgba(0, 0, 0, 0.06);
+  flex-shrink: 0;
 }
 
 .theme-light .match-detail-team-section {

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -21,7 +21,7 @@
             marginTop: '2px'
           }"
         >
-          {{ games.participants[0].stats.win ? '胜利' : '失败' }}
+          {{ resultLabel }}
           <n-divider style="margin: 1px 0; line-height: 1px" />
         </span>
 
@@ -245,6 +245,15 @@ const isDark = computed(
 /** 海克斯乱斗模式 queueId: 1700(斗魂竞技场), 2400(海克斯大乱斗) */
 const augmentQueueIds = new Set([1700, 2400])
 const usesAugments = computed(() => augmentQueueIds.has(props.games.queueId))
+
+const isCherry = computed(() => props.games.gameMode === 'CHERRY')
+const placement = computed(() => props.games.participants[0]?.stats?.subteamPlacement ?? 0)
+const resultLabel = computed(() => {
+  if (isCherry.value && placement.value > 0) {
+    return `第 ${placement.value} 名`
+  }
+  return props.games.participants[0].stats.win ? '胜利' : '失败'
+})
 
 const augmentIds = computed(() => {
   const s = props.games.participants[0].stats

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { useMatchDetailPlayers } from './useMatchDetailPlayers'
+import type { Game, Participant, ParticipantStats } from '@renderer/types/domain/match'
+
+// @vicons/ionicons5 is not installed in the test environment
+vi.mock('@vicons/ionicons5', () => ({
+  CashOutline: {},
+  FlagOutline: {},
+  FootstepsOutline: {},
+  PeopleOutline: {},
+  ShieldOutline: {},
+  SkullOutline: {}
+}))
+
+function makeStats(overrides: Partial<ParticipantStats> = {}): ParticipantStats {
+  return {
+    win: false,
+    item0: 0,
+    item1: 0,
+    item2: 0,
+    item3: 0,
+    item4: 0,
+    item5: 0,
+    item6: 0,
+    perk0: 0,
+    perkPrimaryStyle: 0,
+    perkSubStyle: 0,
+    playerAugment1: 0,
+    playerAugment2: 0,
+    playerAugment3: 0,
+    playerAugment4: 0,
+    kills: 0,
+    deaths: 0,
+    assists: 0,
+    goldEarned: 0,
+    goldSpent: 0,
+    totalDamageDealtToChampions: 0,
+    totalDamageDealt: 0,
+    totalDamageTaken: 0,
+    totalHeal: 0,
+    totalMinionsKilled: 0,
+    neutralMinionsKilled: 0,
+    damageDealtToTurrets: 0,
+    groupRate: 0,
+    goldEarnedRate: 0,
+    damageDealtToChampionsRate: 0,
+    damageTakenRate: 0,
+    healRate: 0,
+    playerSubteamId: 0,
+    subteamPlacement: 0,
+    ...overrides
+  }
+}
+
+function makeP(id: number, teamId: number, stats: ParticipantStats): Participant {
+  return {
+    win: stats.win,
+    participantId: id,
+    teamId,
+    championId: 1,
+    spell1Id: 0,
+    spell2Id: 0,
+    stats
+  }
+}
+
+describe('useMatchDetailPlayers - CHERRY mode grouping', () => {
+  it('should group by playerSubteamId in CHERRY game', () => {
+    const game: Game = {
+      mvp: '',
+      gameDetail: { endOfGameResult: 'GameComplete', participantIdentities: [], participants: [] },
+      gameId: 1,
+      gameCreationDate: '2026-05-10T00:00:00Z',
+      gameDuration: 1200,
+      gameMode: 'CHERRY',
+      gameType: '',
+      mapId: 30,
+      queueId: 1700,
+      queueName: '斗魂竞技场',
+      platformId: '',
+      participantIdentities: Array.from({ length: 16 }, (_, i) => ({
+        player: {
+          accountId: 0,
+          platformId: '',
+          gameName: `P${i + 1}`,
+          tagLine: '0001',
+          summonerName: '',
+          summonerId: 0
+        }
+      })),
+      participants: [
+        // subteam 1, placement 3
+        makeP(1, 100, makeStats({ playerSubteamId: 1, subteamPlacement: 3, win: true })),
+        makeP(2, 100, makeStats({ playerSubteamId: 1, subteamPlacement: 3, win: true })),
+        // subteam 2, placement 1 (champion)
+        makeP(3, 100, makeStats({ playerSubteamId: 2, subteamPlacement: 1, win: true })),
+        makeP(4, 100, makeStats({ playerSubteamId: 2, subteamPlacement: 1, win: true })),
+        // subteam 3, placement 8
+        makeP(5, 200, makeStats({ playerSubteamId: 3, subteamPlacement: 8, win: false })),
+        makeP(6, 200, makeStats({ playerSubteamId: 3, subteamPlacement: 8, win: false }))
+      ]
+    }
+    const { teamSections } = useMatchDetailPlayers(ref(game), ref(''))
+    const sections = teamSections.value
+
+    expect(sections).toHaveLength(3)
+    // 按 placement 升序
+    expect(sections[0].title).toContain('队伍 2')
+    expect(sections[0].title).toContain('第 1')
+    expect(sections[1].title).toContain('队伍 1')
+    expect(sections[1].title).toContain('第 3')
+    expect(sections[2].title).toContain('队伍 3')
+    expect(sections[2].title).toContain('第 8')
+  })
+
+  it('should still group by teamId in non-CHERRY game', () => {
+    const game: Game = {
+      mvp: '',
+      gameDetail: { endOfGameResult: '', participantIdentities: [], participants: [] },
+      gameId: 2,
+      gameCreationDate: '2026-05-10T00:00:00Z',
+      gameDuration: 1500,
+      gameMode: 'CLASSIC',
+      gameType: '',
+      mapId: 11,
+      queueId: 420,
+      queueName: '排位',
+      platformId: '',
+      participantIdentities: Array.from({ length: 10 }, (_, i) => ({
+        player: {
+          accountId: 0,
+          platformId: '',
+          gameName: `P${i + 1}`,
+          tagLine: '0001',
+          summonerName: '',
+          summonerId: 0
+        }
+      })),
+      participants: [
+        ...[1, 2, 3, 4, 5].map(i => makeP(i, 100, makeStats({ win: true }))),
+        ...[6, 7, 8, 9, 10].map(i => makeP(i, 200, makeStats({ win: false })))
+      ]
+    }
+    const { teamSections } = useMatchDetailPlayers(ref(game), ref(''))
+    const sections = teamSections.value
+    expect(sections).toHaveLength(2)
+    expect(sections[0].title).toBe('胜方')
+    expect(sections[1].title).toBe('败方')
+  })
+})

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
@@ -17,6 +17,8 @@ import {
 import type { Game, ParticipantStats } from '@renderer/types/domain/match'
 import { safeRelativePercent } from '@renderer/utils/format'
 
+const PLACEMENT_LABEL = (p: number) => (p > 0 ? `第 ${p} 名` : '')
+
 export interface PlayerBadge {
   key: string
   label: string
@@ -177,6 +179,47 @@ export function useMatchDetailPlayers(
   const mySummary = computed(() => detailPlayers.value.find(p => p.isMe) ?? detailPlayers.value[0])
 
   const teamSections = computed<TeamSection[]>(() => {
+    const g = toValue(game)
+    const isCherry = g?.gameMode === 'CHERRY'
+
+    if (isCherry) {
+      const map = new Map<number, DetailPlayer[]>()
+      for (const p of detailPlayers.value) {
+        const sid = p.stats.playerSubteamId
+        if (!map.has(sid)) map.set(sid, [])
+        map.get(sid)!.push(p)
+      }
+      return [...map.entries()]
+        .map(([subteamId, players]) => {
+          const placement = players[0]?.stats.subteamPlacement ?? 0
+          const won = players[0]?.stats.win ?? false
+          const totals = players.reduce(
+            (acc, p) => {
+              acc.kills += p.stats.kills
+              acc.deaths += p.stats.deaths
+              acc.assists += p.stats.assists
+              acc.gold += p.stats.goldEarned
+              acc.damage += p.stats.totalDamageDealtToChampions
+              acc.taken += p.stats.totalDamageTaken
+              return acc
+            },
+            { kills: 0, deaths: 0, assists: 0, gold: 0, damage: 0, taken: 0 }
+          )
+          return {
+            teamId: subteamId,
+            players,
+            title: `队伍 ${subteamId} · ${PLACEMENT_LABEL(placement)}`,
+            headerClass: won ? 'match-detail-team-header-win' : 'match-detail-team-header-loss',
+            ...totals
+          }
+        })
+        .sort((a, b) => {
+          const pa = a.players[0]?.stats.subteamPlacement ?? 99
+          const pb = b.players[0]?.stats.subteamPlacement ?? 99
+          return pa - pb
+        })
+    }
+
     const teamMap = new Map<number, DetailPlayer[]>()
     for (const player of detailPlayers.value) {
       const cur = teamMap.get(player.teamId) ?? []

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.ts
@@ -1,12 +1,17 @@
 /**
  * 对局会话数据同步：订阅 LCU 推送事件 + 增量合并玩家数据
- * 从 Gaming.vue 中抽出，统一管理生命周期
+ * 多小队模型（CLASSIC: 2 个 subteam，CHERRY: 1~8 个 subteam）
  */
 
 import { onMounted, onUnmounted, reactive, watch } from 'vue'
 import { listen } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
-import type { PreGroupMarkers, SessionData, SessionSummoner } from '@renderer/types/domain/gaming'
+import type {
+  PreGroupMarkers,
+  SessionData,
+  SessionSummoner,
+  Subteam
+} from '@renderer/types/domain/gaming'
 
 const MAX_RETRIES = 3
 const RETRY_DELAY_MS = 3000
@@ -19,11 +24,13 @@ function markersEqual(a: PreGroupMarkers | undefined, b: PreGroupMarkers | undef
   return a.name === b.name && a.type === b.type
 }
 
-function updatePreGroupMarkers(team: SessionSummoner[], markers: Record<string, PreGroupMarkers>) {
-  for (const player of team) {
-    const marker = markers[player.summoner.puuid]
-    if (marker && !markersEqual(player.preGroupMarkers, marker)) {
-      player.preGroupMarkers = marker
+function updatePreGroupMarkers(subteams: Subteam[], markers: Record<string, PreGroupMarkers>) {
+  for (const st of subteams) {
+    for (const player of st.players) {
+      const marker = markers[player.summoner.puuid]
+      if (marker && !markersEqual(player.preGroupMarkers, marker)) {
+        player.preGroupMarkers = marker
+      }
     }
   }
 }
@@ -47,63 +54,77 @@ function playerSignature(p: SessionSummoner): string {
   ].join('|')
 }
 
-function updatePlayerAtIndex(team: SessionSummoner[], index: number, newPlayer: SessionSummoner) {
-  if (!team || index >= team.length) return
-  const oldPlayer = team[index]
+function findSubteam(subteams: Subteam[], subteamId: number): Subteam | undefined {
+  return subteams.find(s => s.subteamId === subteamId)
+}
 
-  // 同一玩家时保留 meetGames/preGroupMarkers（后端最后阶段才计算，避免闪烁）
+function updatePlayerInSubteam(
+  subteams: Subteam[],
+  subteamId: number,
+  index: number,
+  newPlayer: SessionSummoner
+) {
+  const st = findSubteam(subteams, subteamId)
+  if (!st || index >= st.players.length) return
+  const oldPlayer = st.players[index]
   if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
     newPlayer.meetGames = oldPlayer.meetGames
     newPlayer.preGroupMarkers = oldPlayer.preGroupMarkers
   }
-  team[index] = newPlayer
+  st.players[index] = newPlayer
 }
 
-function updateBasicInfo(currentTeam: SessionSummoner[], newTeam: SessionSummoner[]) {
-  if (!newTeam || newTeam.length === 0) return
+function syncSubteams(current: Subteam[], next: Subteam[], mode: 'basic' | 'full') {
+  const nextIds = new Set(next.map(s => s.subteamId))
 
-  for (let i = 0; i < newTeam.length; i++) {
-    const newPlayer = newTeam[i]
-    if (i < currentTeam.length) {
-      const oldPlayer = currentTeam[i]
-      if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
-        oldPlayer.championId = newPlayer.championId
-        oldPlayer.championKey = newPlayer.championKey
-        oldPlayer.summoner = newPlayer.summoner
-      } else {
-        currentTeam[i] = newPlayer
-      }
-    } else {
-      currentTeam.push(newPlayer)
+  for (let i = current.length - 1; i >= 0; i--) {
+    if (!nextIds.has(current[i].subteamId)) current.splice(i, 1)
+  }
+
+  for (const nst of next) {
+    let cst = current.find(s => s.subteamId === nst.subteamId)
+    if (!cst) {
+      cst = { subteamId: nst.subteamId, players: [] }
+      current.push(cst)
     }
+    syncPlayers(cst.players, nst.players, mode)
   }
-
-  if (currentTeam.length > newTeam.length) {
-    currentTeam.splice(newTeam.length)
-  }
+  current.sort((a, b) => a.subteamId - b.subteamId)
 }
 
-function updateTeamData(currentTeam: SessionSummoner[], newTeam: SessionSummoner[]) {
+function syncPlayers(
+  currentTeam: SessionSummoner[],
+  newTeam: SessionSummoner[],
+  mode: 'basic' | 'full'
+) {
   if (!newTeam || newTeam.length === 0) {
     if (currentTeam.length > 0) currentTeam.splice(0, currentTeam.length)
     return
   }
-
   for (let i = 0; i < newTeam.length; i++) {
     const newPlayer = newTeam[i]
     if (i < currentTeam.length) {
       const oldPlayer = currentTeam[i]
-      let shouldUpdate = true
-      if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
-        if (newPlayer.isLoading && !oldPlayer.isLoading) shouldUpdate = false
-        else if (playerSignature(newPlayer) === playerSignature(oldPlayer)) shouldUpdate = false
+      if (mode === 'basic') {
+        if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
+          oldPlayer.championId = newPlayer.championId
+          oldPlayer.championKey = newPlayer.championKey
+          oldPlayer.summoner = newPlayer.summoner
+        } else {
+          currentTeam[i] = newPlayer
+        }
+      } else {
+        let shouldUpdate = true
+        if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
+          if (newPlayer.isLoading && !oldPlayer.isLoading) shouldUpdate = false
+          else if (playerSignature(newPlayer) === playerSignature(oldPlayer)) shouldUpdate = false
+        }
+        if (shouldUpdate) currentTeam[i] = newPlayer
       }
-      if (shouldUpdate) currentTeam[i] = newPlayer
     } else {
       currentTeam.push(newPlayer)
     }
   }
-
   if (currentTeam.length > newTeam.length) {
     currentTeam.splice(newTeam.length)
   }
@@ -115,8 +136,10 @@ export function useSessionSync() {
     type: '',
     typeCn: '',
     queueId: 0,
-    teamOne: [],
-    teamTwo: []
+    gameMode: '',
+    isMultiTeam: false,
+    mySubteamId: 0,
+    subteams: []
   })
 
   const unlisteners: Array<() => void> = []
@@ -133,12 +156,13 @@ export function useSessionSync() {
   function checkAndRetryFetch() {
     if (sessionData.phase !== 'InProgress' && sessionData.phase !== 'GameStart') return
 
-    const enemyMissing =
-      !sessionData.teamTwo ||
-      sessionData.teamTwo.length === 0 ||
-      sessionData.teamTwo.every(p => !p.summoner.gameName)
+    const enoughSubteams = sessionData.isMultiTeam
+      ? sessionData.subteams.length >= 2
+      : sessionData.subteams.some(
+          s => s.subteamId !== sessionData.mySubteamId && s.players.some(p => p.summoner.gameName)
+        )
 
-    if (enemyMissing && retryCount < MAX_RETRIES) {
+    if (!enoughSubteams && retryCount < MAX_RETRIES) {
       retryCount++
       setTimeout(() => {
         requestSessionData()
@@ -147,17 +171,27 @@ export function useSessionSync() {
     }
   }
 
+  function applyMeta(data: SessionData) {
+    sessionData.phase = data.phase
+    sessionData.type = data.type
+    sessionData.typeCn = data.typeCn
+    sessionData.queueId = data.queueId
+    sessionData.gameMode = data.gameMode ?? ''
+    sessionData.isMultiTeam = !!data.isMultiTeam
+    sessionData.mySubteamId = data.mySubteamId ?? 0
+  }
+
   onMounted(async () => {
     unlisteners.push(
       await listen<SessionData>('session-complete', event => {
         const data = event.payload
         if (!data.phase) return
-        sessionData.phase = data.phase
-        sessionData.type = data.type
-        sessionData.typeCn = data.typeCn
-        sessionData.queueId = data.queueId
-        updateTeamData(sessionData.teamOne, Array.isArray(data.teamOne) ? data.teamOne : [])
-        updateTeamData(sessionData.teamTwo, Array.isArray(data.teamTwo) ? data.teamTwo : [])
+        applyMeta(data)
+        syncSubteams(
+          sessionData.subteams,
+          Array.isArray(data.subteams) ? data.subteams : [],
+          'full'
+        )
       })
     )
 
@@ -165,34 +199,29 @@ export function useSessionSync() {
       await listen<SessionData>('session-basic-info', event => {
         const data = event.payload
         if (!data.phase) return
-        sessionData.phase = data.phase
-        sessionData.type = data.type
-        sessionData.typeCn = data.typeCn
-        sessionData.queueId = data.queueId
-        updateBasicInfo(sessionData.teamOne, Array.isArray(data.teamOne) ? data.teamOne : [])
-        updateBasicInfo(sessionData.teamTwo, Array.isArray(data.teamTwo) ? data.teamTwo : [])
+        applyMeta(data)
+        syncSubteams(
+          sessionData.subteams,
+          Array.isArray(data.subteams) ? data.subteams : [],
+          'basic'
+        )
       })
     )
 
     unlisteners.push(
       await listen<Record<string, PreGroupMarkers>>('session-pre-group', event => {
-        updatePreGroupMarkers(sessionData.teamOne, event.payload)
-        updatePreGroupMarkers(sessionData.teamTwo, event.payload)
+        updatePreGroupMarkers(sessionData.subteams, event.payload)
       })
     )
 
     unlisteners.push(
-      await listen('session-player-update-team-one', (event: any) => {
-        const { index, player } = event.payload
-        updatePlayerAtIndex(sessionData.teamOne, index, player)
-      })
-    )
-
-    unlisteners.push(
-      await listen('session-player-update-team-two', (event: any) => {
-        const { index, player } = event.payload
-        updatePlayerAtIndex(sessionData.teamTwo, index, player)
-      })
+      await listen<{ subteamId: number; index: number; total: number; player: SessionSummoner }>(
+        'session-player-update',
+        event => {
+          const { subteamId, index, player } = event.payload
+          updatePlayerInSubteam(sessionData.subteams, subteamId, index, player)
+        }
+      )
     )
 
     unlisteners.push(

--- a/lol-record-analysis-tauri/src/composables/useSessionTiers.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionTiers.ts
@@ -1,6 +1,6 @@
 /**
  * 根据 sessionData 计算每个玩家展示用的段位图标 + 段位中文
- * 同时考虑对局模式（灵活组排时优先使用 RANKED_FLEX_SR）
+ * 多小队模型：返回 subteamId → TierDisplay[]
  */
 
 import { computed, type MaybeRefOrGetter, toValue } from 'vue'
@@ -26,12 +26,14 @@ function toDisplay(player: SessionSummoner, queueType: string): TierDisplay {
   return { imgUrl: tierImage(q.tier), tierCn }
 }
 
+/** 返回 subteamId → TierDisplay[]（按玩家在小队中的顺序） */
 export function useSessionTiers(session: MaybeRefOrGetter<SessionData>) {
-  return computed(() => {
+  return computed<Record<number, TierDisplay[]>>(() => {
     const s = toValue(session)
-    return {
-      teamOne: s.teamOne.map(p => toDisplay(p, s.type)),
-      teamTwo: s.teamTwo.map(p => toDisplay(p, s.type))
+    const out: Record<number, TierDisplay[]> = {}
+    for (const st of s.subteams) {
+      out[st.subteamId] = st.players.map(p => toDisplay(p, s.type))
     }
+    return out
   })
 }

--- a/lol-record-analysis-tauri/src/services/ai/prompts/team-player.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/team-player.ts
@@ -1,0 +1,64 @@
+/**
+ * 单玩家深度分析 Prompt（从 team.ts 拆出）
+ */
+
+import { extractPlayerDeepDive } from '../player-insight'
+
+export function buildPlayerAnalysisPrompt(player: any): string {
+  const tags = player.userTag?.tag || []
+  const recent = player.userTag?.recentData
+  const winRate =
+    recent?.selectWins && recent?.selectLosses
+      ? Math.round((recent.selectWins / (recent.selectWins + recent.selectLosses)) * 100)
+      : 0
+
+  const { topChampions, positionStats, detailedGames } = extractPlayerDeepDive(player)
+
+  return `你是LOL资深分析师，请详细分析这个玩家：
+
+【玩家基本信息】
+名称：${player.summoner?.gameName || '未知'} #${player.summoner?.tagLine}
+等级：${player.summoner?.summonerLevel}
+段位：${player.rank?.queueMap?.RANKED_SOLO_5x5?.tierCn || '无'}
+
+【近期统计】
+模式：${recent?.selectModeCn || '未知'}
+胜率：${recent?.selectWins || 0}胜${recent?.selectLosses || 0}负 (${winRate}%)
+KDA：${recent?.kda?.toFixed(2) || 0}
+场均：${recent?.kills?.toFixed(1) || 0}/${recent?.deaths?.toFixed(1) || 0}/${recent?.assists?.toFixed(1) || 0}
+参团率：${recent?.groupRate || 0}%
+伤害占比：${recent?.damageDealtToChampionsRate || 0}%
+
+【英雄熟练度】
+${JSON.stringify(topChampions, null, 2)}
+
+【位置分布】
+${JSON.stringify(positionStats, null, 2)}
+
+【标签列表】
+${tags.length > 0 ? tags.map((t: any) => `• ${t.tagName}(${t.tagDesc}) - ${t.good ? '正面' : '负面'}`).join('\n') : '无标签'}
+
+【最近15场详细战绩】
+${JSON.stringify(detailedGames, null, 2)}
+
+===== 请按以下结构分析（共200-250字）=====
+
+一、实力评估（60-80字）
+- 整体水平判断
+- 位置和英雄熟练度
+- 操作习惯特点
+
+二、标签深度分析（80-100字）
+针对每个标签：
+- 产生原因分析
+- 从战绩数据验证
+- 标签准确性判断
+
+三、战绩异常检测（40-60字）
+- 数据一致性检查
+- 异常表现分析
+- 可能的代练/摆子迹象
+
+【输出格式】
+用简洁的要点形式，每个要点用•开头。重要信息用【】标注。正面标签用✅，负面标签用⚠️。`
+}

--- a/lol-record-analysis-tauri/src/services/ai/prompts/team.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/team.ts
@@ -3,106 +3,60 @@
  * 数据抽取逻辑复用 ../player-insight.ts
  */
 
-import { extractPlayerDeepDive, extractPlayerInsight } from '../player-insight'
+import { extractPlayerInsight } from '../player-insight'
 
-export function buildTeamAnalysisPrompt(sessionData: any): string {
-  const teamOneInfo = (sessionData.teamOne || []).map((p: any) =>
-    extractPlayerInsight(p, { detailed: true })
-  )
-  const teamTwoInfo = (sessionData.teamTwo || []).map((p: any) =>
-    extractPlayerInsight(p, { detailed: false })
-  )
+interface SessionDataLike {
+  typeCn?: string
+  isMultiTeam?: boolean
+  mySubteamId?: number
+  subteams?: Array<{ subteamId: number; players: any[] }>
+}
 
-  return `你是LOL资深分析师，请从以下三个维度详细分析这局比赛：
+export function buildTeamAnalysisPrompt(sessionData: SessionDataLike): string {
+  const isMulti = !!sessionData.isMultiTeam
+  const mySubteamId = sessionData.mySubteamId ?? 0
+  const subteams = sessionData.subteams ?? []
 
-【对局信息】
-模式：${sessionData.typeCn || '未知'}
+  const blocks = subteams.map(st => {
+    const detailed = st.subteamId === mySubteamId
+    const playersInfo = st.players.map(p => extractPlayerInsight(p, { detailed }))
+    const label = isMulti
+      ? `队伍 ${st.subteamId}${st.subteamId === mySubteamId ? '（我方）' : ''}`
+      : st.subteamId === mySubteamId
+        ? '我方队伍'
+        : '敌方队伍'
+    return `【${label}数据】\n${JSON.stringify(playersInfo, null, 2)}`
+  })
 
-【我方队伍数据】
-${JSON.stringify(teamOneInfo, null, 2)}
+  const prelude = isMulti
+    ? `你是LOL资深分析师，本局为 ${subteams.length} 队混战（${sessionData.typeCn || '未知'}），请详细分析这局比赛：`
+    : `你是LOL资深分析师，请从以下三个维度详细分析这局比赛：\n\n【对局信息】\n模式：${sessionData.typeCn || '未知'}`
 
-【敌方队伍数据】
-${JSON.stringify(teamTwoInfo, null, 2)}
+  return `${prelude}
+
+${blocks.join('\n\n')}
 
 ===== 请按以下结构分析（共300-400字）=====
 
 一、阵容分析（80-100字）
-- 双方阵容特点（控制、输出、前排等）
-- 阵容优劣势对比
+- ${isMulti ? '我方小队的英雄定位与组合优势' : '双方阵容特点（控制、输出、前排等）'}
+- ${isMulti ? '相对其它小队的强弱判断' : '阵容优劣势对比'}
 - 关键英雄作用
 
 二、英雄熟练度与位置分析（100-120字）
 - 每个玩家当前英雄 vs 常玩英雄对比
-- 位置熟练度判断（是否拿手位置）
+- ${isMulti ? '搭档配合度分析（仅适用于我方小队）' : '位置熟练度判断（是否拿手位置）'}
 - 英雄池深度分析
-- 可能的摇摆位
 
 三、标签分析与战绩详情（120-180字）
 针对有标签的玩家，详细分析：
-- 标签产生原因（如"3连胜"、"KDA>=6"、"死亡>=10"等）
+- 标签产生原因
 - 从最近战绩验证标签准确性
 - 该玩家对本局的影响（正面大腿/负面隐患）
-- 是否存在数据异常（如低KDA却有高胜率等）
+- 是否存在数据异常
 
 【输出格式】
 用简洁的要点形式，每个要点用•开头。重要信息用【】标注。正面标签用✅，负面标签用⚠️。`
 }
 
-export function buildPlayerAnalysisPrompt(player: any): string {
-  const tags = player.userTag?.tag || []
-  const recent = player.userTag?.recentData
-  const winRate =
-    recent?.selectWins && recent?.selectLosses
-      ? Math.round((recent.selectWins / (recent.selectWins + recent.selectLosses)) * 100)
-      : 0
-
-  const { topChampions, positionStats, detailedGames } = extractPlayerDeepDive(player)
-
-  return `你是LOL资深分析师，请详细分析这个玩家：
-
-【玩家基本信息】
-名称：${player.summoner?.gameName || '未知'} #${player.summoner?.tagLine}
-等级：${player.summoner?.summonerLevel}
-段位：${player.rank?.queueMap?.RANKED_SOLO_5x5?.tierCn || '无'}
-
-【近期统计】
-模式：${recent?.selectModeCn || '未知'}
-胜率：${recent?.selectWins || 0}胜${recent?.selectLosses || 0}负 (${winRate}%)
-KDA：${recent?.kda?.toFixed(2) || 0}
-场均：${recent?.kills?.toFixed(1) || 0}/${recent?.deaths?.toFixed(1) || 0}/${recent?.assists?.toFixed(1) || 0}
-参团率：${recent?.groupRate || 0}%
-伤害占比：${recent?.damageDealtToChampionsRate || 0}%
-
-【英雄熟练度】
-${JSON.stringify(topChampions, null, 2)}
-
-【位置分布】
-${JSON.stringify(positionStats, null, 2)}
-
-【标签列表】
-${tags.length > 0 ? tags.map((t: any) => `• ${t.tagName}(${t.tagDesc}) - ${t.good ? '正面' : '负面'}`).join('\n') : '无标签'}
-
-【最近15场详细战绩】
-${JSON.stringify(detailedGames, null, 2)}
-
-===== 请按以下结构分析（共200-250字）=====
-
-一、实力评估（60-80字）
-- 整体水平判断
-- 位置和英雄熟练度
-- 操作习惯特点
-
-二、标签深度分析（80-100字）
-针对每个标签：
-- 产生原因分析
-- 从战绩数据验证
-- 标签准确性判断
-
-三、战绩异常检测（40-60字）
-- 数据一致性检查
-- 异常表现分析（如连胜/连败、KDA异常等）
-- 可能的代练/摆子迹象
-
-【输出格式】
-用简洁的要点形式，每个要点用•开头。重要信息用【】标注。正面标签用✅，负面标签用⚠️。`
-}
+export { buildPlayerAnalysisPrompt } from './team-player'

--- a/lol-record-analysis-tauri/src/types/domain/gaming.ts
+++ b/lol-record-analysis-tauri/src/types/domain/gaming.ts
@@ -1,5 +1,11 @@
 /**
- * 对局会话领域模型：当前 session / 我方与敌方
+ * 对局会话领域模型：subteams 统一模型
+ * - CLASSIC 模式：subteams.length === 2，[0] 是我方，[1] 是敌方
+ * - CHERRY 模式：
+ *   - EOG 端点可用时（InProgress / PreEndOfGame / EndOfGame）→ subteams.length === 8，
+ *     subteamId 1~8 与游戏内"队伍 N"权威一致
+ *   - EOG 不可用时（如 ChampSelect）→ 回退到 lobby 的 teamParticipantId 分组，
+ *     subteamId 重映射成 1..N（N 可能 >8，因为 lobby tpid 实测稀疏）
  */
 
 import type { MatchHistory } from './match'
@@ -23,12 +29,18 @@ export interface SessionSummoner {
   isLoading?: boolean
 }
 
-/** teamOne = 我方（左），teamTwo = 敌方（右） */
+export interface Subteam {
+  subteamId: number
+  players: SessionSummoner[]
+}
+
 export interface SessionData {
   phase: string
   type: string
   typeCn: string
   queueId: number
-  teamOne: SessionSummoner[]
-  teamTwo: SessionSummoner[]
+  gameMode: string
+  isMultiTeam: boolean
+  mySubteamId: number
+  subteams: Subteam[]
 }

--- a/lol-record-analysis-tauri/src/types/domain/match.ts
+++ b/lol-record-analysis-tauri/src/types/domain/match.ts
@@ -47,6 +47,10 @@ export interface ParticipantStats {
   damageDealtToChampionsRate: number
   damageTakenRate: number
   healRate: number
+  /** CHERRY/斗魂模式：1~8 玩家所属小队 ID；非 CHERRY 局为 0 */
+  playerSubteamId: number
+  /** CHERRY/斗魂模式：1~8 小队最终名次（1=冠军）；非 CHERRY 局为 0 */
+  subteamPlacement: number
 }
 
 export interface Participant {

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -53,47 +53,20 @@
         <div class="ai-result-content" v-html="renderedAIResult"></div>
       </n-modal>
 
-      <!-- 左我方、右敌方，由后端按 LCU 当前用户交换保证 -->
-      <n-flex justify="space-between" class="gaming-columns">
-        <n-flex vertical class="gaming-team-col gaming-team-blue">
-          <div class="team-label team-label-blue">我方</div>
-          <PlayerCard
-            v-for="(sessionSummoner, i) of sessionData.teamOne"
-            :key="'teamOne' + i"
-            :style="{ '--stagger-i': i }"
-            team="blue"
-            :session-summoner="sessionSummoner"
-            :mode-type="sessionData.type"
-            :type-cn="sessionData.typeCn"
-            :queue-id="sessionData.queueId"
-            :img-url="tiers.teamOne[i]?.imgUrl"
-            :tier-cn="tiers.teamOne[i]?.tierCn"
-          />
-        </n-flex>
-
-        <n-flex vertical class="gaming-team-col gaming-team-red">
-          <div class="team-label team-label-red">敌方</div>
-          <template v-if="sessionData.phase === 'ChampSelect'">
-            <div class="enemy-placeholder">
-              <n-text depth="2">选择中</n-text>
-            </div>
-          </template>
-          <template v-else>
-            <PlayerCard
-              v-for="(sessionSummoner, i) of sessionData.teamTwo"
-              :key="'teamTwo' + i"
-              :style="{ '--stagger-i': i }"
-              team="red"
-              :session-summoner="sessionSummoner"
-              :mode-type="sessionData.type"
-              :type-cn="sessionData.typeCn"
-              :queue-id="sessionData.queueId"
-              :img-url="tiers.teamTwo[i]?.imgUrl"
-              :tier-cn="tiers.teamTwo[i]?.tierCn"
-            />
-          </template>
-        </n-flex>
-      </n-flex>
+      <div class="gaming-grid" :class="{ 'gaming-grid-multi': sessionData.isMultiTeam }">
+        <SubteamCard
+          v-for="st of orderedSubteams"
+          :key="`subteam-${st.subteamId}`"
+          :subteam="st"
+          :is-mine="st.subteamId === sessionData.mySubteamId"
+          :expected-size="expectedSubteamSize"
+          :type-cn="sessionData.typeCn"
+          :mode-type="sessionData.type"
+          :queue-id="sessionData.queueId"
+          :tiers-by-subteam="tiersBySubteam"
+          :density="density"
+        />
+      </div>
     </div>
   </template>
 </template>
@@ -106,13 +79,28 @@ import { useMessage } from 'naive-ui'
 import MarkdownIt from 'markdown-it'
 
 import LoadingComponent from '@renderer/components/LoadingComponent.vue'
-import PlayerCard from '@renderer/components/gaming/PlayerCard.vue'
+import SubteamCard from '@renderer/components/gaming/SubteamCard.vue'
 import { analyzeGameWithAIStream, type StreamCallbacks } from '@renderer/services/ai'
 import { useSessionSync } from '@renderer/composables/useSessionSync'
 import { useSessionTiers } from '@renderer/composables/useSessionTiers'
 
 const { sessionData } = useSessionSync()
-const tiers = useSessionTiers(sessionData)
+const tiersBySubteam = useSessionTiers(sessionData)
+
+const density = computed<'normal' | 'compact'>(() =>
+  sessionData.isMultiTeam ? 'compact' : 'normal'
+)
+
+const expectedSubteamSize = computed(() => (sessionData.isMultiTeam ? 2 : 5))
+
+const orderedSubteams = computed(() => {
+  // 我方排第一格；其它按 subteamId 升序
+  const my = sessionData.subteams.find(s => s.subteamId === sessionData.mySubteamId)
+  const others = sessionData.subteams
+    .filter(s => s.subteamId !== sessionData.mySubteamId)
+    .sort((a, b) => a.subteamId - b.subteamId)
+  return my ? [my, ...others] : others
+})
 
 const showConfig = ref(false)
 const matchCount = ref(4)
@@ -198,6 +186,7 @@ onMounted(async () => {
   height: 100%;
   box-sizing: border-box;
   position: relative;
+  overflow-y: auto;
 }
 
 .gaming-config-btn {
@@ -308,45 +297,16 @@ onMounted(async () => {
   margin: 16px 0;
 }
 
-.gaming-columns {
+.gaming-grid {
   height: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-16);
 }
 
-.gaming-team-col {
-  flex: 1;
-  height: 100%;
-  gap: var(--space-8);
-  position: relative;
-}
-
-.team-label {
-  font-size: 12px;
-  font-weight: 700;
-  padding: var(--space-4) var(--space-8);
-  border-radius: var(--radius-sm);
-  flex-shrink: 0;
-  width: fit-content;
-}
-
-.team-label-blue {
-  background: var(--team-blue);
-  color: var(--text-primary);
-  border: 1px solid rgba(59, 130, 246, 0.4);
-}
-
-.team-label-red {
-  background: var(--team-red);
-  color: var(--text-primary);
-  border: 1px solid rgba(239, 68, 68, 0.4);
-}
-
-.enemy-placeholder {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 120px;
-  font-size: 14px;
+.gaming-grid-multi {
+  height: auto;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: minmax(220px, auto);
 }
 </style>


### PR DESCRIPTION
## Summary

- 让对局页 / 详情页 / 战绩列表 / AI 分析全套支持斗魂竞技场（CHERRY 模式，8 小队 × 2 人）
- 数据模型从 `team_one`/`team_two` 二元字段统一到 `subteams: Vec<Subteam>`，5v5 是其特例（length=2）
- 后端用 `lol-end-of-game/v1/gameclient-eog-stats-block` 拉权威 1~8 小队号——避开 lobby 阶段稀疏 `teamParticipantId` 的坑

## 关键改动

**后端**
- `Stats` 加 `playerSubteamId` / `subteamPlacement` 字段
- `SessionData` 重构成 `{ gameMode, isMultiTeam, mySubteamId, subteams }`
- `process_session_data` 走 CLASSIC / CHERRY 分支
- 新增 `eog_stats.rs` 客户端，拉 16 名玩家的 puuid → subteamId 映射
- 事件流 `session-player-update-team-{one,two}` 合并为 `session-player-update` + `subteamId` payload

**前端**
- 新增 `SubteamCard` 组件 + `PlayerCard` `density: 'normal'｜'compact'` 变体
- `Gaming.vue` 用 grid：CLASSIC 两列，CHERRY 两列 × 自动行 + 整页可滚
- `useMatchDetailPlayers` 在 CHERRY 时按 `playerSubteamId` 分组，标题显示"队伍 N · 第 X 名"
- `RecordCard` CHERRY 局右上角显示"第 X 名"
- AI prompt `buildTeamAnalysisPrompt` 按 `subteams` 数组动态构造

**Spec & 探针**
- spec：`docs/superpowers/specs/2026-05-10-arena-multiteam-support-design.md`
- 探针：`src-tauri/examples/probe_arena.rs` 复用 LCU 鉴权直接落盘，schema 变化时可重跑

## Test plan

- [x] `npm run check` 全绿（prettier + eslint + vue-tsc + cargo fmt + clippy -Dwarnings）
- [x] `npm run test` 217 前端测试通过（含新增 `useMatchDetailPlayers.spec.ts`）
- [x] `cargo test --lib` 95 后端测试通过（含 5 个 session 单测：CLASSIC swap、CHERRY 分组、稀疏 tpid 保留）
- [x] 真实斗魂局：8 小队 × 2 人正确配对（EOG 端点担保）
- [x] 真实斗魂局：详情页按名次升序，标题"队伍 N · 第 X 名"
- [x] 真实斗魂局：战绩列表"第 X 名"
- [x] 5v5 排位 / 海克斯乱斗：行为零回归（左右两栏）
- [ ] 选英雄阶段（EOG 不可用时）回退到 tpid 分组——下次进选英雄时回归测试

## 已知限制

- CHERRY 选英雄阶段 EOG 端点尚不可用，会回退到稀疏 tpid 分组（可能 >8 小队）。InProgress 后立刻切换为权威 1~8 配对。