### PR TITLE
chore(ci): cliff.toml 支持 conventional scope + bump 1.8.1

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -30,16 +30,16 @@ conventional_commits = true
 filter_unconventional = false  # 保留非规范的 commit
 split_commits = false
 commit_parsers = [
-    # 支持全角冒号和半角冒号
-    { message = "(?i)^feat[：:]", group = "🚀 Features" },
-    { message = "(?i)^fix[：:]", group = "🐛 Bug Fixes" },
-    { message = "(?i)^doc[：:]", group = "📚 Documentation" },
-    { message = "(?i)^perf[：:]", group = "⚡ Performance" },
-    { message = "(?i)^refactor[：:]", group = "🛠 Refactor" },
-    { message = "(?i)^style[：:]", group = "🎨 Styling" },
-    { message = "(?i)^test[：:]", group = "🧪 Testing" },
+    # 支持全角/半角冒号，以及可选的 (scope) 后缀(如 fix(arena): xxx)
+    { message = "(?i)^feat(\\(.+?\\))?[：:]", group = "🚀 Features" },
+    { message = "(?i)^fix(\\(.+?\\))?[：:]", group = "🐛 Bug Fixes" },
+    { message = "(?i)^doc(\\(.+?\\))?[：:]", group = "📚 Documentation" },
+    { message = "(?i)^perf(\\(.+?\\))?[：:]", group = "⚡ Performance" },
+    { message = "(?i)^refactor(\\(.+?\\))?[：:]", group = "🛠 Refactor" },
+    { message = "(?i)^style(\\(.+?\\))?[：:]", group = "🎨 Styling" },
+    { message = "(?i)^test(\\(.+?\\))?[：:]", group = "🧪 Testing" },
     { message = "^chore\\(release\\): prepare for", skip = true },
-    { message = "(?i)^chore[：:]", skip = true },
+    { message = "(?i)^chore(\\(.+?\\))?[：:]", skip = true },
     { body = ".*security", group = "🛡️ Security" },
     # 不匹配 conventional commit 格式的跳过
     { message = ".*", skip = true },

--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "lol-record-analysis-app",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.lol-record-analysis-tauri.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- **cliff.toml commit_parsers 正则支持 `(scope)`** — 旧正则 `(?i)^fix[：:]` 要求 type 后立刻跟冒号,带 scope 的 commit (`fix(arena):` / `feat(security):` 等) 全部被 fallthrough 到 `skip = true`,历史所有 scoped commit 都漏出 changelog。加 `(\(.+?\))?` 可选段后,有/无 scope 都正确归类。
- **bump 1.8.1** — 配合 #62 (arena CHERRY 修复) 发版。

## Test plan
- [x] `npm run check` 通过
- [ ] 合并后 release workflow 跑 cliff 生成 changelog 时,scoped commit 应正确归入 🐛 Bug Fixes / 🚀 Features 等分组