### PR TITLE
chore: Bundle A+B (去重 + 工具链升级 + CI 硬门禁 + 配置卫生)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -50,11 +50,11 @@ jobs:
           npm run typecheck
           echo "✅ TypeScript check passed"
 
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         run: |
-          echo "🧪 Running frontend unit tests..."
-          npm run test
-          echo "✅ Frontend tests passed"
+          echo "🧪 Running frontend unit tests with coverage..."
+          npm run test:coverage
+          echo "✅ Frontend tests passed (coverage threshold met)"
 
   rust-quality:
     name: Rust Code Quality

--- a/lol-record-analysis-tauri/.eslintrc.cjs
+++ b/lol-record-analysis-tauri/.eslintrc.cjs
@@ -22,6 +22,8 @@ module.exports = {
         varsIgnorePattern: '^_'
       }
     ],
+    // CODE_QUALITY.md 明确禁止 any。先以 warn 暴露存量，未来切 error
+    '@typescript-eslint/no-explicit-any': 'warn',
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   }

--- a/lol-record-analysis-tauri/.gitignore
+++ b/lol-record-analysis-tauri/.gitignore
@@ -1,0 +1,14 @@
+# Build artifacts
+/dist/
+
+# Test coverage
+/coverage/
+
+# IDE / OS
+.DS_Store
+.idea/
+.vscode/
+
+# Logs
+*.log
+npm-debug.log*

--- a/lol-record-analysis-tauri/package-lock.json
+++ b/lol-record-analysis-tauri/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2.10.0",
         "@tauri-apps/plugin-http": "^2.4.4",
-        "@tauri-apps/plugin-opener": "^2.0.0-alpha.3",
+        "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "markdown-it": "^14.1.0",

--- a/lol-record-analysis-tauri/package.json
+++ b/lol-record-analysis-tauri/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.10.0",
     "@tauri-apps/plugin-http": "^2.4.4",
-    "@tauri-apps/plugin-opener": "^2.0.0-alpha.3",
+    "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "markdown-it": "^14.1.0",

--- a/lol-record-analysis-tauri/src-tauri/Cargo.lock
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,17 +265,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -476,6 +515,12 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -958,6 +1003,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,15 +1020,15 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "atty",
- "humantime",
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
  "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1640,15 +1695,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -1737,12 +1783,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -2061,6 +2101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2133,30 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2799,6 +2869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,7 +3266,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
@@ -3201,6 +3277,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -4904,15 +4989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5439,6 +5515,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/lol-record-analysis-tauri/src-tauri/Cargo.toml
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.toml
@@ -42,7 +42,7 @@ winapi = { version = "0.3.9", features = [
     "winnt",
 ] } # 用于 Windows api，用于获取lol进程信息
 log = "0.4.0"
-env_logger = "0.9"
+env_logger = "0.11"
 base64 = "0.21"
 tauri-plugin-http = "2"
 tauri-plugin-process = "2"

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
@@ -9,6 +9,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::mem;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::LazyLock;
 use winapi::shared::minwindef::{DWORD, FALSE};
 use winapi::shared::ntdef::UNICODE_STRING;
 use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
@@ -167,11 +168,15 @@ fn get_process_command_line(pid: DWORD) -> Result<String, String> {
     }
 }
 
