### PR TITLE
refactor: 统一 config IPC 格式为 { value: T } 包装

### DIFF
--- a/lol-record-analysis-tauri/src/components/record/UserRecord.vue
+++ b/lol-record-analysis-tauri/src/components/record/UserRecord.vue
@@ -143,6 +143,7 @@ import {
 } from '@renderer/types/domain/analysis'
 import { modeOptions, initModeOptions } from '@renderer/composables/useGameModes'
 import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import RelationshipPanel from './RelationshipPanel.vue'
 import RankCard from './RankCard.vue'
 import RecentStatsTable from './RecentStatsTable.vue'
@@ -183,7 +184,9 @@ const loadSummonerData = async (summonerName: string) => {
 
   const [rankValue, modeValue, platformValue, solo, flex] = await Promise.all([
     invoke<Rank>('get_rank_by_name', { name }),
-    invoke<number>('get_config', { key: 'selectMode' }).then(v => v || 0),
+    // 历史上 reader 用 `selectMode`、writer 用 `settings.user.selectMode`，
+    // 导致用户切换的模式从来没被持久化读到。统一为 writer 用的 key。
+    getConfigByIpc<number>('settings.user.selectMode').then(v => v ?? 0),
     invoke<string>('get_platform_name_by_name', { name }),
     invoke<RecentWinRate>('get_win_rate_by_name_mode', { name, mode: 420 }),
     invoke<RecentWinRate>('get_win_rate_by_name_mode', { name, mode: 440 })
@@ -218,7 +221,7 @@ watch(
 const mode = ref('全部')
 const updateModel = (value: string | number, option: any) => {
   const selectMode = value as number
-  invoke('put_config', { key: 'settings.user.selectMode', value: selectMode })
+  putConfigByIpc('settings.user.selectMode', selectMode)
   getTags(name, selectMode)
   mode.value = option.label as string
 }

--- a/lol-record-analysis-tauri/src/composables/useRules.ts
+++ b/lol-record-analysis-tauri/src/composables/useRules.ts
@@ -1,7 +1,6 @@
 /**
  * Pick/Ban 规则 CRUD composable
  * 包装 put_config / get_config Tauri 命令，提供响应式的规则列表读写。
- * 配置层以 `{ value: <list> }` 格式存储；读取由 getConfigByIpc 自动解包。
  */
 
 import { ref } from 'vue'
@@ -32,7 +31,7 @@ export function usePickRules() {
 
   const save = async (next: PickRule[]) => {
     rules.value = next
-    await putConfigByIpc(PICK_KEY, { value: next })
+    await putConfigByIpc(PICK_KEY, next)
   }
 
   return { rules, reload, save }
@@ -59,7 +58,7 @@ export function useBanRules() {
 
   const save = async (next: BanRule[]) => {
     rules.value = next
-    await putConfigByIpc(BAN_KEY, { value: next })
+    await putConfigByIpc(BAN_KEY, next)
   }
 
   return { rules, reload, save }

--- a/lol-record-analysis-tauri/src/pinia/setting.ts
+++ b/lol-record-analysis-tauri/src/pinia/setting.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { darkTheme, lightTheme } from 'naive-ui'
-import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 
 export const useSettingsStore = defineStore('settings', () => {
   const theme = ref(darkTheme)
@@ -9,7 +9,7 @@ export const useSettingsStore = defineStore('settings', () => {
   /** 从持久化配置拉取主题，由 main.ts 在 app 启动时显式调用 */
   async function initTheme() {
     try {
-      const savedTheme = await invoke<string>('get_config', { key: 'theme' })
+      const savedTheme = await getConfigByIpc<string>('theme')
       theme.value = savedTheme === 'light' ? lightTheme : darkTheme
     } catch (error) {
       console.error('Failed to load theme config:', error)
@@ -19,10 +19,10 @@ export const useSettingsStore = defineStore('settings', () => {
   async function toggleTheme() {
     if (theme.value.name == 'dark') {
       theme.value = lightTheme
-      await invoke('put_config', { key: 'theme', value: 'light' })
+      await putConfigByIpc('theme', 'light')
     } else {
       theme.value = darkTheme
-      await invoke('put_config', { key: 'theme', value: 'dark' })
+      await putConfigByIpc('theme', 'dark')
     }
   }
 

--- a/lol-record-analysis-tauri/src/services/ipc.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ipc.spec.ts
@@ -74,23 +74,23 @@ describe('ipc', () => {
 
   describe('putConfigByIpc', () => {
     /**
-     * 测试：当调用时应使用正确的参数调用 invoke
+     * 测试：调用方传裸值，helper 内部包装成 { value: T } 写入
      */
-    it('should call invoke with correct parameters when putting config', async () => {
+    it('should wrap scalar value in { value } when writing config', async () => {
       vi.mocked(invoke).mockResolvedValue(undefined)
 
       await putConfigByIpc('theme', 'dark')
 
       expect(invoke).toHaveBeenCalledWith('put_config', {
         key: 'theme',
-        value: 'dark'
+        value: { value: 'dark' }
       })
     })
 
     /**
-     * 测试：当传入复杂值时应正确处理
+     * 测试：复杂对象 value 也应被原样包装一层
      */
-    it('should handle complex config values correctly', async () => {
+    it('should wrap complex object value in { value }', async () => {
       vi.mocked(invoke).mockResolvedValue(undefined)
 
       const complexValue = { name: 'Dark', primary: '#000000' }
@@ -98,21 +98,21 @@ describe('ipc', () => {
 
       expect(invoke).toHaveBeenCalledWith('put_config', {
         key: 'theme',
-        value: complexValue
+        value: { value: complexValue }
       })
     })
 
     /**
-     * 测试：当传入布尔值时应正确处理
+     * 测试：布尔值也走相同包装路径
      */
-    it('should handle boolean config values correctly', async () => {
+    it('should wrap boolean value in { value }', async () => {
       vi.mocked(invoke).mockResolvedValue(undefined)
 
       await putConfigByIpc('autoUpdateSwitch', true)
 
       expect(invoke).toHaveBeenCalledWith('put_config', {
         key: 'autoUpdateSwitch',
-        value: true
+        value: { value: true }
       })
     })
 
@@ -187,14 +187,39 @@ describe('ipc', () => {
     })
 
     /**
-     * 测试：当配置值为 null 时应返回 null
+     * 测试：当配置值为 null 时应返回 null（包装本身存在，只是内部值是 null）
      */
-    it('should return null when config value is null', async () => {
+    it('should return null when wrapped value is null', async () => {
       vi.mocked(invoke).mockResolvedValue({ value: null })
 
       const result = await getConfigByIpc<null>('empty')
 
       expect(result).toBeNull()
+    })
+
+    /**
+     * 测试：键不存在 / 后端返回 null 时应返回 undefined
+     */
+    it('should return undefined when backend returns null (key absent)', async () => {
+      vi.mocked(invoke).mockResolvedValue(null)
+
+      const result = await getConfigByIpc<string>('missing')
+
+      expect(result).toBeUndefined()
+    })
+
+    /**
+     * 测试：老格式裸值（非 { value: T } 包装）应返回 undefined，让调用方走默认值
+     *
+     * 强切迁移后，老用户磁盘上残留的裸值 key（theme / matchHistoryCount /
+     * selectMode）会被读为 undefined，用户在 UI 上重新设置一次即可恢复。
+     */
+    it('should return undefined when stored value is bare (legacy format)', async () => {
+      vi.mocked(invoke).mockResolvedValue('dark')
+
+      const result = await getConfigByIpc<string>('theme')
+
+      expect(result).toBeUndefined()
     })
 
     /**

--- a/lol-record-analysis-tauri/src/services/ipc.ts
+++ b/lol-record-analysis-tauri/src/services/ipc.ts
@@ -12,23 +12,33 @@ export async function getImgBase64ByIpc(typeString: string, id: number) {
   return base64
 }
 
-/** value 允许任何可序列化为 JSON 的类型；Rust 端使用 serde_json::Value 接收 */
-export async function putConfigByIpc(key: string, value: unknown) {
-  await invoke('put_config', { key, value })
-}
-
-interface ConfigValue<T = unknown> {
-  value: T
+/**
+ * 写入配置。
+ *
+ * 持久化格式统一为 `{ value: T }` 包装 —— helper 内部完成包装，调用方只传裸值。
+ * 历史上配置以"裸值"和"包装值"两种格式混存，会让后续 contributor 很容易踩坑
+ * （比如 read 用 helper 解包但 write 忘了包装）。现统一为单一格式，避免再发生。
+ *
+ * 注意：不要把形如 `{ value: ... }` 的业务对象作为 value 传入 ——
+ * 会被 `getConfigByIpc` 读出时误解包成内部字段。
+ */
+export async function putConfigByIpc<T>(key: string, value: T): Promise<void> {
+  await invoke('put_config', { key, value: { value } })
 }
 
 /**
- * 调用者通过泛型声明期望类型。
- * 这里的类型断言（configValue.value as T）是 Tauri <-> 前端的信任边界 ——
- * Rust 侧负责 schema，前端接收到的就是声明的类型。
+ * 读取配置，自动解包 `{ value: T }` 格式。
+ *
+ * 老版本（v1.8.0 及之前）可能以裸值持久化少数 key（theme / matchHistoryCount /
+ * selectMode）；升级后这些键读出 `undefined`，调用方走默认值，用户需要在 UI
+ * 上重新设置一次。这是已知一次性影响，写在 CHANGELOG。
  */
-export async function getConfigByIpc<T>(key: string) {
-  const configValue = await invoke<ConfigValue<T>>('get_config', { key })
-  return configValue.value
+export async function getConfigByIpc<T>(key: string): Promise<T | undefined> {
+  const raw = await invoke<{ value: T } | null>('get_config', { key })
+  if (raw && typeof raw === 'object' && 'value' in raw) {
+    return raw.value
+  }
+  return undefined
 }
 
 export async function getGameModesByIpc() {

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -73,7 +73,7 @@
 
 <script lang="ts" setup>
 import { computed, onMounted, ref } from 'vue'
-import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { SettingsOutline, SparklesOutline } from '@vicons/ionicons5'
 import { useMessage } from 'naive-ui'
 import MarkdownIt from 'markdown-it'
@@ -122,7 +122,7 @@ const renderedAIResult = computed(() => (aiResult.value ? md.render(aiResult.val
 const handleUpdateConfig = async (value: number | null) => {
   if (!value) return
   try {
-    await invoke('put_config', { key: 'matchHistoryCount', value })
+    await putConfigByIpc('matchHistoryCount', value)
     message.success('设置已保存')
   } catch (e) {
     message.error('保存失败')
@@ -158,11 +158,9 @@ const handleAIAnalysis = async () => {
 
 onMounted(async () => {
   try {
-    const val = await invoke('get_config', { key: 'matchHistoryCount' })
+    const val = await getConfigByIpc<number>('matchHistoryCount')
     if (typeof val === 'number') {
       matchCount.value = val
-    } else if (typeof val === 'string' && val) {
-      matchCount.value = parseInt(val) || 4
     }
   } catch (e) {
     console.error(e)

--- a/lol-record-analysis-tauri/src/views/settings/Automation.vue
+++ b/lol-record-analysis-tauri/src/views/settings/Automation.vue
@@ -229,12 +229,12 @@ const banEditing = ref<BanRule | undefined>(undefined)
 onMounted(async () => {
   const opts = await invoke<championOption[]>('get_champion_options')
   options.value = opts.filter(opt => opt.value > 0)
-  autoAccept.value = await getConfigByIpc<boolean>('settings.auto.acceptMatchSwitch')
-  autoPick.value = await getConfigByIpc<boolean>('settings.auto.pickChampionSwitch')
-  autoBan.value = await getConfigByIpc<boolean>('settings.auto.banChampionSwitch')
-  myPickData.value = (await getConfigByIpc<number[]>('settings.auto.pickChampionSlice')) || []
-  myBanData.value = (await getConfigByIpc<number[]>('settings.auto.banChampionSlice')) || []
-  autoStart.value = await getConfigByIpc<boolean>('settings.auto.startMatchSwitch')
+  autoAccept.value = (await getConfigByIpc<boolean>('settings.auto.acceptMatchSwitch')) ?? false
+  autoPick.value = (await getConfigByIpc<boolean>('settings.auto.pickChampionSwitch')) ?? false
+  autoBan.value = (await getConfigByIpc<boolean>('settings.auto.banChampionSwitch')) ?? false
+  myPickData.value = (await getConfigByIpc<number[]>('settings.auto.pickChampionSlice')) ?? []
+  myBanData.value = (await getConfigByIpc<number[]>('settings.auto.banChampionSlice')) ?? []
+  autoStart.value = (await getConfigByIpc<boolean>('settings.auto.startMatchSwitch')) ?? false
   await reloadPickRules()
   await reloadBanRules()
 })
@@ -321,23 +321,23 @@ const myPickData = ref<number[]>([])
 const myBanData = ref<number[]>([])
 
 const updateAcceptSwitch = async () => {
-  await putConfigByIpc('settings.auto.acceptMatchSwitch', { value: autoAccept.value })
+  await putConfigByIpc('settings.auto.acceptMatchSwitch', autoAccept.value)
 }
 
 const updatePickSwitch = async () => {
-  await putConfigByIpc('settings.auto.pickChampionSwitch', { value: autoPick.value })
+  await putConfigByIpc('settings.auto.pickChampionSwitch', autoPick.value)
 }
 const updateBanSwitch = async () => {
-  await putConfigByIpc('settings.auto.banChampionSwitch', { value: autoBan.value })
+  await putConfigByIpc('settings.auto.banChampionSwitch', autoBan.value)
 }
 const updatePickData = async () => {
-  await putConfigByIpc('settings.auto.pickChampionSlice', { value: myPickData.value })
+  await putConfigByIpc('settings.auto.pickChampionSlice', myPickData.value)
 }
 const updateBanData = async () => {
-  await putConfigByIpc('settings.auto.banChampionSlice', { value: myBanData.value })
+  await putConfigByIpc('settings.auto.banChampionSlice', myBanData.value)
 }
 const updateStartSwitch = async () => {
-  await putConfigByIpc('settings.auto.startMatchSwitch', { value: autoStart.value })
+  await putConfigByIpc('settings.auto.startMatchSwitch', autoStart.value)
 }
 
 const deleteBanData = async (value: any) => {

--- a/lol-record-analysis-tauri/src/views/settings/General.vue
+++ b/lol-record-analysis-tauri/src/views/settings/General.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { useMessage } from 'naive-ui'
 
 const matchCount = ref(4)
@@ -23,12 +23,9 @@ const message = useMessage()
 
 onMounted(async () => {
   try {
-    const val = await invoke('get_config', { key: 'matchHistoryCount' })
-    // Handle explicit number or string fallback
+    const val = await getConfigByIpc<number>('matchHistoryCount')
     if (typeof val === 'number') {
       matchCount.value = val
-    } else if (typeof val === 'string' && val) {
-      matchCount.value = parseInt(val) || 4
     }
   } catch (e) {
     console.error(e)
@@ -38,7 +35,7 @@ onMounted(async () => {
 const handleUpdate = async (value: number | null) => {
   if (!value) return
   try {
-    await invoke('put_config', { key: 'matchHistoryCount', value })
+    await putConfigByIpc('matchHistoryCount', value)
     message.success('设置已保存，下次获取数据时生效')
   } catch (e) {
     message.error('保存失败')


### PR DESCRIPTION
## Summary

整体 review 的 follow-up：把项目里 config 读写的两种风格收敛到一种。

### 背景

之前 config 持久化格式不统一：
- `pinia/setting.ts` 走原生 \`invoke<T>('get_config'/'put_config', ...)\`，存的是裸值（\`theme: \"dark\"\`）
- \`views/settings/Automation.vue\` / \`composables/useRules.ts\` 走 \`putConfigByIpc(key, { value: x })\`（调用方手动包装），\`getConfigByIpc\` 读时解 \`.value\`，磁盘上是 \`{ value: true }\`
- \`Gaming.vue\` / \`General.vue\` / \`UserRecord.vue\` 又混用裸 invoke

两种约定并存的坑：写时忘了包 / 读时用错 helper 会静默拿到 \`undefined\`，没有任何报错。PR #59 review 时就被这个坑过一次（详见该 PR 描述）。

### 改动

- **\`putConfigByIpc\` 内部强包装**，\`getConfigByIpc\` 自动解包。调用方只见裸值，磁盘统一存 \`{ value: T }\`
- **8 个文件迁移**到 helper：\`pinia/setting.ts\` / \`Automation.vue\` / \`useRules.ts\` / \`General.vue\` / \`Gaming.vue\` / \`UserRecord.vue\` / \`services/ipc.ts\` / \`services/ipc.spec.ts\`。仓库内不再有任何直接 \`invoke('get_config'|'put_config'...)\` 调用
- **\`getConfigByIpc\` 返回类型收紧** \`Promise<T>\` → \`Promise<T | undefined>\`。修复 Automation.vue 4 处隐藏的 \`ref<boolean> = undefined\` 类型错（用 \`?? false / ?? []\` 兜底）
- **顺手修 UserRecord.vue 一个预先存在的 bug**：reader 读 \`'selectMode'\`、writer 写 \`'settings.user.selectMode'\`，键不一致，导致用户切换的模式从未持久化读到（每次重启都回默认）。统一到 \`'settings.user.selectMode'\`

### 迁移影响（仅老用户）

\`theme\` / \`matchHistoryCount\` / \`selectMode\` 三个 key 历史上以裸值持久化，新 helper 期望 \`{ value: T }\` 包装格式 → 读出 \`undefined\` → 回落默认值。**改过这三项偏好的用户需要在 UI 重新设置一次**：
- 主题：右上角主题切换按钮点一下
- 默认战绩场数：设置 → 常规设置 → 默认战绩场数
- 用户选择模式（UserRecord 下拉框）：本来就因为上述 bug 没在持久化，新版才会真正生效

其他配置（Automation 6 个开关 / Pick-Ban 规则）原本就是包装格式，**零影响**。

### 不在范围

- 一次性数据迁移逻辑（启动时把老格式裸值搬到新格式）：评估后没做，3 个 key 的损失换 1 次点击 vs. 30 行迁移代码 + 测试，选了前者
- helper 容错读取裸值（双格式 fallback）：同理，强切换 cleaner

## Test plan

- [x] \`npm run check\` 通过（prettier + eslint + vue-tsc + cargo fmt --check + cargo clippy -Dwarnings）
- [x] \`npm run test\` 通过（219/219，含更新后的 24 个 ipc.spec.ts case 全绿）
- [ ] Windows 上 \`npm run tauri dev\` 手测：
  - [ ] 主题切换正常，重启后保持
  - [ ] Settings 默认战绩场数能改、重启保持
  - [ ] Automation 6 个开关 + 双方英雄列表能改、重启读回正确
  - [ ] Pick / Ban 规则增删改持久化正常
  - [ ] UserRecord 下拉模式切换后，重新进入页面能读回上次选择（验证 bug fix）