### PR TITLE
fix(security): close CUR_PID data race and disable markdown-it raw HTML

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
@@ -8,6 +8,7 @@ use ntapi::ntpsapi::{NtQueryInformationProcess, PROCESS_COMMAND_LINE_INFORMATION
 use regex::Regex;
 use std::collections::HashMap;
 use std::mem;
+use std::sync::atomic::{AtomicU32, Ordering};
 use winapi::shared::minwindef::{DWORD, FALSE};
 use winapi::shared::ntdef::UNICODE_STRING;
 use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
@@ -193,7 +194,12 @@ fn auth_resolver(command_line: &str) -> Result<(String, String), String> {
     Ok((remoting_auth_token.clone(), app_port.clone()))
 }
 
-static mut CUR_PID: DWORD = 0;
+/// 上次成功定位的 LeagueClientUx.exe PID 缓存。
+///
+/// 多线程读写：HTTP 重试路径、game_state_monitor、WebSocket listener 等
+/// 可能从不同线程并发调用 `get_auth()`。使用 `AtomicU32` 避免 `static mut`
+/// 的数据竞争（Rust UB）。
+static CUR_PID: AtomicU32 = AtomicU32::new(0);
 
 /// 获取当前 LCU 认证信息。
 ///
@@ -210,39 +216,35 @@ pub fn get_auth() -> Result<(String, String), String> {
 
     let mut cmd_line = String::new();
     let mut found_valid_process = false;
+    let cached_pid = CUR_PID.load(Ordering::Relaxed);
 
     for &pid in &pids {
-        unsafe {
-            if pid == CUR_PID {
-                log::info!("跳过当前PID: {}", pid);
-                continue;
-            }
+        if pid == cached_pid {
+            log::info!("跳过当前PID: {}", pid);
+            continue;
+        }
 
-            log::info!("正在检查PID: {}", pid);
-            match get_process_command_line(pid) {
-                Ok(temp_cmd_line) if !temp_cmd_line.is_empty() => {
-                    cmd_line = temp_cmd_line;
-                    CUR_PID = pid;
-                    found_valid_process = true;
-                    log::info!("找到有效进程，PID: {}", pid);
-                    break;
-                }
-                Err(e) => log::info!("获取进程 {} 的命令行失败: {}", pid, e),
-                _ => log::info!("进程 {} 的命令行为空", pid),
+        log::info!("正在检查PID: {}", pid);
+        match get_process_command_line(pid) {
+            Ok(temp_cmd_line) if !temp_cmd_line.is_empty() => {
+                cmd_line = temp_cmd_line;
+                CUR_PID.store(pid, Ordering::Relaxed);
+                found_valid_process = true;
+                log::info!("找到有效进程，PID: {}", pid);
+                break;
             }
+            Err(e) => log::info!("获取进程 {} 的命令行失败: {}", pid, e),
+            _ => log::info!("进程 {} 的命令行为空", pid),
         }
     }
 
     if !found_valid_process {
-        log::info!("未找到有效的命令行，尝试使用当前PID: {}", unsafe {
-            CUR_PID
-        });
-        unsafe {
-            if CUR_PID > 0 {
-                cmd_line = get_process_command_line(CUR_PID)?;
-            } else {
-                return Err("未找到有效的英雄联盟客户端进程".to_string());
-            }
+        let cached = CUR_PID.load(Ordering::Relaxed);
+        log::info!("未找到有效的命令行，尝试使用当前PID: {}", cached);
+        if cached > 0 {
+            cmd_line = get_process_command_line(cached)?;
+        } else {
+            return Err("未找到有效的英雄联盟客户端进程".to_string());
         }
     }
 

--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' http://asset.localhost https://asset.localhost data: blob:; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost https://ai.nuliyangguang.top; frame-src 'none'; object-src 'none'; base-uri 'self'"
     }
   },
   "bundle": {

--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' http://asset.localhost https://asset.localhost data: blob:; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost https://ai.nuliyangguang.top; frame-src 'none'; object-src 'none'; base-uri 'self'"
+      "csp": null
     }
   },
   "bundle": {

--- a/lol-record-analysis-tauri/src/composables/useMatchAIAnalysis.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchAIAnalysis.ts
@@ -9,7 +9,8 @@ import { useMessage } from 'naive-ui'
 import type { Game } from '@renderer/types/domain/match'
 import { analyzeMatchDetailWithAIStream, type MatchDetailAnalysisMode } from '@renderer/services/ai'
 
-const md = new MarkdownIt({ html: true, breaks: true, linkify: true })
+// html:false 阻断 AI/外部数据中夹带 raw HTML（XSS 防线，CSP 之外的纵深防御）
+const md = new MarkdownIt({ html: false, breaks: true, linkify: true })
 
 export function useMatchAIAnalysis(game: MaybeRefOrGetter<Game | null>) {
   const message = useMessage()

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -114,7 +114,8 @@ const showAITooltip = ref(false)
 /** AI 功能提示状态（内存中存储，每次打开软件只提示一次） */
 let hasShownAITip = false
 
-const md = new MarkdownIt({ html: true, breaks: true, linkify: true })
+// html:false 阻断 AI/外部数据中夹带 raw HTML（XSS 防线，CSP 之外的纵深防御）
+const md = new MarkdownIt({ html: false, breaks: true, linkify: true })
 
 const renderedAIResult = computed(() => (aiResult.value ? md.render(aiResult.value) : ''))
 


### PR DESCRIPTION
## Summary

修复整体 review 中识别出的两个 P0 安全/正确性问题。

### 1. `CUR_PID` 数据竞争 (Rust UB)
`src-tauri/src/lcu/util/token.rs` 里的 `static mut CUR_PID: DWORD` 在 HTTP 重试路径、`game_state_monitor`、WebSocket listener 三处会被多线程并发读写，没有任何同步原语 —— Rust 明确定义的 undefined behavior。替换为 `static CUR_PID: AtomicU32`，`load`/`store(Ordering::Relaxed)` 即可（仅作 last-good PID 缓存提示，未通过它同步其他内存），相关 `unsafe` 块一并删除。

### 2. Webview XSS — 在源头堵 markdown-it raw HTML
- `useMatchAIAnalysis.ts:12` 与 `Gaming.vue:117` 的 markdown-it 实例都启用了 `html: true`，意味着 AI 输出里夹带的 `<script>` / `<img onerror>` 会在 Tauri 特权 webview 上下文中直接执行，且能调用所有 `invoke` 命令 —— 是真实可利用的 XSS → RCE 通路。
- 两处统一改为 `html: false`（markdown 语法本身仍正常渲染，只是不再透传 raw HTML）。
- `src/views/settings/About.vue` 使用 `new MarkdownIt()` 默认 `html: false`，不受影响。

### 范围之外

- **CSP** 一度在本 PR 内尝试过（`tauri.conf.json` 从 `csp: null` 改为白名单），但 CSP 在不真机跑过 dev/build 验证的情况下风险高于收益（错误的 CSP 会让用户装包后某个功能突然白屏且无任何编译报错），且 XSS 第一道防线已经在源头堵死，CSP 仅是纵深防御。已 revert，待后续单开 `chore(security): add CSP` 在 Windows 上完整跑过 HMR / 字体 / asset:// / AI 流式 / ipc: 后再加。
- 其他 review 发现 (`block_on` in asset protocol / `serde_yaml` deprecated / `reqwest 0.11` 锁版本 / `useMatchAIAnalysis` 模式切换 UX bug / `dangerousInsecureTransportProtocol: true` hygiene 等) 都已降级到 P1/P2，会用独立 chore PR 渐进推进。

## Test plan

- [x] `git diff` 仅含 3 个目标文件（`token.rs` + 两个 `MarkdownIt`），无 `.claude/settings.local.json` 等本地配置漂移
- [x] `npm run check` 通过（prettier + eslint + vue-tsc + cargo fmt --check + cargo clippy -Dwarnings）
- [ ] AI 分析功能 markdown 渲染正常（粗体/列表/链接通过 markdown 语法，不再依赖 raw HTML）
- [ ] 启停游戏客户端模拟 LCU 多次重连，验证 `CUR_PID` 路径无 panic