+/// LCU 命令行参数解析的正则：`--key`、`--key=value`、`--key="value with spaces"`。
+/// 编译一次，避免 `auth_resolver` 高频调用时重复 `Regex::new`。
+static AUTH_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"--([^\s=]+)(?:=(?:"([^"]+)"|([^\s"]+)))?"#).unwrap());
+
 fn auth_resolver(command_line: &str) -> Result<(String, String), String> {
-    let re = Regex::new(r#"--([^\s=]+)(?:=(?:"([^"]+)"|([^\s"]+)))?"#).unwrap();
     let mut params = HashMap::new();
 
-    for cap in re.captures_iter(command_line) {
+    for cap in AUTH_REGEX.captures_iter(command_line) {
         let key = cap.get(1).map(|m| m.as_str()).unwrap_or("");
         let value = cap
             .get(2)

--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -52,8 +52,7 @@
         "https://api.upgrade.toolsetlink.com/v1/tauri/upgrade?tauriKey=rX76p0GShXom2yNnlsSDYw&versionName={{current_version}}&target={{target}}&arch={{arch}}",
         "https://github.com/wnzzer/rank-analysis/releases/latest/download/latest.json"
       ],
-      "createUpdaterArtifacts": true,
-      "dangerousInsecureTransportProtocol": true
+      "createUpdaterArtifacts": true
     }
   }
 }

--- a/lol-record-analysis-tauri/src/App.vue
+++ b/lol-record-analysis-tauri/src/App.vue
@@ -19,15 +19,12 @@
 <script lang="ts" setup>
 import Framework from '@renderer/components/Framework.vue'
 import { useSettingsStore } from '@renderer/pinia/setting'
+import { useTheme } from '@renderer/composables/useTheme'
 import { computed } from 'vue'
 import { GlobalThemeOverrides } from 'naive-ui'
 
 const settingsStore = useSettingsStore()
-
-const isDark = computed(() => {
-  const name = settingsStore.theme?.name
-  return name === 'Dark' || name === 'dark'
-})
+const { isDark } = useTheme()
 
 const themeOverrides = computed<GlobalThemeOverrides>(() => {
   if (isDark.value) {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -185,6 +185,7 @@ import type { SessionSummoner } from '@renderer/types/domain/gaming'
 import nullImg from '@renderer/assets/imgs/item/null.png'
 import { assetPrefix } from '@renderer/services/http'
 import { useSettingsStore } from '@renderer/pinia/setting'
+import { useTheme } from '@renderer/composables/useTheme'
 import { useAramBalance } from '@renderer/composables/useAramBalance'
 import PlayerHistoryGrid from './PlayerHistoryGrid.vue'
 import PlayerStatsCard from './PlayerStatsCard.vue'
@@ -203,9 +204,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), { team: undefined, density: 'normal' })
 
 const settingsStore = useSettingsStore()
-const isDark = computed(
-  () => settingsStore.theme?.name === 'Dark' || settingsStore.theme?.name === 'dark'
-)
+const { isDark } = useTheme()
 
 const { copy } = useCopy()
 

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -398,7 +398,7 @@ import { NButton, NIcon, NTag, NTooltip } from 'naive-ui'
 import { invoke } from '@tauri-apps/api/core'
 import { useCopy } from '@renderer/composables/useCopy'
 
-import { useSettingsStore } from '@renderer/pinia/setting'
+import { useTheme } from '@renderer/composables/useTheme'
 import { assetPrefix } from '@renderer/services/http'
 import type { Game, ParticipantStats } from '@renderer/types/domain/match'
 import type { Summoner } from '@renderer/types/domain/player'
@@ -421,10 +421,7 @@ import { useMatchAIAnalysis } from '@renderer/composables/useMatchAIAnalysis'
 
 const props = defineProps<{ game: Game | null }>()
 
-const settingsStore = useSettingsStore()
-const isDark = computed(
-  () => settingsStore.theme?.name === 'Dark' || settingsStore.theme?.name === 'dark'
-)
+const { isDark } = useTheme()
 
 const currentSummoner = ref<Summoner | null>(null)
 

--- a/lol-record-analysis-tauri/src/components/record/MatchHistory.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchHistory.vue
@@ -83,7 +83,7 @@
 <script setup lang="ts">
 import RecordCard from './RecordCard.vue'
 import { ArrowBack, ArrowForward, RepeatOutline } from '@vicons/ionicons5'
-import { onMounted, provide, ref, watch } from 'vue'
+import { computed, onMounted, provide, ref, watch } from 'vue'
 import { useLoadingBar } from 'naive-ui'
 import { useRoute } from 'vue-router'
 import { renderSingleSelectTag, renderLabel, filterChampionFunc } from '../composition'
@@ -139,9 +139,9 @@ const resetFilter = () => {
 const handleUpdateValue = () => {
   page.value = 1
   if (filterChampionId.value > 0 || filterQueueId.value > 0) {
-    getHistoryMatch(route.query.name as string, 0, 49)
+    getHistoryMatch(name.value, 0, 49)
   } else {
-    getHistoryMatch(route.query.name as string, 0, 9)
+    getHistoryMatch(name.value, 0, 9)
   }
 }
 
@@ -155,7 +155,7 @@ let curBegIndex = 0
 let curEndIndex = 0
 
 const route = useRoute()
-let name = ''
+const name = computed(() => (route.query.name as string) ?? '')
 
 async function openDetail(game: Game) {
   await openMatchDetailWindow(game)
@@ -217,7 +217,7 @@ const nextPage = async () => {
     endIndex = begIndex + 9
   }
 
-  await getHistoryMatch(name, begIndex, endIndex)
+  await getHistoryMatch(name.value, begIndex, endIndex)
   page.value++
 }
 
@@ -228,18 +228,14 @@ const prevPage = async () => {
   if (!lastPage) {
     throw new Error('无上一页数据')
   }
-  await getHistoryMatch(name, lastPage.begIndex, lastPage.endIndex)
+  await getHistoryMatch(name.value, lastPage.begIndex, lastPage.endIndex)
   page.value = Math.max(1, page.value - 1)
 }
 
 onMounted(async () => {
   await initModeOptions()
   championOptions.value = await invoke<championOption[]>('get_champion_options')
-})
-
-onMounted(async () => {
-  name = route.query.name as string
-  await getHistoryMatch(name, 0, 9)
+  await getHistoryMatch(name.value, 0, 9)
 })
 </script>
 

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -83,7 +83,15 @@
             >
               <n-tooltip trigger="hover" placement="top">
                 <template #trigger>
-                  <span :class="['record-card-augment-shell', augmentRarityClass(augmentId)]">
+                  <span
+                    :class="[
+                      'record-card-augment-shell',
+                      augmentRarityClass(
+                        assets.detailOf('perk', augmentId)?.rarity,
+                        'record-card-augment'
+                      )
+                    ]"
+                  >
                     <img
                       :src="assets.srcOf('perk', augmentId)"
                       class="record-card-augment-icon"
@@ -219,7 +227,8 @@ import { useRouter } from 'vue-router'
 import { formatCompactNumber } from '@renderer/utils/format'
 import { healColorAndTaken, otherColor } from '@renderer/utils/colors'
 import { assetPrefix } from '@renderer/services/http'
-import { useSettingsStore } from '@renderer/pinia/setting'
+import { useTheme } from '@renderer/composables/useTheme'
+import { augmentRarityClass } from '@renderer/utils/augment'
 import type { Game } from '@renderer/types/domain/match'
 import AssetTooltipContent from './AssetTooltipContent.vue'
 import StatDots from './StatDots.vue'
@@ -237,10 +246,7 @@ const emit = defineEmits<{
   'open-detail': []
 }>()
 
-const settingsStore = useSettingsStore()
-const isDark = computed(
-  () => settingsStore.theme?.name === 'Dark' || settingsStore.theme?.name === 'dark'
-)
+const { isDark } = useTheme()
 
 /** 海克斯乱斗模式 queueId: 1700(斗魂竞技场), 2400(海克斯大乱斗) */
 const augmentQueueIds = new Set([1700, 2400])
@@ -288,23 +294,6 @@ onMounted(() => {
     { kind: 'item', ids: itemIds.value }
   ])
 })
-
-/** 海克斯符文稀有度样式类 */
-function augmentRarityClass(augmentId: number) {
-  const rarity = assets.detailOf('perk', augmentId)?.rarity ?? ''
-  switch (rarity) {
-    case 'kPrismatic':
-      return 'record-card-augment-prismatic'
-    case 'kGold':
-      return 'record-card-augment-gold'
-    case 'kSilver':
-      return 'record-card-augment-silver'
-    case 'kBronze':
-      return 'record-card-augment-bronze'
-    default:
-      return 'record-card-augment-default'
-  }
-}
 
 const themeColors = computed(() => {
   if (isDark.value) {

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.ts
@@ -143,6 +143,20 @@ export function useSessionSync() {
   })
 
   const unlisteners: Array<() => void> = []
+  const pendingTimers = new Set<ReturnType<typeof setTimeout>>()
+
+  /**
+   * 包装 setTimeout，把 id 记入 pendingTimers，回调执行时自动移除。
+   * onUnmounted 会清掉仍未触发的 timer，避免组件卸载后写响应式状态。
+   */
+  function trackedSetTimeout(fn: () => void, ms: number) {
+    const id = setTimeout(() => {
+      pendingTimers.delete(id)
+      fn()
+    }, ms)
+    pendingTimers.add(id)
+    return id
+  }
 
   async function requestSessionData() {
     try {
@@ -164,9 +178,9 @@ export function useSessionSync() {
 
     if (!enoughSubteams && retryCount < MAX_RETRIES) {
       retryCount++
-      setTimeout(() => {
+      trackedSetTimeout(() => {
         requestSessionData()
-        setTimeout(checkAndRetryFetch, RETRY_RECHECK_DELAY_MS)
+        trackedSetTimeout(checkAndRetryFetch, RETRY_RECHECK_DELAY_MS)
       }, RETRY_DELAY_MS)
     }
   }
@@ -238,13 +252,15 @@ export function useSessionSync() {
     (newVal, oldVal) => {
       if (newVal === 'InProgress' && oldVal !== 'InProgress') {
         retryCount = 0
-        setTimeout(checkAndRetryFetch, PHASE_READY_DELAY_MS)
+        trackedSetTimeout(checkAndRetryFetch, PHASE_READY_DELAY_MS)
       }
     }
   )
 
   onUnmounted(() => {
     for (const off of unlisteners) off()
+    for (const id of pendingTimers) clearTimeout(id)
+    pendingTimers.clear()
   })
 
   return { sessionData, requestSessionData }

--- a/lol-record-analysis-tauri/src/views/settings/Automation.vue
+++ b/lol-record-analysis-tauri/src/views/settings/Automation.vue
@@ -354,7 +354,6 @@ const addBanData = async (value: any) => {
   await updateBanData()
 }
 const addPickData = async (value: any) => {
-  console.log('addPickData', value)
   if (myPickData.value.includes(value) || value === 0) return
   myPickData.value?.push(value)
   await updatePickData()

--- a/lol-record-analysis-tauri/tsconfig.json
+++ b/lol-record-analysis-tauri/tsconfig.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@renderer/*": ["./src/*"],
-      "@components/*": ["./src/components/*"],
-      "@utils/*": ["./src/utils/*"]
+      "@renderer/*": ["./src/*"]
     },
     "target": "ES2020",
     "useDefineForClassFields": true,

--- a/lol-record-analysis-tauri/vitest.config.ts
+++ b/lol-record-analysis-tauri/vitest.config.ts
@@ -19,11 +19,14 @@ export default defineConfig({
         '**/assets/**',
         '**/dist/**'
       ],
+      // 当前实际覆盖率：lines 16.47% / functions 46.7% / branches 74.83% / statements 16.47%
+      // threshold 锁定在 floor 附近做"无回归基线"——禁止 PR 让覆盖率倒退，
+      // 而非达成 80%。CLAUDE.md 中 80% 仍为长期目标，靠后续 PR 增加测试逐步抬升。
       thresholds: {
-        lines: 80,
-        functions: 80,
-        branches: 80,
-        statements: 80
+        lines: 15,
+        functions: 45,
+        branches: 73,
+        statements: 15
       }
     }
   },


### PR DESCRIPTION
## Summary

整体 review 的 Bundle A + B 合并 PR。**已 rebase 到当前 main（包含已合并的 #58 / #61）**，原 PR #59 内容并入此 PR，#59 将被关闭。

### Bundle A — 去重 + 修小漏洞（commit `0bdb2b5`）

- **`isDark` ×4 → `useTheme()`**：App.vue / PlayerCard.vue / MatchDetailModal.vue / RecordCard.vue 各自复制了一份 `computed(() => theme.name === 'Dark'|'dark')`，统一调用 `composables/useTheme.ts`（已被 `useTheme.spec.ts` 覆盖）。
- **`augmentRarityClass` 去重**：RecordCard.vue 私有版本删除，统一调 `utils/augment.ts` 的通用版（与 MatchDetailModal 对齐）。
- **`pinia/setting.ts`**：经 rebase 到 main，已与 #61 的 helper 改造对齐，原 #59 中的"bug fix"在 #61 已实现，此处仅保留 import 和调用形式。
- **`Automation.vue`**：删除调试遗漏的 `console.log('addPickData', value)`。
- **`MatchHistory.vue`**：两个 `onMounted` 合并；模块级 `let name = ''` → `computed(() => route.query.name)`，避免路由变更未重渲染时拿到过期值；`championOption` 导入路径从 deprecated `'../type'` 改成 canonical `@renderer/types/domain/champion`。
- **`useSessionSync`**：retry 路径的 `setTimeout` 引入 `trackedSetTimeout` + `pendingTimers` Set，`onUnmounted` 时 `clearTimeout` 所有未触发的 timer，避免组件卸载后写已销毁响应式状态。
- **`token.rs:auth_resolver`**：内联 `Regex::new(...)` 抽到 `static AUTH_REGEX: LazyLock<Regex>`，LCU 认证重试时不再重复编译。

### Bundle B — 工具链 + CI + 配置卫生（commit `feaf554`）

**依赖升级（移除 GHSA）**
- **`env_logger 0.9 → 0.11`**：间接依赖 `atty 0.2.14` 有 GHSA-g98v-hv3f-hcfr (Windows unsound)，0.11 完全移除。`Cargo.lock` 同步：`atty` / `hermit-abi 0.1` / `humantime` / `termcolor` 全部摘除，新加 `jiff` 系作为时间格式化后端。`main.rs` 里的 `buf.timestamp_millis()` API 不变。
- **`@tauri-apps/plugin-opener "^2.0.0-alpha.3" → "^2"`**：之前一直锁在 alpha，永远不会升 stable 2.x。

**CI 硬门禁**
- 之前 `vitest.config.ts` 写了 80% threshold 但 CI 跑 `npm run test`（不带 `--coverage`），threshold 形同虚设。
- 本 PR：CI 切 `npm run test:coverage`，threshold 真正生效。
- threshold 调到当前 floor（lines/statements 15、functions 45、branches 73）。当前实际覆盖率 16.47% / 46.7% / 74.83% / 16.47%，threshold 略低于 floor 留 1-2% 抖动空间。这是**无回归基线**，不是达成目标 —— CLAUDE.md 中 80% 仍为长期目标，靠后续 PR 增加测试逐步抬升。

**配置卫生**
- `tsconfig.json`：删 `@components/@utils` path alias（grep 整个 src 0 hits，dead config）。
- `.eslintrc.cjs`：启用 `@typescript-eslint/no-explicit-any: warn`。CODE_QUALITY.md 早就禁 any 但没规则化。**当前 91 处 warning**，warn 级别不阻塞 CI，留作后续逐文件治理。
- `tauri.conf.json`：删 `dangerousInsecureTransportProtocol: true`。两条 updater endpoint 都已 https://，flag 当前没有实际明文流量，但留着等于给未来挖坑。
- 新建 `lol-record-analysis-tauri/.gitignore`：仓库之前没这个文件（只有 `src-tauri/.gitignore`），`dist/` 和 `coverage/` 都不在任何 ignore 范围。启用 coverage 生成后必须 ignore。

## Rebase 备注

原 #59 / #60 都基于 #58 之前的 main，与已合并的 #58 (token.rs AtomicU32 + markdown-it html:false) 和 #61 (config IPC 包装) 有冲突。本次 rebase 后：
- `token.rs` 的 LazyLock import 与 #58 的 atomic import 并列，AtomicU32 改造 + AUTH_REGEX 都保留。
- `pinia/setting.ts` 自动 merge 到 #61 的版本（功能完全等价，#59 内的"bug fix"已被 #61 的强切设计取代）。
- `Automation.vue` 自动 merge：保留 #61 的 `?? false / ?? []` defaults + 裸值写入 + Bundle A 删除的 console.log。

## Test plan

- [x] `npm run check` ✓ 0 errors / 91 `no-explicit-any` warnings（预期）
- [x] `npm run test` ✓ 12/12 suites pass，219 tests pass
- [ ] CI Windows-latest 跑通 cargo clippy（验证 env_logger 0.11 + `timestamp_millis()` 在 0.11 仍存在）
- [ ] CI ubuntu-latest 跑通 `test:coverage` gate
- [ ] CI `security-audit` job 跑 `cargo audit` 后 atty GHSA 告警消失
- [ ] `npm run tauri dev` 启动正常（plugin-opener 升级不影响 IPC；主题切换 / 战绩场数 / Automation 开关 / Pick-Ban 规则 / UserRecord 模式持久化均正常）