### PR TITLE
feat(ui): Record/Gaming/MatchDetail 设计 token 收口 + viewport 自适应

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -67,7 +67,20 @@
       "mcp___hypothesi_tauri-mcp-server__ipc_get_backend_state",
       "mcp___hypothesi_tauri-mcp-server__webview_execute_js",
       "mcp___hypothesi_tauri-mcp-server__webview_dom_snapshot",
-      "mcp___hypothesi_tauri-mcp-server__get_setup_instructions"
+      "mcp___hypothesi_tauri-mcp-server__get_setup_instructions",
+      "Bash(git reset *)",
+      "Bash(git checkout *)",
+      "Bash(git *)",
+      "mcp___hypothesi_tauri-mcp-server__manage_window",
+      "mcp___hypothesi_tauri-mcp-server__webview_wait_for",
+      "mcp__playwright__browser_navigate",
+      "Bash(grep -iE \"#[0-9a-f]{3,8}\\\\b\")",
+      "Bash(findstr \"9223\")",
+      "Bash(findstr :9223)",
+      "mcp___hypothesi_tauri-mcp-server__webview_interact",
+      "mcp___hypothesi_tauri-mcp-server__webview_find_element",
+      "Bash(grep -nA 3 \"^\\\\.stats-card\" lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue)",
+      "Bash(grep *)"
     ]
   }
 }

--- a/docs/superpowers/specs/2026-05-23-record-page-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-05-23-record-page-ui-polish-design.md
@@ -1,0 +1,207 @@
+# Record 页面 UI Polish (Reference Quality) — 设计
+
+> 状态：设计稿，待实施
+> 日期：2026-05-23
+> 作者：wnzzer
+
+## 1. 背景
+
+Record 是 app 最高频入口页（左侧召唤师卡 + 段位 + 最近表现，右侧战绩列表），现状 13 个相关组件 UI 品质未到 reference quality，主要问题：
+
+- **Token 已有但未贯彻**：`src/global.css` 已经定义了完整的 `--space-*` / `--radius-*` / `--shadow-*` / `--dur-*` / `--ease-*` 体系，但组件大量硬编码——5 种 radius 值（6/8/10/12/999px）、8 档 font-size、3 种 padding 值散布在 inline style 与 scoped CSS 里
+- **缺字阶 token**：现有 token 不含 font-size 阶梯，导致字号无规范
+- **naive-ui 视觉脱钩**：没配 `GlobalThemeOverrides`，naive-ui 内置组件（Card / Button / Tag 等）默认外观跟自家 token 不对齐
+- **加载/空态降级粗糙**：列表加载只有全屏 loadingbar、无骨架屏；筛选无结果无专属 empty 态；图片懒加载无占位
+- **响应式断点过低**：500px 才切移动态，且 v-show 硬切无过渡
+
+### 目标
+
+把 Record 页打磨到 reference quality（A 视觉精致度 + C 交互反馈 + D 一致性/token 三层联动），作为后续 Gaming/MatchDetail/其他页扩散设计语言的基准。此页打磨后的 token + 模式将复用到其他页，每页后续按这套迁移属于常规改造，不再单独 spec。
+
+### 用户硬约束
+
+- 小组件不上毛玻璃效果（保留大面板 `panel-glass`）
+- 侧边栏禁止滚动条
+- Settings 页保持原样不动
+
+## 2. 范围
+
+### 涉及文件（新建 / 修改 / 不动 三类）
+
+**新建**：
+- `src/theme/overrides.ts` — naive-ui GlobalThemeOverrides 工厂
+- `src/composables/useBreakpoint.ts` — 响应式断点 reactive ref
+- `src/components/record/RecordCardSkeleton.vue` — 战绩卡骨架屏
+- `src/components/common/LazyImg.vue` — 带占位的懒加载 img wrapper
+
+**修改**：
+- `src/global.css` — 追加字阶、补 space 阶、补 radius、抽 win/loss 渐变
+- `src/pinia/setting.ts` — 暴露 `themeOverrides` computed（依赖主题切换）
+- `src/views/Record.vue` — 断点抬到 768px、加过渡动画
+- 13 个 record 相关组件 — token 清洗（pattern 一致）：
+  `UserRecord.vue` / `MatchHistory.vue` / `RecordCard.vue` / `RankCard.vue` / `RelationshipPanel.vue` / `RecentStatsTable.vue` / `ProgressStatRow.vue` / `StatDots.vue` / `RecordButton.vue` / `TeamAvatarGroup.vue` / `AssetTooltipContent.vue` / `MatchDetailModal.vue` / `MatchAIPanel.vue`
+
+**不动**（Out of Scope）：
+- `src/views/Settings.vue` 和 `src/views/settings/**`（用户约束）
+- `src/components/Header.vue` / `SideNavigation.vue` / `Framework.vue`（全局 layout）
+- `src/components/automation/**` / `tags/**` / `gaming/**`（下一轮扩散）
+- IPC / composable 业务逻辑 / Rust 端
+- 不引入 Tailwind / UnoCSS / CSS-in-JS / Storybook
+- 不做 i18n 提取、a11y 全面审计、第三主题
+
+## 3. 设计
+
+### 3.1 Token 体系补全
+
+`global.css` 在 `:root` 和 `.theme-light` 块内**只追加不删**（确保未改动的旧组件继续可用）：
+
+| 类别 | 新增 token | 用途 |
+|---|---|---|
+| 字阶 | `--font-size-{2xs:10, xs:11, sm:12, base:13, md:14, lg:16, xl:18}` | 收编 8 档硬编码 |
+| 字阶辅助 | `--line-height-{tight:1.2, normal:1.45}` + `--font-weight-{medium:500, semibold:600, bold:700}` | 配套 |
+| 间距补阶 | `--space-{2:2, 6:6, 10:10}` | tooltip padding / icon gap 强需 |
+| 圆角 | `--radius-xs: 3px`（收编 MVP 徽章） + `--radius-pill: 999px`（进度条 token 化） | 消化 5 种值 |
+| 渐变 | `--win-bar-gradient` / `--loss-bar-gradient`（深浅两套） | 从 RecordCard 内联渐变抽离 |
+
+### 3.2 naive-ui GlobalThemeOverrides
+
+新建 `src/theme/overrides.ts`：
+
+```ts
+export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides
+```
+
+实现要点：
+- 通过 `getComputedStyle(document.documentElement).getPropertyValue(...)` 读 token
+- 每个 key 带 fallback hex/数值，防 SSR/首屏空字符串
+- 至少覆盖以下范畴（具体值在实现时按 token 填）：
+  - `common`: primaryColor / textColor1/2/3 / borderColor / cardColor
+  - `Card`: borderRadius = `--radius-lg`, paddingMedium = `--space-12`
+  - `Button`: borderRadiusSmall = `--radius-sm`
+  - `Select / Input / Pagination`: 圆角对齐 sm/md
+  - `Tag`: borderRadius = `--radius-pill`, heightSmall = 18px
+  - `Tooltip / Popover`: borderRadius = `--radius-md`, padding = `--space-8 --space-12`
+  - `Skeleton / Empty`: borderRadius = `--radius-md`
+
+`src/pinia/setting.ts` 增 computed `themeOverrides`（依赖 `theme.value.name`），App 根 `n-config-provider` 绑 `:theme-overrides`。求值放在 `onMounted` / `nextTick` 后，避免首屏读不到 CSS var。
+
+### 3.3 组件清洗 pattern（13 个全做）
+
+通用 pattern：
+
+1. inline `style="font-size: Xpx"` → class + `var(--font-size-*)`，按字阶映射
+2. `padding/margin/gap: Xpx` → `var(--space-X)`；不在阶上的吸附到最近 token
+3. `border-radius: 6/10/12px` → `var(--radius-{sm,md,lg})`
+4. ad-hoc `box-shadow` → `var(--shadow-{sm,md,lg})`；保留 `--glow-win/loss` 不动
+5. naive-ui 组件上的微调 style 迁到 scoped class，多数能被 `GlobalThemeOverrides` 兜底删除
+6. 十六进制硬编码色 → 对应 `--semantic-*` / `--win-*` / `--loss-*` token；若代码里有 rgba 透明度拼字符串场景，保留 `--glow-*` 不动
+
+代表重灾区（先做这 3 个建立 pattern 范例，其他批量过）：
+
+| 组件 | 硬编码处数 | 重要性 |
+|---|---|---|
+| `RecordCard.vue` | 16 | 列表基本单元，权重最高 |
+| `UserRecord.vue` | 8 | 占侧栏，是字号视觉基准 |
+| `MatchDetailModal.vue` | 34 | 弹窗最大单文件 |
+
+### 3.4 新增 UI 状态
+
+**骨架屏（n-skeleton）**：
+- 新建 `RecordCardSkeleton.vue`（高度对齐真实 ~64px，内 `n-skeleton` 模拟 win-bar / 头像 / KDA / 装备格）
+- `MatchHistory.vue` 在 `isRequestingMatchHostory && !matchHistory` 时渲染 10 个 skeleton 占位
+- 翻页 loading 走 toolbar 上方 2px 进度条，不全屏闪
+- `MatchAIPanel.vue` 流式加载初期 `n-skeleton text :repeat="4"` 替代空白
+
+**空态（n-empty）**：
+- `MatchHistory.vue` 筛选后 `games.length === 0`：`<n-empty description="没有匹配的对局" />` + "清除筛选" 按钮（复用 `resetFilter`）
+- 战绩首次加载失败：catch 分支设 `loadError = true` → `<n-empty>` + 重试按钮
+
+**图片懒加载占位**：
+- 新建 `src/components/common/LazyImg.vue`：onload 前用 `--bg-elevated` + `@keyframes shimmer`（global.css 已有）扫光，onload 后切真实 img；onError fallback
+- 本轮落地到 `RecordCard.vue` 的英雄/item/spell/perk icon 和 `TeamAvatarGroup.vue`
+
+### 3.5 响应式过渡
+
+`Record.vue` 当前 `windowWidth < 500` 直 `v-show` 切换。改造：
+
+- 新建 `src/composables/useBreakpoint.ts`，导出 `{ md: 768, lg: 1024 }` 的 reactive ref；替换组件内直接读 `window.innerWidth` 的散落代码
+- 断点抬到 768px
+- `n-layout-content` 包 `<Transition name="slide-fade">`：`opacity + translateX(16px)` + `var(--dur-normal)` + `var(--ease-expo)`
+- `n-layout-sider` 宽度变化加 `transition: width var(--dur-spring) var(--ease-expo)`
+- 把"侧栏无滚动条"的 `::-webkit-scrollbar { display: none }` 从 scoped 提到 `global.css` 的 `.no-scrollbar` 类，组件按需 class（确保用户硬约束生效）
+
+## 4. 验证
+
+### 4.1 MCP 截图对比流程（用 hypothesi/tauri-mcp-server）
+
+1. 启动 `npm run tauri dev`；`driver_session start port=9223`
+2. **基线快照**：对 `#/Record?name=幽默的二次元#12510` 截 4 张到 `tests/visual/baseline/`：
+   - dark × ≥768px viewport
+   - dark × 767px（mobile 态）
+   - light × ≥768px
+   - light × 767px
+
+   用 `manage_window resize` 切窗口宽度
+3. 每完成一个组件清洗：`webview_screenshot` 同视口 → 与 baseline 肉眼/diff 比对（不能"明显变样"，只能更整齐）
+4. **token 验证脚本**（`webview_execute_js`）：遍历 RecordCard / UserRecord 内的关键节点，读 `getComputedStyle(el).{fontSize, borderRadius, padding}`，断言数值落在 token 集合内（不能出现 7px/10px 这类非阶值）
+5. **DOM 对比**：`webview_dom_snapshot type=structure` 前后跑一次，确认没多塞元素、层级一致
+
+### 4.2 自动化测试
+
+- `vitest`：
+  - `useBreakpoint` 纯逻辑（resize 事件触发 → ref 更新）
+  - `buildThemeOverrides(isDark)` 工厂函数返回结构断言
+  - `MatchHistory` skeleton / empty 分支：`@vue/test-utils` 渲染断言"loading 时 skeleton 数量 == 10" / "filter 且 0 games 时 n-empty 出现"
+
+### 4.3 视觉回归人工自查清单
+
+每个组件改完，从开发窗口实际滚一遍：
+a) hover 态
+b) dark ↔ light 切主题
+c) 768px 临界 resize
+d) 筛选 0 条
+e) 翻页 loading
+f) 战绩加载失败模拟
+
+### 4.4 质量门禁
+
+`cd lol-record-analysis-tauri && npm run check` 必须全绿（prettier + eslint + vue-tsc + cargo fmt --check + cargo clippy -Dwarnings，与 CI 一致）。
+
+## 5. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| `getComputedStyle` 读 token 在首屏返回空字符串 | 每个 key 带 fallback hex；`themeOverrides` 求值放 `onMounted` / `nextTick` |
+| 十六进制硬编码改 CSS var 后 rgba 拼字符串失效 | 保留 `--glow-win/loss` 不动，只替换实色用法 |
+| 断点抬到 768px 在小窗 Tauri 直接进 mobile 态 | 接受现状，代码留 user override hook（YAGNI 本轮不做） |
+| 13 个组件 token 清洗误改文案/结构 | 每个组件独立 commit；MCP DOM snapshot 前后对比；视觉自查清单逐项过 |
+| GlobalThemeOverrides 改 naive-ui 视觉，可能波及未在 scope 的页面（Settings/Header）| 这些页面已经是 naive-ui 默认外观，新 overrides 若与默认差异大需在 PR 自查；小差异接受、大差异酌情豁免某些 naive 组件 |
+
+## 6. 回滚策略
+
+每个组件独立 commit（消息格式 `refactor(record): clean tokens in <Component>`），token 与 overrides 各自单独 commit。出问题逐 commit `git revert`。`global.css` 只追加不删 token，旧组件即使没改也不会坏。
+
+## 7. 实施顺序
+
+建议执行顺序（每步独立 commit，方便 revert）：
+
+1. `global.css` 追加字阶 / space-2/6/10 / radius-xs/pill / win-loss 渐变 token
+2. 新建 `theme/overrides.ts` + `pinia/setting.ts` 接通 + App 根 `n-config-provider` 绑定
+3. 新建 `composables/useBreakpoint.ts`
+4. 新建 `common/LazyImg.vue` + `record/RecordCardSkeleton.vue`
+5. `Record.vue` 断点 + 过渡（先验证布局没破）
+6. `RecordCard.vue` → `UserRecord.vue` → `MatchHistory.vue`（含 skeleton/empty 接入）
+7. `RankCard` / `RelationshipPanel` / `RecentStatsTable` / `ProgressStatRow` / `StatDots` / `RecordButton` / `TeamAvatarGroup` / `AssetTooltipContent`
+8. `MatchDetailModal.vue`（34 处，最重）
+9. `MatchAIPanel.vue`（含 streaming skeleton）
+10. 全量 `npm run check` + MCP 截图对比 + 视觉自查清单走一遍
+
+## 8. 后续工作（非本 spec 范围）
+
+本 spec 落地后，token + 模式将成为基准。后续每个页/组件群按相同 pattern 扩散：
+
+- 下一轮：`MatchDetailModal` 系列已含本轮；之后是 `gaming/**`（PlayerCard / SubteamCard / PlayerStatsCard 等）
+- 再下一轮：`automation/**` / `tags/**`
+- 最后：是否引入 `:root[data-density="compact|comfortable"]` 让用户切信息密度（YAGNI，看反馈）
+
+这些都作为单独的小型 spec 或常规改造 PR 走，不再单独大型设计。

--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -602,11 +602,13 @@ async fn process_subteam_parallel(
             };
         }
 
-        let count = match crate::config::get_config("matchHistoryCount").await {
-            Ok(crate::config::Value::Integer(v)) => v as i32,
-            Ok(crate::config::Value::String(s)) => s.parse().unwrap_or(4),
-            _ => 4,
-        };
+        let count = crate::config::get_config("matchHistoryCount")
+            .await
+            .ok()
+            .as_ref()
+            .and_then(crate::config::extract_int)
+            .map(|n| n as i32)
+            .unwrap_or(4);
         let puuid = player.puuid.clone();
 
         let (summoner, match_history, rank) = tokio::join!(

--- a/lol-record-analysis-tauri/src-tauri/src/config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/config.rs
@@ -307,6 +307,18 @@ pub fn extract_bool(value: &Value) -> Option<bool> {
     }
 }
 
+/// 从配置 Value 中提取整数。
+///
+/// 前端 `putConfigByIpc` 一律写入 `Value::Map({"value": ...})`，本函数只认这一种格式。
+pub fn extract_int(value: &Value) -> Option<i64> {
+    if let Value::Map(m) = value {
+        if let Some(Value::Integer(n)) = m.get("value") {
+            return Some(*n);
+        }
+    }
+    None
+}
+
 /// 从缓存获取配置值。
 ///
 /// 如果键不存在，返回根据键名推断的默认值。

--- a/lol-record-analysis-tauri/src/App.vue
+++ b/lol-record-analysis-tauri/src/App.vue
@@ -20,83 +20,14 @@
 import Framework from '@renderer/components/Framework.vue'
 import { useSettingsStore } from '@renderer/pinia/setting'
 import { useTheme } from '@renderer/composables/useTheme'
+import { buildThemeOverrides } from '@renderer/theme/overrides'
 import { computed } from 'vue'
 import { GlobalThemeOverrides } from 'naive-ui'
 
 const settingsStore = useSettingsStore()
 const { isDark } = useTheme()
 
-const themeOverrides = computed<GlobalThemeOverrides>(() => {
-  if (isDark.value) {
-    return {
-      common: {
-        borderRadius: '8px',
-        borderRadiusSmall: '6px'
-      },
-      Card: {
-        borderRadius: '10px',
-        color: 'rgba(255,255,255,0.05)',
-        boxShadow: '0 2px 8px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.06)',
-        borderColor: 'rgba(255,255,255,0.09)'
-      },
-      Input: {
-        borderRadius: '8px',
-        color: 'rgba(255,255,255,0.05)',
-        border: '1px solid rgba(255,255,255,0.09)'
-      },
-      Button: {
-        borderRadiusSmall: '6px',
-        borderRadiusMedium: '8px'
-      },
-      Select: {
-        borderRadius: '8px'
-      },
-      Layout: {
-        color: '#0a0a0d'
-      },
-      Menu: {
-        itemColorActive: 'rgba(61,155,122,0.14)',
-        itemColorActiveHover: 'rgba(61,155,122,0.18)',
-        itemBorderRadius: '10px',
-        itemTextColorActive: '#3d9b7a',
-        itemIconColorActive: '#3d9b7a'
-      }
-    }
-  }
-  return {
-    common: {
-      borderRadius: '8px',
-      borderRadiusSmall: '6px'
-    },
-    Card: {
-      borderRadius: '10px',
-      color: 'rgba(0,0,0,0.035)',
-      boxShadow: '0 2px 8px rgba(0,0,0,0.12), inset 0 1px 0 rgba(255,255,255,0.7)',
-      borderColor: 'rgba(0,0,0,0.08)'
-    },
-    Input: {
-      borderRadius: '8px',
-      border: '1px solid rgba(0,0,0,0.08)'
-    },
-    Button: {
-      borderRadiusSmall: '6px',
-      borderRadiusMedium: '8px'
-    },
-    Select: {
-      borderRadius: '8px'
-    },
-    Layout: {
-      color: '#f0f2f5'
-    },
-    Menu: {
-      itemColorActive: 'rgba(45,138,108,0.12)',
-      itemColorActiveHover: 'rgba(45,138,108,0.18)',
-      itemBorderRadius: '10px',
-      itemTextColorActive: '#2d8a6c',
-      itemIconColorActive: '#2d8a6c'
-    }
-  }
-})
+const themeOverrides = computed<GlobalThemeOverrides>(() => buildThemeOverrides(isDark.value))
 </script>
 <style lang="css">
 html,

--- a/lol-record-analysis-tauri/src/components/common/LazyImg.vue
+++ b/lol-record-analysis-tauri/src/components/common/LazyImg.vue
@@ -51,7 +51,8 @@ function onError() {
   display: block;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  /* contain: 保留图标的透明 halo / 留白，不裁切（适合图标类用例 — 项目里 LazyImg 全用在图标） */
+  object-fit: contain;
   transition: opacity var(--dur-fast) var(--ease-expo);
 }
 .lazy-img-loading img {

--- a/lol-record-analysis-tauri/src/components/common/LazyImg.vue
+++ b/lol-record-analysis-tauri/src/components/common/LazyImg.vue
@@ -1,0 +1,77 @@
+<template>
+  <span
+    class="lazy-img"
+    :class="{
+      'lazy-img-loading': state === 'loading',
+      'lazy-img-error': state === 'error'
+    }"
+  >
+    <img :src="src" :alt="alt" loading="lazy" @load="onLoad" @error="onError" />
+  </span>
+</template>
+
+<script setup lang="ts">
+/**
+ * 懒加载图片组件
+ *
+ * 在图片加载完成前显示 shimmer 占位动画，加载失败时降低透明度作为错误回退。
+ *
+ * @example
+ * ```vue
+ * <LazyImg src="/champion/1.png" alt="champion" />
+ * ```
+ */
+import { ref } from 'vue'
+
+defineProps<{
+  /** 图片地址 */
+  src: string
+  /** 替代文本 */
+  alt?: string
+}>()
+
+const state = ref<'loading' | 'loaded' | 'error'>('loading')
+
+function onLoad() {
+  state.value = 'loaded'
+}
+
+function onError() {
+  state.value = 'error'
+}
+</script>
+
+<style scoped>
+.lazy-img {
+  display: inline-block;
+  position: relative;
+  line-height: 0;
+}
+.lazy-img img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity var(--dur-fast) var(--ease-expo);
+}
+.lazy-img-loading img {
+  opacity: 0;
+}
+.lazy-img-loading::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    var(--bg-elevated) 0%,
+    var(--glass-bg-mid) 50%,
+    var(--bg-elevated) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
+  border-radius: inherit;
+}
+.lazy-img-error img {
+  opacity: 0.3;
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/common/LazyImg.vue
+++ b/lol-record-analysis-tauri/src/components/common/LazyImg.vue
@@ -21,9 +21,9 @@
  * <LazyImg src="/champion/1.png" alt="champion" />
  * ```
  */
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
-defineProps<{
+const props = defineProps<{
   /** 图片地址 */
   src: string
   /** 替代文本 */
@@ -31,6 +31,14 @@ defineProps<{
 }>()
 
 const state = ref<'loading' | 'loaded' | 'error'>('loading')
+
+// src 变化时重置回 loading, 否则列表复用同一实例切图时新图片不显示 shimmer / 残留 error 态
+watch(
+  () => props.src,
+  () => {
+    state.value = 'loading'
+  }
+)
 
 function onLoad() {
   state.value = 'loaded'

--- a/lol-record-analysis-tauri/src/components/common/__tests__/LazyImg.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/LazyImg.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LazyImg from '../LazyImg.vue'
+
+describe('LazyImg', () => {
+  it('renders an img with the given src and alt', () => {
+    const wrapper = mount(LazyImg, { props: { src: '/x.png', alt: 'champion' } })
+    const img = wrapper.find('img')
+    expect(img.attributes('src')).toBe('/x.png')
+    expect(img.attributes('alt')).toBe('champion')
+  })
+
+  it('shows loading class before load and removes it after load event', async () => {
+    const wrapper = mount(LazyImg, { props: { src: '/x.png' } })
+    expect(wrapper.classes()).toContain('lazy-img-loading')
+    await wrapper.find('img').trigger('load')
+    expect(wrapper.classes()).not.toContain('lazy-img-loading')
+  })
+
+  it('switches to error class when img fires error', async () => {
+    const wrapper = mount(LazyImg, { props: { src: '/x.png' } })
+    await wrapper.find('img').trigger('error')
+    expect(wrapper.classes()).toContain('lazy-img-error')
+  })
+})

--- a/lol-record-analysis-tauri/src/components/gaming/MettingPlayersCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/MettingPlayersCard.vue
@@ -9,11 +9,10 @@
         >
           <!-- Left: Champion -->
           <div class="champion-section">
-            <img
+            <LazyImg
               :src="assetPrefix + '/champion/' + meetGame.championId"
+              alt="champion"
               class="champion-img"
-              loading="lazy"
-              decoding="async"
             />
           </div>
 
@@ -52,6 +51,7 @@ import type { Game } from '../record/match'
 import { assetPrefix } from '../../services/http'
 import { openMatchDetailWindow } from '../record/detailWindow'
 import { invoke } from '@tauri-apps/api/core'
+import LazyImg from '@renderer/components/common/LazyImg.vue'
 
 function getFormattedDate(dateString: string) {
   const date = new Date(dateString)
@@ -89,20 +89,21 @@ defineProps<{
 .game-card {
   display: flex;
   align-items: center;
-  padding: 6px 8px;
+  padding: var(--space-6) var(--space-8);
   border-radius: var(--radius-md);
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: var(--glass-bg-low);
   border: 1px solid transparent;
-  transition: all 0.2s ease;
+  transition: all var(--dur-fast) var(--ease-expo);
+  /* 固定 48px 行高：保证栅格视觉对齐 */
   height: 48px;
   box-sizing: border-box;
   cursor: pointer;
 }
 
 .game-card:hover {
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: var(--glass-bg-high);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
 }
 
 .game-card:active {
@@ -110,25 +111,30 @@ defineProps<{
 }
 
 .game-card.is-win {
-  border-left: 3px solid #8bdfb7;
+  border-left: 3px solid var(--semantic-win);
+  /* tinted gradient：保留 rgba 平铺，仅作为半透明背景渲染 */
   background: linear-gradient(90deg, rgba(139, 223, 183, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
 }
 
 .game-card.is-loss {
-  border-left: 3px solid #ba3f53;
+  border-left: 3px solid var(--semantic-loss);
   background: linear-gradient(90deg, rgba(186, 63, 83, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
 }
 
 .champion-section {
-  margin-right: 8px;
+  margin-right: var(--space-8);
   display: flex;
   align-items: center;
 }
 
+/* 固定 32px 英雄方头像：像素精确布局，不取 token 阶 */
 .champion-img {
   width: 32px;
   height: 32px;
   border-radius: var(--radius-sm);
+}
+
+.champion-img :deep(img) {
   object-fit: cover;
 }
 
@@ -137,41 +143,42 @@ defineProps<{
   display: flex;
   flex-direction: column;
   justify-content: center;
-  line-height: 1.2;
+  line-height: var(--line-height-tight);
   overflow: hidden;
 }
 
 .kda-row {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
   font-family: 'Oswald', sans-serif;
   white-space: nowrap;
 }
 
 .kda-val.kill {
-  color: #8bdfb7;
+  color: var(--semantic-win);
 }
 
 .kda-val.death {
-  color: #ba3f53;
+  color: var(--semantic-loss);
 }
 
 .kda-val.assist {
+  /* TODO: --semantic-warn token —— 当前无 warn/highlight semantic 令牌，保留原 orange */
   color: #d38b2a;
 }
 
 .kda-sep {
-  color: #666;
-  margin: 0 2px;
-  font-size: 11px;
+  color: var(--text-tertiary);
+  margin: 0 var(--space-2);
+  font-size: var(--font-size-xs);
 }
 
 .meta-row {
-  font-size: 10px;
-  color: #999;
-  margin-top: 2px;
+  font-size: var(--font-size-2xs);
+  color: var(--text-tertiary);
+  margin-top: var(--space-2);
   display: flex;
-  gap: 6px;
+  gap: var(--space-6);
   white-space: nowrap;
 }
 
@@ -181,37 +188,39 @@ defineProps<{
   align-items: flex-end;
   justify-content: center;
   min-width: 32px;
-  margin-left: 4px;
+  margin-left: var(--space-4);
 }
 
 .result-text {
-  font-size: 12px;
-  font-weight: bold;
-  margin-bottom: 2px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  margin-bottom: var(--space-2);
 }
 
 .text-win {
-  color: #8bdfb7;
+  color: var(--semantic-win);
 }
 
 .text-loss {
-  color: #ba3f53;
+  color: var(--semantic-loss);
 }
 
 .relation-badge {
-  font-size: 10px;
-  padding: 1px 4px;
+  font-size: var(--font-size-2xs);
+  /* 1px：徽标紧凑内边距，非 token 阶 */
+  padding: 1px var(--space-4);
   border-radius: var(--radius-sm);
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--glass-bg-high);
 }
 
 .relation-badge.is-friend {
-  color: #8bdfb7;
+  color: var(--semantic-win);
+  /* tinted badge bg：保留 rgba 以保持半透明 hover 视觉 */
   background-color: rgba(139, 223, 183, 0.15);
 }
 
 .relation-badge.is-enemy {
-  color: #ba3f53;
+  color: var(--semantic-loss);
   background-color: rgba(186, 63, 83, 0.15);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -11,11 +11,11 @@
     ]"
     size="small"
     :bordered="true"
-    content-style="padding: 6px;"
+    :content-style="cardContentStyle"
   >
     <div v-if="sessionSummoner.isLoading" key="loading-known" class="loading-container">
       <div class="custom-spin"></div>
-      <span v-if="sessionSummoner.summoner.gameName" style="font-size: 12px; color: #aaa">
+      <span v-if="sessionSummoner.summoner.gameName" class="loading-name">
         {{ sessionSummoner.summoner.gameName }}
       </span>
     </div>
@@ -45,7 +45,7 @@
       <div class="left-section">
         <!-- Profile -->
         <div class="profile-section">
-          <n-flex align="center" :wrap="false" style="gap: 10px">
+          <n-flex align="center" :wrap="false" class="profile-row">
             <div class="avatar-wrapper">
               <n-image
                 width="40"
@@ -58,7 +58,7 @@
             </div>
 
             <div class="info-wrapper">
-              <n-flex align="center" style="gap: 4px">
+              <n-flex align="center" class="name-row">
                 <n-button
                   text
                   @click="
@@ -67,7 +67,7 @@
                     )
                   "
                 >
-                  <n-ellipsis style="max-width: 110px; font-size: 13px; font-weight: 700">
+                  <n-ellipsis class="name-ellipsis">
                     {{ sessionSummoner?.summoner.gameName }}
                   </n-ellipsis>
                 </n-button>
@@ -83,17 +83,17 @@
                 </n-button>
               </n-flex>
 
-              <n-flex align="center" style="gap: 6px; flex-wrap: wrap">
+              <n-flex align="center" class="meta-row">
                 <span class="tag-line">#{{ sessionSummoner?.summoner.tagLine }}</span>
-                <n-flex align="center" style="gap: 4px">
-                  <img class="tier-icon" :src="imgUrl" />
+                <n-flex align="center" class="tier-row">
+                  <LazyImg class="tier-icon" :src="imgUrl" alt="tier" />
                   <span class="tier-text">{{ tierCn }}</span>
                 </n-flex>
                 <!-- ARAM Balance Status -->
                 <n-popover
                   v-if="balanceTags.length > 0 && isAramMode"
                   trigger="hover"
-                  style="padding: 5px"
+                  :style="{ padding: 'var(--space-4)' }"
                 >
                   <template #trigger>
                     <n-tag
@@ -101,12 +101,12 @@
                       :type="overallBalanceStatus.type"
                       :bordered="false"
                       round
-                      style="height: 18px; padding: 0 6px; font-size: 11px; cursor: help"
+                      class="balance-tag"
                     >
                       {{ overallBalanceStatus.label }}
                     </n-tag>
                   </template>
-                  <n-flex vertical size="small" style="gap: 4px">
+                  <n-flex vertical size="small" class="balance-list">
                     <n-tag
                       v-for="tag in balanceTags"
                       :key="tag.label"
@@ -189,6 +189,7 @@ import { useTheme } from '@renderer/composables/useTheme'
 import { useAramBalance } from '@renderer/composables/useAramBalance'
 import PlayerHistoryGrid from './PlayerHistoryGrid.vue'
 import PlayerStatsCard from './PlayerStatsCard.vue'
+import LazyImg from '@renderer/components/common/LazyImg.vue'
 
 interface Props {
   sessionSummoner: SessionSummoner
@@ -202,6 +203,9 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), { team: undefined, density: 'normal' })
+
+/** n-card content-style：用 token 控制内边距 */
+const cardContentStyle = 'padding: var(--space-6);'
 
 const settingsStore = useSettingsStore()
 const { isDark } = useTheme()
@@ -263,7 +267,48 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-8);
+}
+
+.loading-name {
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+}
+
+.profile-row {
+  gap: var(--space-10);
+}
+
+.name-row {
+  gap: var(--space-4);
+}
+
+.name-ellipsis {
+  /* 110px: 名称列最大宽度，固定 UI 不入 token */
+  max-width: 110px;
+  font-size: var(--font-size-base);
+  font-weight: 700;
+}
+
+.meta-row {
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.tier-row {
+  gap: var(--space-4);
+}
+
+.balance-tag {
+  /* 18px / cursor:help：紧凑标签固定高度，不入 token */
+  height: 18px;
+  padding: 0 var(--space-6);
+  font-size: var(--font-size-xs);
+  cursor: help;
+}
+
+.balance-list {
+  gap: var(--space-4);
 }
 
 .hidden-record-block {
@@ -282,7 +327,7 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 }
 
 .hidden-record-text {
-  font-size: 13px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--text-tertiary);
 }
@@ -291,26 +336,28 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-8);
   min-width: 0;
 }
 
 .right-section {
+  /* 100px: 右侧统计列固定宽，保持视觉对齐 */
   width: 100px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-left: 8px;
+  gap: var(--space-8);
+  margin-left: var(--space-8);
 }
 
 .profile-section {
-  padding-bottom: 8px;
+  padding-bottom: var(--space-8);
   border-bottom: 1px solid var(--n-divider-color);
 }
 
 .avatar-wrapper {
   position: relative;
+  /* 40px: 头像固定尺寸 */
   width: 40px;
   height: 40px;
   flex-shrink: 0;
@@ -326,13 +373,15 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 
 .level-badge {
   position: absolute;
-  bottom: -6px;
-  right: -6px;
-  font-size: 10px;
+  bottom: calc(var(--space-6) * -1);
+  right: calc(var(--space-6) * -1);
+  font-size: var(--font-size-2xs);
+  /* 黑色半透明叠加层，固定不入主题 token */
   background: rgba(0, 0, 0, 0.7);
-  padding: 0 4px;
+  padding: 0 var(--space-4);
   border-radius: var(--radius-sm);
   color: white;
+  /* 14px 行高对齐徽标视觉，固定 UI */
   line-height: 14px;
 }
 
@@ -346,15 +395,15 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   min-width: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-4);
   justify-content: flex-end;
   align-items: center;
-  padding-left: 8px;
+  padding-left: var(--space-8);
 }
 
 .copy-btn {
   opacity: 0.6;
-  transition: opacity 0.2s;
+  transition: opacity var(--dur-fast) var(--ease-expo);
 }
 
 .copy-btn:hover {
@@ -363,20 +412,29 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 
 .tag-line {
   color: var(--n-text-color-3);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 
 .tier-icon {
+  /* 16px: 段位图标固定尺寸 */
+  display: inline-block;
   width: 16px;
   height: 16px;
 }
 
+.tier-icon :deep(img) {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .tier-text {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--n-text-color-2);
 }
 
 .custom-spin {
+  /* 22px: spinner 固定尺寸 */
   width: 22px;
   height: 22px;
   border-radius: 50%;
@@ -427,7 +485,7 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 }
 
 .player-card-density-compact .left-section {
-  gap: 4px;
+  gap: var(--space-4);
 }
 
 .player-card-density-compact :deep(.player-history-grid) {
@@ -435,6 +493,6 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 }
 
 .player-card-density-compact .info-wrapper :deep(.n-button) {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -48,7 +48,7 @@
           <n-flex align="center" :wrap="false" class="profile-row">
             <div class="avatar-wrapper">
               <n-image
-                width="40"
+                width="36"
                 :src="assetPrefix + '/champion/' + sessionSummoner.championId"
                 preview-disabled
                 :fallback-src="nullImg"
@@ -86,7 +86,10 @@
               <n-flex align="center" class="meta-row">
                 <span class="tag-line">#{{ sessionSummoner?.summoner.tagLine }}</span>
                 <n-flex align="center" class="tier-row">
-                  <LazyImg class="tier-icon" :src="imgUrl" alt="tier" />
+                  <span v-if="imgUrl.includes('unranked')" class="tier-icon-placeholder">
+                    <n-icon><HelpCircleOutline /></n-icon>
+                  </span>
+                  <LazyImg v-else class="tier-icon" :src="imgUrl" alt="tier" />
                   <span class="tier-text">{{ tierCn }}</span>
                 </n-flex>
                 <!-- ARAM Balance Status -->
@@ -177,7 +180,7 @@ import {
   NTag,
   NTooltip
 } from 'naive-ui'
-import { CopyOutline } from '@vicons/ionicons5'
+import { CopyOutline, HelpCircleOutline } from '@vicons/ionicons5'
 import MettingPlayersCard from './MettingPlayersCard.vue'
 import { useCopy } from '@renderer/composables/useCopy'
 import { searchSummoner } from '@renderer/utils/navigation'
@@ -204,8 +207,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), { team: undefined, density: 'normal' })
 
-/** n-card content-style：用 token 控制内边距 */
-const cardContentStyle = 'padding: var(--space-6);'
+/** n-card content-style：用 token 控制内边距（P0 收紧为 --space-4 让 4 场 1 屏装下） */
+const cardContentStyle = 'padding: var(--space-4);'
 
 const settingsStore = useSettingsStore()
 const { isDark } = useTheme()
@@ -336,7 +339,7 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: var(--space-8);
+  gap: var(--space-6);
   min-width: 0;
 }
 
@@ -351,15 +354,15 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 }
 
 .profile-section {
-  padding-bottom: var(--space-8);
+  padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--n-divider-color);
 }
 
 .avatar-wrapper {
   position: relative;
-  /* 40px: 头像固定尺寸 */
-  width: 40px;
-  height: 40px;
+  /* 36px: 头像（P1 精致化，从 40 收到 36） */
+  width: 36px;
+  height: 36px;
   flex-shrink: 0;
 }
 
@@ -416,16 +419,27 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 }
 
 .tier-icon {
-  /* 16px: 段位图标固定尺寸 */
+  /* 20px: 段位图标固定尺寸（从 16 提到 20，视觉更显眼） */
   display: inline-block;
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
 }
 
 .tier-icon :deep(img) {
   width: 100%;
   height: 100%;
   object-fit: contain;
+}
+
+/* 未定级时用 n-icon 占位（QuestionMark），保持视觉权重一致 */
+.tier-icon-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  font-size: 18px;
+  color: var(--text-tertiary);
 }
 
 .tier-text {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -48,7 +48,7 @@
           <n-flex align="center" :wrap="false" class="profile-row">
             <div class="avatar-wrapper">
               <n-image
-                width="36"
+                width="100%"
                 :src="assetPrefix + '/champion/' + sessionSummoner.championId"
                 preview-disabled
                 :fallback-src="nullImg"
@@ -286,10 +286,12 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   gap: var(--space-4);
 }
 
-.name-ellipsis {
-  /* 110px: 名称列最大宽度，固定 UI 不入 token */
-  max-width: 110px;
-  font-size: var(--font-size-base);
+/* :deep 因为 .name-ellipsis 在 n-ellipsis 子组件根，scoped 属性不自动透传 */
+:deep(.name-ellipsis) {
+  /* 110px: 名称列最大宽度（窄屏限制），宽屏放开 */
+  max-width: clamp(110px, calc(110px + (100vw - 900px) * 60 / 2100), 170px);
+  /* 13→20px 随 viewport 平滑放大 (900→3000) */
+  font-size: clamp(13px, calc(13px + (100vw - 900px) * 7 / 2100), 20px);
   font-weight: 700;
 }
 
@@ -360,9 +362,9 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 
 .avatar-wrapper {
   position: relative;
-  /* 36px: 头像（P1 精致化，从 40 收到 36） */
-  width: 36px;
-  height: 36px;
+  /* 头像平滑缩放：900 视口=36, 3000 视口=60 (含 4K) */
+  width: clamp(36px, calc(36px + (100vw - 900px) * 24 / 2100), 60px);
+  height: clamp(36px, calc(36px + (100vw - 900px) * 24 / 2100), 60px);
   flex-shrink: 0;
 }
 
@@ -419,10 +421,10 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 }
 
 .tier-icon {
-  /* 20px: 段位图标固定尺寸（从 16 提到 20，视觉更显眼） */
+  /* 20→32px 随 viewport 平滑放大 (900→3000) */
   display: inline-block;
-  width: 20px;
-  height: 20px;
+  width: clamp(20px, calc(20px + (100vw - 900px) * 12 / 2100), 32px);
+  height: clamp(20px, calc(20px + (100vw - 900px) * 12 / 2100), 32px);
 }
 
 .tier-icon :deep(img) {
@@ -436,9 +438,9 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  font-size: 18px;
+  width: clamp(20px, calc(20px + (100vw - 900px) * 12 / 2100), 32px);
+  height: clamp(20px, calc(20px + (100vw - 900px) * 12 / 2100), 32px);
+  font-size: clamp(18px, calc(18px + (100vw - 900px) * 11 / 2100), 29px);
   color: var(--text-tertiary);
 }
 

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -85,7 +85,11 @@ defineProps<{ games: Game[] }>()
 /* minmax(0, 1fr) 阻止 KDA 大数字 (15/10/33) 把 1fr 列撑大挤掉 queue 列 */
 .history-row {
   display: grid;
-  grid-template-columns: 18px 24px minmax(0, 1fr) clamp(60px, calc(60px + (100vw - 900px) * 20 / 2100), 80px);
+  grid-template-columns: 18px 24px minmax(0, 1fr) clamp(
+      60px,
+      calc(60px + (100vw - 900px) * 20 / 2100),
+      80px
+    );
   align-items: center;
   gap: var(--space-6);
 }

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -6,7 +6,7 @@
       class="history-item"
       :class="{ 'is-win': game.participants[0].stats.win }"
     >
-      <n-flex justify="space-between" align="center" :wrap="false">
+      <div class="history-row">
         <span class="win-status" :class="{ 'is-win': game.participants[0].stats.win }">
           {{ game.participants[0].stats.win ? '胜' : '负' }}
         </span>
@@ -26,13 +26,13 @@
           </template>
           {{ game.queueName || '其他' }}
         </n-tooltip>
-      </n-flex>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { NFlex, NTooltip } from 'naive-ui'
+import { NTooltip } from 'naive-ui'
 import type { Game } from '@renderer/types/domain/match'
 import { assetPrefix } from '@renderer/services/http'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
@@ -44,8 +44,13 @@ defineProps<{ games: Game[] }>()
 .history-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  /* 3px：紧凑历史栅格的密集间隙，非 token 阶 */
-  gap: 3px;
+  /* 行按内容高度，避免被 stretch 撑高 */
+  grid-auto-rows: min-content;
+  /* 行集合在 grid 容器内垂直居中 */
+  align-content: center;
+  /* 列间 3px 紧凑，行间 6px 配合 1 屏布局 */
+  column-gap: 3px;
+  row-gap: var(--space-6);
   flex: 1;
   overflow-y: auto;
 }
@@ -53,33 +58,43 @@ defineProps<{ games: Game[] }>()
 .history-item {
   background: var(--glass-bg-low);
   border-radius: var(--radius-sm);
-  /* 3px / 5px：紧凑卡片内边距，非 token 阶 */
-  padding: 3px 5px;
+  /* P0 收紧到 4px 配合 1 屏 4 场布局 */
+  padding: var(--space-4) 5px;
   font-size: var(--font-size-2xs);
   border: 1px solid var(--glass-border);
+  /* P1: 左侧锚点 2px + 半透明，更轻盈 */
   border-left-width: 2px;
-  border-left-color: var(--semantic-loss);
+  border-left-color: color-mix(in srgb, var(--semantic-loss) 70%, transparent);
 }
 
 .history-item.is-win {
-  border-left-color: var(--semantic-win);
+  border-left-color: color-mix(in srgb, var(--semantic-win) 70%, transparent);
+}
+
+/* 固定列宽 grid：胜负 / 头像 / KDA / 模式 —— 跨行跨卡片严格对齐 */
+.history-row {
+  display: grid;
+  grid-template-columns: 18px 24px 1fr 60px;
+  align-items: center;
+  gap: var(--space-6);
 }
 
 .win-status {
-  font-weight: var(--font-weight-semibold);
+  /* P1: 11px + bold，保持识别但不抢戏 */
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   color: var(--semantic-loss);
-  width: 20px;
-  flex-shrink: 0;
+  text-align: center;
 }
 
 .win-status.is-win {
   color: var(--semantic-win);
 }
 
-/* 固定 24px 圆形英雄头像：像素级精确布局，不取 token 阶 */
+/* P1 精致化：22px 圆形英雄头像 */
 .history-champ-img {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
 }
 
@@ -91,11 +106,10 @@ defineProps<{ games: Game[] }>()
   font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size-sm);
-  /* 固定 60px 列宽：保持栅格对齐 */
-  min-width: 60px;
+  /* tabular-nums: 数字等宽，确保 5/17/20 与 23/12/39 的斜杠纵向对齐 */
+  font-variant-numeric: tabular-nums;
   text-align: center;
   white-space: nowrap;
-  flex-shrink: 0;
 }
 
 .kill {
@@ -111,10 +125,9 @@ defineProps<{ games: Game[] }>()
 }
 
 .queue-name {
+  /* P1: 容器收紧后 10px 灰阶刚好 */
   font-size: var(--font-size-2xs);
   color: var(--n-text-color-3);
-  /* 固定 40px 列宽 */
-  width: 40px;
   text-align: right;
   white-space: nowrap;
   overflow: hidden;

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -82,9 +82,10 @@ defineProps<{ games: Game[] }>()
 
 /* 固定列宽 grid：胜负 / 头像 / KDA / 模式 —— 跨行跨卡片严格对齐 */
 /* 模式列宽也随 viewport 平滑放大 (60→80px), 配合 queue-name 字号 10→14px 容纳 5 字"海克斯乱斗" */
+/* minmax(0, 1fr) 阻止 KDA 大数字 (15/10/33) 把 1fr 列撑大挤掉 queue 列 */
 .history-row {
   display: grid;
-  grid-template-columns: 18px 24px 1fr clamp(60px, calc(60px + (100vw - 900px) * 20 / 2100), 80px);
+  grid-template-columns: 18px 24px minmax(0, 1fr) clamp(60px, calc(60px + (100vw - 900px) * 20 / 2100), 80px);
   align-items: center;
   gap: var(--space-6);
 }

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -72,9 +72,10 @@ defineProps<{ games: Game[] }>()
 }
 
 /* 固定列宽 grid：胜负 / 头像 / KDA / 模式 —— 跨行跨卡片严格对齐 */
+/* 模式列宽也随 viewport 平滑放大 (60→80px), 配合 queue-name 字号 10→14px 容纳 5 字"海克斯乱斗" */
 .history-row {
   display: grid;
-  grid-template-columns: 18px 24px 1fr 60px;
+  grid-template-columns: 18px 24px 1fr clamp(60px, calc(60px + (100vw - 900px) * 20 / 2100), 80px);
   align-items: center;
   gap: var(--space-6);
 }

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -80,8 +80,8 @@ defineProps<{ games: Game[] }>()
 }
 
 .win-status {
-  /* P1: 11px + bold，保持识别但不抢戏 */
-  font-size: var(--font-size-xs);
+  /* 11→16px 随 viewport 平滑放大 (900→3000) */
+  font-size: clamp(11px, calc(11px + (100vw - 900px) * 5 / 2100), 16px);
   font-weight: var(--font-weight-bold);
   color: var(--semantic-loss);
   text-align: center;
@@ -91,10 +91,10 @@ defineProps<{ games: Game[] }>()
   color: var(--semantic-win);
 }
 
-/* P1 精致化：22px 圆形英雄头像 */
+/* 22→36px 随 viewport 平滑放大 (900→3000) */
 .history-champ-img {
-  width: 22px;
-  height: 22px;
+  width: clamp(22px, calc(22px + (100vw - 900px) * 14 / 2100), 36px);
+  height: clamp(22px, calc(22px + (100vw - 900px) * 14 / 2100), 36px);
   border-radius: 50%;
 }
 
@@ -105,7 +105,8 @@ defineProps<{ games: Game[] }>()
 .kda-text {
   font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   font-weight: var(--font-weight-bold);
-  font-size: var(--font-size-sm);
+  /* 12→18px 随 viewport 平滑放大 (900→3000) */
+  font-size: clamp(12px, calc(12px + (100vw - 900px) * 6 / 2100), 18px);
   /* tabular-nums: 数字等宽，确保 5/17/20 与 23/12/39 的斜杠纵向对齐 */
   font-variant-numeric: tabular-nums;
   text-align: center;
@@ -125,8 +126,8 @@ defineProps<{ games: Game[] }>()
 }
 
 .queue-name {
-  /* P1: 容器收紧后 10px 灰阶刚好 */
-  font-size: var(--font-size-2xs);
+  /* 10→14px 随 viewport 平滑放大 (900→3000) */
+  font-size: clamp(10px, calc(10px + (100vw - 900px) * 4 / 2100), 14px);
   color: var(--n-text-color-3);
   text-align: right;
   white-space: nowrap;

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -10,11 +10,10 @@
         <span class="win-status" :class="{ 'is-win': game.participants[0].stats.win }">
           {{ game.participants[0].stats.win ? '胜' : '负' }}
         </span>
-        <img
+        <LazyImg
           :src="assetPrefix + '/champion/' + game.participants[0]?.championId"
+          alt="champion"
           class="history-champ-img"
-          loading="lazy"
-          decoding="async"
         />
         <div class="kda-text">
           <span class="kill">{{ game.participants[0].stats?.kills }}</span>
@@ -36,6 +35,7 @@
 import { NFlex, NTooltip } from 'naive-ui'
 import type { Game } from '@renderer/types/domain/match'
 import { assetPrefix } from '@renderer/services/http'
+import LazyImg from '@renderer/components/common/LazyImg.vue'
 
 defineProps<{ games: Game[] }>()
 </script>
@@ -44,6 +44,7 @@ defineProps<{ games: Game[] }>()
 .history-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  /* 3px：紧凑历史栅格的密集间隙，非 token 阶 */
   gap: 3px;
   flex: 1;
   overflow-y: auto;
@@ -52,8 +53,9 @@ defineProps<{ games: Game[] }>()
 .history-item {
   background: var(--glass-bg-low);
   border-radius: var(--radius-sm);
+  /* 3px / 5px：紧凑卡片内边距，非 token 阶 */
   padding: 3px 5px;
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   border: 1px solid var(--glass-border);
   border-left-width: 2px;
   border-left-color: var(--semantic-loss);
@@ -64,7 +66,7 @@ defineProps<{ games: Game[] }>()
 }
 
 .win-status {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--semantic-loss);
   width: 20px;
   flex-shrink: 0;
@@ -74,17 +76,22 @@ defineProps<{ games: Game[] }>()
   color: var(--semantic-win);
 }
 
+/* 固定 24px 圆形英雄头像：像素级精确布局，不取 token 阶 */
 .history-champ-img {
   width: 24px;
   height: 24px;
   border-radius: 50%;
+}
+
+.history-champ-img :deep(img) {
   object-fit: cover;
 }
 
 .kda-text {
   font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  font-weight: 700;
-  font-size: 12px;
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-sm);
+  /* 固定 60px 列宽：保持栅格对齐 */
   min-width: 60px;
   text-align: center;
   white-space: nowrap;
@@ -104,8 +111,9 @@ defineProps<{ games: Game[] }>()
 }
 
 .queue-name {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   color: var(--n-text-color-3);
+  /* 固定 40px 列宽 */
   width: 40px;
   text-align: right;
   white-space: nowrap;

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -53,6 +53,15 @@ defineProps<{ games: Game[] }>()
   row-gap: var(--space-6);
   flex: 1;
   overflow-y: auto;
+  /* 锁住横向滚动 (内部 history-item 偶尔 min-content 超出, 不能让浏览器自动加 X 滚动条) */
+  overflow-x: hidden;
+  /* 1fr 1fr 想要平分 → item 必须能 shrink 到 fraction 单位下 */
+  min-width: 0;
+}
+
+.history-item {
+  /* 允许 grid 1fr 把 item 压到比 min-content 还小 (内部 KDA / queue 已有 ellipsis/clip 兜底) */
+  min-width: 0;
 }
 
 .history-item {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
@@ -34,15 +34,12 @@
       <div v-else class="stats-full">
         <div class="stats-row">
           <span class="label">模式</span>
-          <span class="value" style="font-weight: 600">{{ recent.selectModeCn }}</span>
+          <span class="value value-strong">{{ recent.selectModeCn }}</span>
         </div>
         <div class="stats-row">
           <span class="label">KDA</span>
           <div class="value-group">
-            <span
-              :style="{ color: kdaColor(recent.kda, isDark) }"
-              style="font-weight: bold; margin-right: 4px"
-            >
+            <span class="kda-main" :style="{ color: kdaColor(recent.kda, isDark) }">
               {{ recent.kda }}
             </span>
             <span class="kda-detail">
@@ -111,7 +108,7 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
 .stats-card {
   background: var(--glass-bg-low);
   border-radius: var(--radius-md);
-  padding: 6px;
+  padding: var(--space-6);
   transition: all var(--dur-normal) var(--ease-expo);
   border: 1px solid var(--glass-border);
 }
@@ -120,9 +117,11 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
   position: absolute;
   top: 0;
   right: 0;
+  /* 240px: 展开态固定宽度，避免抖动 */
   width: 240px;
   z-index: 100;
   background: var(--bg-elevated);
+  /* 半透明 win 色描边，强调激活态；alpha 自定义保留 rgba */
   border-color: rgba(61, 155, 122, 0.25);
   box-shadow: var(--shadow-lg);
 }
@@ -132,13 +131,13 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  margin-bottom: 4px;
-  padding-bottom: 4px;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--n-divider-color);
 }
 
 .stats-title {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   color: var(--n-text-color-2);
 }
@@ -154,26 +153,30 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
 .compact-row {
   display: flex;
   justify-content: space-between;
-  font-size: 11px;
-  margin-bottom: 2px;
+  font-size: var(--font-size-xs);
+  margin-bottom: var(--space-2);
 }
 
 .stats-full {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding-top: 4px;
+  gap: var(--space-6);
+  padding-top: var(--space-4);
 }
 
 .stats-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 
 .label {
   color: var(--n-text-color-3);
+}
+
+.value-strong {
+  font-weight: 600;
 }
 
 .value-group {
@@ -181,9 +184,14 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
   align-items: center;
 }
 
+.kda-main {
+  font-weight: bold;
+  margin-right: var(--space-4);
+}
+
 .kda-detail {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   opacity: 0.9;
-  margin-left: 4px;
+  margin-left: var(--space-4);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
@@ -109,7 +109,10 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
   background: var(--glass-bg-low);
   border-radius: var(--radius-md);
   padding: var(--space-6);
-  transition: all var(--dur-normal) var(--ease-expo);
+  transition:
+    background var(--dur-normal) var(--ease-expo),
+    border-color var(--dur-normal) var(--ease-expo),
+    box-shadow var(--dur-normal) var(--ease-expo);
   border: 1px solid var(--glass-border);
 }
 

--- a/lol-record-analysis-tauri/src/components/gaming/ProgressMiniRow.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ProgressMiniRow.vue
@@ -30,7 +30,7 @@ defineProps<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 
 .label {
@@ -40,10 +40,10 @@ defineProps<{
 .progress-wrapper {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-6);
   flex: 1;
   justify-content: flex-end;
-  margin-left: 8px;
+  margin-left: var(--space-8);
 }
 
 .progress-wrapper .n-progress {
@@ -52,7 +52,7 @@ defineProps<{
 }
 
 .progress-text {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   min-width: 35px;
   text-align: right;
 }

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -88,6 +88,8 @@ const placeholderCount = computed(() =>
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  /* 显式锁掉横向滚动 (避免内部元素溢出时底部出滚动条) */
+  overflow-x: hidden;
 }
 
 .subteam-card-empty {

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -52,8 +52,8 @@ const placeholderCount = computed(() =>
 .subteam-card {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 6px;
+  gap: var(--space-4);
+  padding: var(--space-6);
   border-radius: var(--radius-md);
   background: var(--glass-bg-mid);
   border: 1px solid var(--glass-border);
@@ -63,27 +63,28 @@ const placeholderCount = computed(() =>
 }
 
 .subteam-card-mine {
-  border-color: rgba(34, 197, 94, 0.6);
+  border-color: var(--semantic-win);
+  /* tinted ring：保持 rgba 以与卡片 token 颜色一致的发光感，复用全局 --glow-win 风格 */
   box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.3);
 }
 
 .subteam-card-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 4px;
+  gap: var(--space-6);
+  padding: 0 var(--space-4);
 }
 
 .subteam-card-title {
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
 }
 
 .subteam-card-body {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-4);
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -97,7 +98,7 @@ const placeholderCount = computed(() =>
   border: 1px dashed var(--border-subtle);
   border-radius: var(--radius-sm);
   color: var(--text-tertiary);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   min-height: 60px;
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/AssetTooltipContent.vue
+++ b/lol-record-analysis-tauri/src/components/record/AssetTooltipContent.vue
@@ -62,7 +62,7 @@ const sanitizedDescription = computed(() => {
 <style scoped>
 .asset-tooltip {
   max-width: 320px;
-  padding: 2px 0;
+  padding: var(--space-2) 0;
   position: relative;
 }
 
@@ -91,22 +91,22 @@ const sanitizedDescription = computed(() => {
   bottom: 0;
   width: 3px;
   background: var(--rarity-color);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   box-shadow: 0 0 6px var(--rarity-color);
 }
 
 .asset-tooltip-header {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: var(--space-8);
+  margin-bottom: var(--space-6);
 }
 
 .asset-tooltip-icon {
   width: 26px;
   height: 26px;
   flex-shrink: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border-subtle);
   background: var(--bg-elevated);
   object-fit: cover;
@@ -120,14 +120,14 @@ const sanitizedDescription = computed(() => {
 .asset-tooltip-title-wrap {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .asset-tooltip-title {
-  font-size: 13px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
-  line-height: 1.2;
+  line-height: var(--line-height-tight);
 }
 
 .asset-tooltip[class*='asset-tooltip-'] .asset-tooltip-title {
@@ -135,16 +135,16 @@ const sanitizedDescription = computed(() => {
 }
 
 .asset-tooltip-rarity {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--rarity-color);
   letter-spacing: 0.04em;
 }
 
 .asset-tooltip-description {
   white-space: normal;
-  line-height: 1.45;
-  font-size: 12px;
+  line-height: var(--line-height-normal);
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
@@ -155,6 +155,6 @@ const sanitizedDescription = computed(() => {
 .asset-tooltip-description :deep(br) {
   display: block;
   content: '';
-  margin-bottom: 4px;
+  margin-bottom: var(--space-4);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/MatchAIPanel.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchAIPanel.vue
@@ -27,21 +27,36 @@
       </div>
 
       <div v-if="renderedResult" class="match-detail-ai-result" v-html="renderedResult"></div>
+      <div v-else-if="aiLoading" class="match-detail-ai-skeleton">
+        <n-skeleton text :repeat="4" />
+        <n-skeleton text class="match-detail-ai-skeleton-short" />
+      </div>
       <div v-else class="match-detail-ai-empty">选择分析类型后即可生成复盘结果。</div>
     </div>
   </n-modal>
 </template>
 
 <script setup lang="ts">
-import { NModal, NRadioGroup, NRadioButton, NSelect, NButton } from 'naive-ui'
+import { NModal, NRadioGroup, NRadioButton, NSelect, NButton, NSkeleton } from 'naive-ui'
 import type { MatchDetailAnalysisMode } from '@renderer/services/ai'
 
+/**
+ * AI 复盘弹窗
+ * @property show - 是否显示
+ * @property mode - 分析模式：整局总览 / 单人复盘
+ * @property targetParticipantId - 单人复盘目标参与者 ID
+ * @property loading - 重新分析按钮 loading 状态
+ * @property renderedResult - 已渲染的 markdown HTML（流式拼接）
+ * @property aiLoading - AI 当前是否正在请求中（用于首块文本到达前显示 skeleton）
+ * @property playerOptions - 单人复盘下拉选项
+ */
 defineProps<{
   show: boolean
   mode: MatchDetailAnalysisMode
   targetParticipantId: number | null
   loading: boolean
   renderedResult: string
+  aiLoading?: boolean
   playerOptions: { label: string; value: number }[]
 }>()
 
@@ -57,48 +72,60 @@ const emit = defineEmits<{
 .match-detail-ai-modal-body {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-12);
 }
 
 .match-detail-ai-controls {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-12);
 }
 
 .match-detail-ai-player-select {
+  /* 单人复盘下拉宽度，保留像素值（非 token 体系内的控件最小宽度） */
   min-width: 240px;
 }
 
 .match-detail-ai-result {
   max-height: 70vh;
   overflow-y: auto;
-  padding: 8px 4px;
+  padding: var(--space-8) var(--space-4);
   line-height: 1.8;
-  font-size: 14px;
+  font-size: var(--font-size-md);
 }
 
 .match-detail-ai-result :deep(h2) {
-  margin: 16px 0 8px;
-  font-size: 17px;
-  font-weight: 700;
+  margin: var(--space-16) 0 var(--space-8);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
 }
 
 .match-detail-ai-result :deep(ul) {
-  padding-left: 20px;
+  padding-left: var(--space-20);
 }
 
 .match-detail-ai-result :deep(li) {
-  margin: 6px 0;
+  margin: var(--space-6) 0;
 }
 
 .match-detail-ai-result :deep(p) {
-  margin: 8px 0;
+  margin: var(--space-8) 0;
+}
+
+.match-detail-ai-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding: var(--space-8) var(--space-4);
+}
+
+.match-detail-ai-skeleton-short {
+  width: 60%;
 }
 
 .match-detail-ai-empty {
-  padding: 24px 8px;
+  padding: var(--space-24) var(--space-8);
   text-align: center;
   color: var(--text-secondary);
 }

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -229,7 +229,7 @@
                         :key="`${player.participantId}-perk-${perkId}-${index}`"
                         trigger="hover"
                         placement="top"
-                        :disabled="!assets.detailOf('perk', perkId)"
+                        :disabled="!usesAugments && !assets.detailOf('perk', perkId)"
                       >
                         <template #trigger>
                           <span

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -368,6 +368,7 @@
       :mode="ai.aiMode.value"
       :target-participant-id="ai.aiTargetParticipantId.value"
       :loading="ai.aiLoading.value"
+      :ai-loading="ai.aiLoading.value"
       :rendered-result="ai.renderedAiResult.value"
       :player-options="aiPlayerOptions"
       @update:show="ai.showAiModal.value = $event"

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -13,11 +13,10 @@
               <span class="match-detail-meta">{{ formattedDate }} · {{ durationLabel }}</span>
             </div>
             <div class="match-detail-player-row">
-              <img
+              <LazyImg
                 class="match-detail-hero"
                 :src="assetPrefix + '/champion/' + mySummary.championId"
                 alt="champion"
-                decoding="async"
               />
               <div class="match-detail-player-copy">
                 <div class="match-detail-player-name">{{ mySummary.displayName }}</div>
@@ -137,12 +136,10 @@
               >
                 <div class="match-detail-player-cell">
                   <div class="match-detail-player-main">
-                    <img
+                    <LazyImg
                       class="match-detail-player-avatar"
                       :src="assetPrefix + '/champion/' + player.championId"
                       alt="champion"
-                      loading="lazy"
-                      decoding="async"
                     />
                     <div class="match-detail-player-text">
                       <div class="match-detail-player-text-row">
@@ -405,6 +402,7 @@ import type { Summoner } from '@renderer/types/domain/player'
 import AssetTooltipContent from './AssetTooltipContent.vue'
 import StatDots from './StatDots.vue'
 import MatchAIPanel from './MatchAIPanel.vue'
+import LazyImg from '@renderer/components/common/LazyImg.vue'
 import {
   assistsColor,
   deathsColor,
@@ -550,7 +548,7 @@ watch(
 .match-detail-page {
   width: 100%;
   height: 100%;
-  padding: 2px 3px 3px;
+  padding: var(--space-2) var(--radius-xs) var(--radius-xs);
   box-sizing: border-box;
   background: var(--bg-base);
 }
@@ -562,7 +560,7 @@ watch(
   padding: 0;
   overflow: hidden;
   border: 1px solid var(--border-subtle);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   box-sizing: border-box;
   color: var(--text-primary);
   background:
@@ -579,50 +577,51 @@ watch(
 .match-detail-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 270px;
-  gap: 6px;
-  padding: 7px 10px 5px;
+  gap: var(--space-6);
+  padding: 7px var(--space-10) 5px; /* 顶部 7px 微调 + 左右 token + 底部 5px */
   border-bottom: 1px solid var(--border-subtle);
 }
 
 .match-detail-title-row {
   display: flex;
   align-items: center;
-  gap: 5px;
-  margin-bottom: 3px;
+  gap: 5px; /* 标签之间紧凑间距,介于 4 和 6 */
+  margin-bottom: var(--radius-xs);
 }
 
 .match-detail-queue {
-  font-size: 18px;
+  font-size: var(--font-size-xl);
   font-weight: 700;
   color: var(--text-primary);
 }
 
 .match-detail-meta {
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
 }
 
 .match-detail-player-row {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 7px; /* 头像与文字间距,介于 6 和 8 */
 }
 
 .match-detail-hero {
   width: 40px;
   height: 40px;
-  border-radius: 10px;
+  border-radius: var(--space-10);
   border: 1px solid var(--border-subtle);
+  display: block;
 }
 
 .match-detail-player-copy {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-player-name {
-  font-size: 15px;
+  font-size: 15px; /* 介于 sm(12) / lg(16),保留视觉过渡 */
   font-weight: 700;
   color: var(--text-primary);
 }
@@ -632,13 +631,13 @@ watch(
   align-items: center;
   gap: 5px;
   flex-wrap: wrap;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
 }
 
 .match-detail-kda-ratio {
-  margin-left: 3px;
-  font-size: 11px;
+  margin-left: var(--radius-xs);
+  font-size: var(--font-size-xs);
   font-weight: 600;
 }
 
@@ -651,15 +650,15 @@ watch(
 .match-detail-summary-side {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-6);
 }
 
 .match-detail-summary-card {
   padding: 5px 7px;
   border: 1px solid var(--border-subtle);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--glass-bg-low);
 }
 
 .theme-light .match-detail-summary-card {
@@ -668,12 +667,12 @@ watch(
 
 .match-detail-summary-label {
   color: var(--text-secondary);
-  font-size: 10px;
-  margin-bottom: 4px;
+  font-size: var(--font-size-2xs);
+  margin-bottom: var(--space-4);
 }
 
 .match-detail-summary-value {
-  font-size: 13px;
+  font-size: var(--font-size-base);
   font-weight: 700;
   color: var(--text-primary);
 }
@@ -682,11 +681,11 @@ watch(
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 6px 8px;
+  gap: var(--space-8);
+  padding: var(--space-6) var(--space-8);
   border: 1px solid var(--border-subtle);
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.03);
+  border-radius: var(--space-10);
+  background: var(--glass-bg-low);
 }
 
 .theme-light .match-detail-ai-toolbar {
@@ -696,23 +695,23 @@ watch(
 .match-detail-ai-copy {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-ai-title {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   font-weight: 700;
   color: var(--text-primary);
 }
 
 .match-detail-ai-subtitle {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
 }
 
 .match-detail-body {
   overflow: auto;
-  padding: 4px 10px 6px;
+  padding: var(--space-4) var(--space-10) var(--space-6);
   display: flex;
   flex-direction: column;
   gap: 5px;
@@ -720,7 +719,7 @@ watch(
 
 .match-detail-team-section {
   border: 1px solid var(--border-subtle);
-  border-radius: 10px;
+  border-radius: var(--space-10);
   overflow: hidden;
   background: rgba(0, 0, 0, 0.06);
   flex-shrink: 0;
@@ -734,7 +733,7 @@ watch(
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-6);
   padding: 5px 9px;
   color: #fff;
 }
@@ -750,35 +749,36 @@ watch(
 .match-detail-team-title-wrap {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  gap: var(--space-8);
 }
 
 .match-detail-team-title {
-  font-size: 14px;
+  font-size: var(--font-size-md);
   font-weight: 700;
 }
 
 .match-detail-team-subtitle {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   opacity: 0.95;
 }
 
 .match-detail-column-header,
 .match-detail-row {
+  /* 表格列宽固定，保留像素值（pixel-art layout，与表头对齐） */
   display: grid;
   grid-template-columns: minmax(188px, 1.22fr) minmax(214px, 1.36fr) 72px 68px 62px 68px minmax(
       198px,
       1.3fr
     );
-  gap: 6px;
+  gap: var(--space-6);
   align-items: center;
 }
 
 .match-detail-column-header {
-  padding: 4px 9px;
+  padding: var(--space-4) 9px;
   color: var(--text-secondary);
-  font-size: 10px;
-  background: rgba(255, 255, 255, 0.03);
+  font-size: var(--font-size-2xs);
+  background: var(--glass-bg-low);
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -792,7 +792,7 @@ watch(
 }
 
 .match-detail-row {
-  padding: 4px 9px;
+  padding: var(--space-4) 9px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -811,22 +811,23 @@ watch(
 .match-detail-player-main {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-6);
 }
 
 .match-detail-player-avatar {
   width: 30px;
   height: 30px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
   flex-shrink: 0;
+  display: block;
 }
 
 .match-detail-player-text {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-player-text-row {
@@ -837,7 +838,7 @@ watch(
 
 .match-detail-player-display {
   font-weight: 600;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -861,7 +862,7 @@ watch(
 .match-detail-badge-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-4);
 }
 
 .match-detail-player-text-row :deep(.n-tag) {
@@ -871,7 +872,7 @@ watch(
 .match-detail-badge-icon {
   width: 16px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -879,6 +880,8 @@ watch(
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
+/* 战绩荣誉徽章配色：与战绩页 KDA/输出/承伤 色系一致,
+   暂无 token 对应,保留 hex 作为视觉锚点 */
 .match-detail-badge-kills {
   color: #f2bf63;
   background: rgba(242, 191, 99, 0.14);
@@ -907,19 +910,19 @@ watch(
 .match-detail-build-cell {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: var(--radius-xs);
 }
 
 .match-detail-build-topline {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 6px;
+  gap: var(--space-6);
 }
 
 .match-detail-spells {
   display: flex;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-spell-icon,
@@ -927,7 +930,7 @@ watch(
 .match-detail-perk-icon {
   width: 17px;
   height: 17px;
-  border-radius: 5px;
+  border-radius: 5px; /* 17px 方块视觉圆角,介于 xs(3)/sm(6) */
   border: 1px solid var(--border-subtle);
   background: var(--bg-elevated);
   object-fit: cover;
@@ -936,7 +939,7 @@ watch(
 .match-detail-perks {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-augment-icon-shell {
@@ -948,7 +951,7 @@ watch(
   justify-content: center;
   width: 17px;
   height: 17px;
-  border-radius: 5px;
+  border-radius: 5px; /* 与 spell/item/perk 视觉对齐 */
   border: 1px solid var(--augment-border);
   background: var(--augment-background);
   box-sizing: border-box;
@@ -1003,19 +1006,19 @@ watch(
 .match-detail-items {
   display: flex;
   flex-wrap: wrap;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-value-cell {
   font-weight: 600;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-primary);
 }
 
 .match-detail-kda-value-cell {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-kda-separator {
@@ -1025,7 +1028,7 @@ watch(
 .match-detail-dots-cell {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .match-detail-empty-state {
@@ -1035,19 +1038,19 @@ watch(
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-8);
   color: var(--text-secondary);
   background: var(--bg-base);
 }
 
 .match-detail-empty-title {
   color: var(--text-primary);
-  font-size: 18px;
+  font-size: var(--font-size-xl);
   font-weight: 700;
 }
 
 .match-detail-empty-copy {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 
 @media (max-width: 1100px) {
@@ -1070,7 +1073,7 @@ watch(
   }
 
   .match-detail-row {
-    gap: 10px;
+    gap: var(--space-10);
   }
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -120,10 +120,10 @@
             <div class="match-detail-column-header">
               <span>玩家</span>
               <span>装备 / 技能 / {{ usesAugments ? '海克斯' : '符文' }}</span>
-              <span>KDA</span>
-              <span>金钱</span>
-              <span>补兵</span>
-              <span>推塔</span>
+              <span class="match-detail-header-center">KDA</span>
+              <span class="match-detail-header-right">金钱</span>
+              <span class="match-detail-header-right">补兵</span>
+              <span class="match-detail-header-right">推塔</span>
               <span></span>
             </div>
 
@@ -778,11 +778,22 @@ watch(
 }
 
 .match-detail-column-header {
-  padding: var(--space-4) 9px;
+  padding: var(--space-6) 9px;
   color: var(--text-secondary);
   font-size: var(--font-size-2xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
   background: var(--glass-bg-low);
   border-bottom: 1px solid var(--border-subtle);
+  text-transform: none;
+}
+
+/* 表头数字列与数据行 text-align 对齐 (B+E 一起) */
+.match-detail-header-right {
+  text-align: right;
+}
+.match-detail-header-center {
+  text-align: center;
 }
 
 .theme-light .match-detail-column-header {
@@ -797,18 +808,31 @@ watch(
 .match-detail-row {
   padding: var(--space-4) 9px;
   border-bottom: 1px solid var(--border-subtle);
+  /* hover 反馈: 整行加亮 + 强调左侧 (A 优化) */
+  transition: background var(--dur-fast) var(--ease-expo);
+  position: relative;
+}
+
+.match-detail-row:hover {
+  background: var(--glass-bg-mid);
 }
 
 .match-detail-row:last-child {
   border-bottom: none;
 }
 
+/* "我" 行强化高亮: 左侧 3px 队伍色 accent + 略强背景 (G 优化) */
 .match-detail-row-me {
-  background: rgba(92, 163, 234, 0.08);
+  background: rgba(92, 163, 234, 0.12);
+  box-shadow: inset 3px 0 0 0 var(--semantic-win);
+}
+
+.match-detail-row-me:hover {
+  background: rgba(92, 163, 234, 0.18);
 }
 
 .theme-light .match-detail-row-me {
-  background: rgba(92, 163, 234, 0.06);
+  background: rgba(92, 163, 234, 0.08);
 }
 
 .match-detail-player-main {
@@ -1020,6 +1044,14 @@ watch(
   font-weight: 600;
   font-size: var(--font-size-xs);
   color: var(--text-primary);
+  /* tabular-nums: 数字等宽, 列与列之间数字纵向对齐 (E 优化) */
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* KDA 单元格保留居中（KDA 视觉中心对齐更易扫读, 跟 PlayerHistoryGrid 一致） */
+.match-detail-kda-value-cell {
+  text-align: center;
 }
 
 .match-detail-kda-value-cell {

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -806,7 +806,8 @@ watch(
 }
 
 .match-detail-row {
-  padding: var(--space-4) 9px;
+  /* 行内边距 4→8 给呼吸 (解决"闭塞") */
+  padding: var(--space-8) 9px;
   border-bottom: 1px solid var(--border-subtle);
   /* hover 反馈: 整行加亮 + 强调左侧 (A 优化) */
   transition: background var(--dur-fast) var(--ease-expo);
@@ -842,9 +843,9 @@ watch(
 }
 
 .match-detail-player-avatar {
-  /* AI 复盘弹窗内玩家头像 30→38 随 viewport */
-  width: clamp(30px, calc(30px + (100vw - 1100px) * 8 / 1100), 38px);
-  height: clamp(30px, calc(30px + (100vw - 1100px) * 8 / 1100), 38px);
+  /* 玩家头像 36→48 (放大一档增强主视觉) */
+  width: clamp(36px, calc(36px + (100vw - 1100px) * 12 / 1100), 48px);
+  height: clamp(36px, calc(36px + (100vw - 1100px) * 12 / 1100), 48px);
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
   flex-shrink: 0;
@@ -956,10 +957,10 @@ watch(
 .match-detail-spell-icon,
 .match-detail-item-icon,
 .match-detail-perk-icon {
-  /* 17→22 随 viewport (1100→2200) */
-  width: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
-  height: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
-  border-radius: 5px; /* 17px 方块视觉圆角,介于 xs(3)/sm(6) */
+  /* 22→30 (icon 整体放大解决"闭塞"+"图标小") */
+  width: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
+  height: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
+  border-radius: 5px; /* 方块视觉圆角,介于 xs(3)/sm(6) */
   border: 1px solid var(--border-subtle);
   background: var(--bg-elevated);
   object-fit: cover;
@@ -978,10 +979,10 @@ watch(
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* 17→22 随 viewport, 与 spell/item/perk 同步 */
-  width: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
-  height: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
-  border-radius: 5px; /* 与 spell/item/perk 视觉对齐 */
+  /* 22→30 与 spell/item/perk 同步 */
+  width: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
+  height: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
+  border-radius: 5px;
   border: 1px solid var(--augment-border);
   background: var(--augment-background);
   box-sizing: border-box;
@@ -989,9 +990,9 @@ watch(
 }
 
 .match-detail-augment-icon {
-  /* shell 17→22, inner 12→17 同比放大 */
-  width: clamp(12px, calc(12px + (100vw - 1100px) * 5 / 1100), 17px);
-  height: clamp(12px, calc(12px + (100vw - 1100px) * 5 / 1100), 17px);
+  /* inner 17→23 同比放大 (shell 22→30, inner 留 5px 边距) */
+  width: clamp(17px, calc(17px + (100vw - 1100px) * 6 / 1100), 23px);
+  height: clamp(17px, calc(17px + (100vw - 1100px) * 6 / 1100), 23px);
   object-fit: contain;
   filter: var(--augment-filter);
 }

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -548,7 +548,7 @@ watch(
 .match-detail-page {
   width: 100%;
   height: 100%;
-  padding: var(--space-2) var(--radius-xs) var(--radius-xs);
+  padding: var(--space-2) var(--space-4) var(--space-4);
   box-sizing: border-box;
   background: var(--bg-base);
 }
@@ -586,7 +586,7 @@ watch(
   display: flex;
   align-items: center;
   gap: 5px; /* 标签之间紧凑间距,介于 4 和 6 */
-  margin-bottom: var(--radius-xs);
+  margin-bottom: var(--space-4);
 }
 
 .match-detail-queue {
@@ -609,7 +609,7 @@ watch(
 .match-detail-hero {
   width: 40px;
   height: 40px;
-  border-radius: var(--space-10);
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   display: block;
 }
@@ -636,7 +636,7 @@ watch(
 }
 
 .match-detail-kda-ratio {
-  margin-left: var(--radius-xs);
+  margin-left: var(--space-4);
   font-size: var(--font-size-xs);
   font-weight: 600;
 }
@@ -684,7 +684,7 @@ watch(
   gap: var(--space-8);
   padding: var(--space-6) var(--space-8);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--space-10);
+  border-radius: var(--radius-lg);
   background: var(--glass-bg-low);
 }
 
@@ -719,7 +719,7 @@ watch(
 
 .match-detail-team-section {
   border: 1px solid var(--border-subtle);
-  border-radius: var(--space-10);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: rgba(0, 0, 0, 0.06);
   flex-shrink: 0;
@@ -910,7 +910,7 @@ watch(
 .match-detail-build-cell {
   display: flex;
   flex-direction: column;
-  gap: var(--radius-xs);
+  gap: var(--space-4);
 }
 
 .match-detail-build-topline {

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -608,8 +608,9 @@ watch(
 }
 
 .match-detail-hero {
-  width: 40px;
-  height: 40px;
+  /* 40→52px 随 viewport (1100→2200) */
+  width: clamp(40px, calc(40px + (100vw - 1100px) * 12 / 1100), 52px);
+  height: clamp(40px, calc(40px + (100vw - 1100px) * 12 / 1100), 52px);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   display: block;
@@ -622,7 +623,8 @@ watch(
 }
 
 .match-detail-player-name {
-  font-size: 15px; /* 介于 sm(12) / lg(16),保留视觉过渡 */
+  /* 15→19px 随 viewport (1100→2200) */
+  font-size: clamp(15px, calc(15px + (100vw - 1100px) * 4 / 1100), 19px);
   font-weight: 700;
   color: var(--text-primary);
 }
@@ -816,8 +818,9 @@ watch(
 }
 
 .match-detail-player-avatar {
-  width: 30px;
-  height: 30px;
+  /* AI 复盘弹窗内玩家头像 30→38 随 viewport */
+  width: clamp(30px, calc(30px + (100vw - 1100px) * 8 / 1100), 38px);
+  height: clamp(30px, calc(30px + (100vw - 1100px) * 8 / 1100), 38px);
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
   flex-shrink: 0;
@@ -929,8 +932,9 @@ watch(
 .match-detail-spell-icon,
 .match-detail-item-icon,
 .match-detail-perk-icon {
-  width: 17px;
-  height: 17px;
+  /* 17→22 随 viewport (1100→2200) */
+  width: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
+  height: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
   border-radius: 5px; /* 17px 方块视觉圆角,介于 xs(3)/sm(6) */
   border: 1px solid var(--border-subtle);
   background: var(--bg-elevated);
@@ -950,8 +954,9 @@ watch(
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 17px;
-  height: 17px;
+  /* 17→22 随 viewport, 与 spell/item/perk 同步 */
+  width: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
+  height: clamp(17px, calc(17px + (100vw - 1100px) * 5 / 1100), 22px);
   border-radius: 5px; /* 与 spell/item/perk 视觉对齐 */
   border: 1px solid var(--augment-border);
   background: var(--augment-background);
@@ -960,8 +965,9 @@ watch(
 }
 
 .match-detail-augment-icon {
-  width: 12px;
-  height: 12px;
+  /* shell 17→22, inner 12→17 同比放大 */
+  width: clamp(12px, calc(12px + (100vw - 1100px) * 5 / 1100), 17px);
+  height: clamp(12px, calc(12px + (100vw - 1100px) * 5 / 1100), 17px);
   object-fit: contain;
   filter: var(--augment-filter);
 }

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -222,35 +222,17 @@
                         />
                       </n-tooltip>
                     </div>
-                    <div class="match-detail-perks">
+                    <!-- 经典模式 (符文非 augment): 主/副符文跟 spells 同行 -->
+                    <div v-if="!usesAugments" class="match-detail-perks">
                       <n-tooltip
                         v-for="(perkId, index) in displayedPerkIds(player.stats)"
                         :key="`${player.participantId}-perk-${perkId}-${index}`"
                         trigger="hover"
                         placement="top"
-                        :disabled="!usesAugments && !assets.detailOf('perk', perkId)"
+                        :disabled="!assets.detailOf('perk', perkId)"
                       >
                         <template #trigger>
-                          <span
-                            v-if="usesAugments"
-                            :class="[
-                              'match-detail-augment-icon-shell',
-                              augmentRarityClass(
-                                assets.detailOf('perk', perkId)?.rarity,
-                                'match-detail-augment'
-                              )
-                            ]"
-                          >
-                            <img
-                              :src="assets.srcOf('perk', perkId)"
-                              class="match-detail-augment-icon"
-                              alt="augment"
-                              loading="lazy"
-                              decoding="async"
-                            />
-                          </span>
                           <img
-                            v-else
                             :src="assets.srcOf('perk', perkId)"
                             :class="[
                               'match-detail-perk-icon',
@@ -263,15 +245,47 @@
                         </template>
                         <AssetTooltipContent
                           :icon-src="assets.srcOf('perk', perkId)"
-                          :name="
-                            assets.detailOf('perk', perkId)?.name ??
-                            (usesAugments ? `海克斯 #${perkId}` : `符文 #${perkId}`)
-                          "
+                          :name="assets.detailOf('perk', perkId)?.name ?? `符文 #${perkId}`"
                           :description="assets.detailOf('perk', perkId)?.description ?? ''"
                           :rarity="assets.detailOf('perk', perkId)?.rarity"
                         />
                       </n-tooltip>
                     </div>
+                  </div>
+                  <!-- ARAM/CHERRY 模式: 海克斯独占一行居中, 跟装备/技能视觉解耦 -->
+                  <div v-if="usesAugments" class="match-detail-augments-row">
+                    <n-tooltip
+                      v-for="(perkId, index) in displayedPerkIds(player.stats)"
+                      :key="`${player.participantId}-augment-${perkId}-${index}`"
+                      trigger="hover"
+                      placement="top"
+                    >
+                      <template #trigger>
+                        <span
+                          :class="[
+                            'match-detail-augment-icon-shell',
+                            augmentRarityClass(
+                              assets.detailOf('perk', perkId)?.rarity,
+                              'match-detail-augment'
+                            )
+                          ]"
+                        >
+                          <img
+                            :src="assets.srcOf('perk', perkId)"
+                            class="match-detail-augment-icon"
+                            alt="augment"
+                            loading="lazy"
+                            decoding="async"
+                          />
+                        </span>
+                      </template>
+                      <AssetTooltipContent
+                        :icon-src="assets.srcOf('perk', perkId)"
+                        :name="assets.detailOf('perk', perkId)?.name ?? `海克斯 #${perkId}`"
+                        :description="assets.detailOf('perk', perkId)?.description ?? ''"
+                        :rarity="assets.detailOf('perk', perkId)?.rarity"
+                      />
+                    </n-tooltip>
                   </div>
                   <div class="match-detail-items">
                     <n-tooltip
@@ -767,11 +781,11 @@ watch(
 
 .match-detail-column-header,
 .match-detail-row {
-  /* 表格列宽固定，保留像素值（pixel-art layout，与表头对齐） */
+  /* 表格列宽固定（P2: 右侧 stats 1.3→1.2fr 释放空间给 build-cell augment 独立行) */
   display: grid;
-  grid-template-columns: minmax(188px, 1.22fr) minmax(214px, 1.36fr) 72px 68px 62px 68px minmax(
-      198px,
-      1.3fr
+  grid-template-columns: minmax(188px, 1.22fr) minmax(214px, 1.42fr) 72px 68px 62px 68px minmax(
+      192px,
+      1.2fr
     );
   gap: var(--space-6);
   align-items: center;
@@ -806,10 +820,9 @@ watch(
 }
 
 .match-detail-row {
-  /* 行内边距 4→8 给呼吸 (解决"闭塞") */
   padding: var(--space-8) 9px;
-  border-bottom: 1px solid var(--border-subtle);
-  /* hover 反馈: 整行加亮 + 强调左侧 (A 优化) */
+  /* P2: divider alpha 调淡, 行间不抢戏 */
+  border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 60%, transparent);
   transition: background var(--dur-fast) var(--ease-expo);
   position: relative;
 }
@@ -970,6 +983,18 @@ watch(
   display: flex;
   align-items: center;
   gap: var(--space-2);
+}
+
+/* ARAM/CHERRY 海克斯独占一行: 居中, subtle bg 视觉分组 (P0) */
+.match-detail-augments-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  padding: var(--space-4) 0;
+  margin: var(--space-2) 0;
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg-low);
 }
 
 .match-detail-augment-icon-shell {

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -222,8 +222,8 @@
                         />
                       </n-tooltip>
                     </div>
-                    <!-- 经典模式 (符文非 augment): 主/副符文跟 spells 同行 -->
-                    <div v-if="!usesAugments" class="match-detail-perks">
+                    <!-- 符文/海克斯都跟 spells 同行 (密集布局) -->
+                    <div class="match-detail-perks">
                       <n-tooltip
                         v-for="(perkId, index) in displayedPerkIds(player.stats)"
                         :key="`${player.participantId}-perk-${perkId}-${index}`"
@@ -232,7 +232,26 @@
                         :disabled="!assets.detailOf('perk', perkId)"
                       >
                         <template #trigger>
+                          <span
+                            v-if="usesAugments"
+                            :class="[
+                              'match-detail-augment-icon-shell',
+                              augmentRarityClass(
+                                assets.detailOf('perk', perkId)?.rarity,
+                                'match-detail-augment'
+                              )
+                            ]"
+                          >
+                            <img
+                              :src="assets.srcOf('perk', perkId)"
+                              class="match-detail-augment-icon"
+                              alt="augment"
+                              loading="lazy"
+                              decoding="async"
+                            />
+                          </span>
                           <img
+                            v-else
                             :src="assets.srcOf('perk', perkId)"
                             :class="[
                               'match-detail-perk-icon',
@@ -245,47 +264,15 @@
                         </template>
                         <AssetTooltipContent
                           :icon-src="assets.srcOf('perk', perkId)"
-                          :name="assets.detailOf('perk', perkId)?.name ?? `符文 #${perkId}`"
+                          :name="
+                            assets.detailOf('perk', perkId)?.name ??
+                            (usesAugments ? `海克斯 #${perkId}` : `符文 #${perkId}`)
+                          "
                           :description="assets.detailOf('perk', perkId)?.description ?? ''"
                           :rarity="assets.detailOf('perk', perkId)?.rarity"
                         />
                       </n-tooltip>
                     </div>
-                  </div>
-                  <!-- ARAM/CHERRY 模式: 海克斯独占一行居中, 跟装备/技能视觉解耦 -->
-                  <div v-if="usesAugments" class="match-detail-augments-row">
-                    <n-tooltip
-                      v-for="(perkId, index) in displayedPerkIds(player.stats)"
-                      :key="`${player.participantId}-augment-${perkId}-${index}`"
-                      trigger="hover"
-                      placement="top"
-                    >
-                      <template #trigger>
-                        <span
-                          :class="[
-                            'match-detail-augment-icon-shell',
-                            augmentRarityClass(
-                              assets.detailOf('perk', perkId)?.rarity,
-                              'match-detail-augment'
-                            )
-                          ]"
-                        >
-                          <img
-                            :src="assets.srcOf('perk', perkId)"
-                            class="match-detail-augment-icon"
-                            alt="augment"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                        </span>
-                      </template>
-                      <AssetTooltipContent
-                        :icon-src="assets.srcOf('perk', perkId)"
-                        :name="assets.detailOf('perk', perkId)?.name ?? `海克斯 #${perkId}`"
-                        :description="assets.detailOf('perk', perkId)?.description ?? ''"
-                        :rarity="assets.detailOf('perk', perkId)?.rarity"
-                      />
-                    </n-tooltip>
                   </div>
                   <div class="match-detail-items">
                     <n-tooltip
@@ -792,7 +779,8 @@ watch(
 }
 
 .match-detail-column-header {
-  padding: var(--space-6) 9px;
+  /* 密集: 表头 padding 6→4 */
+  padding: var(--space-4) 9px;
   color: var(--text-secondary);
   font-size: var(--font-size-2xs);
   font-weight: 600;
@@ -820,8 +808,8 @@ watch(
 }
 
 .match-detail-row {
-  padding: var(--space-8) 9px;
-  /* P2: divider alpha 调淡, 行间不抢戏 */
+  /* 密集模式: padding 收紧到 4px */
+  padding: var(--space-4) 9px;
   border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 60%, transparent);
   transition: background var(--dur-fast) var(--ease-expo);
   position: relative;
@@ -856,9 +844,9 @@ watch(
 }
 
 .match-detail-player-avatar {
-  /* 玩家头像 36→48 (放大一档增强主视觉) */
-  width: clamp(36px, calc(36px + (100vw - 1100px) * 12 / 1100), 48px);
-  height: clamp(36px, calc(36px + (100vw - 1100px) * 12 / 1100), 48px);
+  /* 密集模式: 32→40 */
+  width: clamp(32px, calc(32px + (100vw - 1100px) * 8 / 1100), 40px);
+  height: clamp(32px, calc(32px + (100vw - 1100px) * 8 / 1100), 40px);
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle);
   flex-shrink: 0;
@@ -952,7 +940,8 @@ watch(
 .match-detail-build-cell {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  /* 密集: topline 与 items 间距 4→2 */
+  gap: var(--space-2);
 }
 
 .match-detail-build-topline {
@@ -970,10 +959,10 @@ watch(
 .match-detail-spell-icon,
 .match-detail-item-icon,
 .match-detail-perk-icon {
-  /* 22→30 (icon 整体放大解决"闭塞"+"图标小") */
-  width: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
-  height: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
-  border-radius: 5px; /* 方块视觉圆角,介于 xs(3)/sm(6) */
+  /* 密集模式: 18→24 (上限收回) */
+  width: clamp(18px, calc(18px + (100vw - 1100px) * 6 / 1100), 24px);
+  height: clamp(18px, calc(18px + (100vw - 1100px) * 6 / 1100), 24px);
+  border-radius: 4px;
   border: 1px solid var(--border-subtle);
   background: var(--bg-elevated);
   object-fit: cover;
@@ -985,18 +974,6 @@ watch(
   gap: var(--space-2);
 }
 
-/* ARAM/CHERRY 海克斯独占一行: 居中, subtle bg 视觉分组 (P0) */
-.match-detail-augments-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-4);
-  padding: var(--space-4) 0;
-  margin: var(--space-2) 0;
-  border-radius: var(--radius-sm);
-  background: var(--glass-bg-low);
-}
-
 .match-detail-augment-icon-shell {
   --augment-border: rgba(172, 185, 201, 0.42);
   --augment-background: linear-gradient(180deg, rgba(56, 65, 78, 0.92), rgba(27, 32, 41, 0.96));
@@ -1004,10 +981,10 @@ watch(
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* 22→30 与 spell/item/perk 同步 */
-  width: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
-  height: clamp(22px, calc(22px + (100vw - 1100px) * 8 / 1100), 30px);
-  border-radius: 5px;
+  /* 密集: 18→24 同步 */
+  width: clamp(18px, calc(18px + (100vw - 1100px) * 6 / 1100), 24px);
+  height: clamp(18px, calc(18px + (100vw - 1100px) * 6 / 1100), 24px);
+  border-radius: 4px;
   border: 1px solid var(--augment-border);
   background: var(--augment-background);
   box-sizing: border-box;
@@ -1015,9 +992,9 @@ watch(
 }
 
 .match-detail-augment-icon {
-  /* inner 17→23 同比放大 (shell 22→30, inner 留 5px 边距) */
-  width: clamp(17px, calc(17px + (100vw - 1100px) * 6 / 1100), 23px);
-  height: clamp(17px, calc(17px + (100vw - 1100px) * 6 / 1100), 23px);
+  /* inner 13→19 */
+  width: clamp(13px, calc(13px + (100vw - 1100px) * 6 / 1100), 19px);
+  height: clamp(13px, calc(13px + (100vw - 1100px) * 6 / 1100), 19px);
   object-fit: contain;
   filter: var(--augment-filter);
 }

--- a/lol-record-analysis-tauri/src/components/record/MatchHistory.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchHistory.vue
@@ -32,9 +32,28 @@
         </n-tooltip>
       </n-flex>
 
-      <TransitionGroup name="list" tag="div" class="match-history-list">
+      <template v-if="isRequestingMatchHostory && !matchHistory">
+        <div class="match-history-list">
+          <RecordCardSkeleton v-for="i in 10" :key="`skel-${i}`" />
+        </div>
+      </template>
+      <template v-else-if="loadError">
+        <n-empty description="加载失败" class="match-history-empty">
+          <template #extra>
+            <n-button size="small" @click="retry">重试</n-button>
+          </template>
+        </n-empty>
+      </template>
+      <template v-else-if="games.length === 0 && hasFilter">
+        <n-empty description="没有匹配的对局" class="match-history-empty">
+          <template #extra>
+            <n-button size="small" @click="resetFilter">清除筛选</n-button>
+          </template>
+        </n-empty>
+      </template>
+      <TransitionGroup v-else name="list" tag="div" class="match-history-list">
         <div
-          v-for="(game, index) in matchHistory?.games?.games || []"
+          v-for="(game, index) in games"
           :key="game.gameId"
           :style="{ '--stagger-i': index }"
           class="list-item"
@@ -82,9 +101,10 @@
 
 <script setup lang="ts">
 import RecordCard from './RecordCard.vue'
+import RecordCardSkeleton from './RecordCardSkeleton.vue'
 import { ArrowBack, ArrowForward, RepeatOutline } from '@vicons/ionicons5'
 import { computed, onMounted, provide, ref, watch } from 'vue'
-import { useLoadingBar } from 'naive-ui'
+import { NEmpty, NButton, useLoadingBar } from 'naive-ui'
 import { useRoute } from 'vue-router'
 import { renderSingleSelectTag, renderLabel, filterChampionFunc } from '../composition'
 import { modeOptions, initModeOptions } from './composition'
@@ -155,6 +175,7 @@ const handleUpdateValue = () => {
 const matchHistory = ref<MatchHistory>()
 const loadingBar = useLoadingBar()
 const isRequestingMatchHostory = ref(false)
+const loadError = ref(false)
 const page = ref(1)
 const pageHistory = ref<{ begIndex: number; endIndex: number }[]>([])
 
@@ -164,6 +185,12 @@ let curEndIndex = 0
 const route = useRoute()
 const name = computed(() => (route.query.name as string) ?? '')
 
+/** 当前页对局列表（响应式扁平化，便于空态判断） */
+const games = computed<Game[]>(() => matchHistory.value?.games?.games ?? [])
+
+/** 是否启用了任何筛选条件（用于区分"无数据"与"筛选无结果"） */
+const hasFilter = computed(() => filterChampionId.value > 0 || filterQueueId.value > 0)
+
 async function openDetail(game: Game) {
   await openMatchDetailWindow(game)
 }
@@ -172,6 +199,7 @@ async function openDetail(game: Game) {
 const getHistoryMatch = async (name: string, begIndex: number, endIndex: number) => {
   loadingBar.start()
   isRequestingMatchHostory.value = true
+  loadError.value = false
   try {
     if (filterChampionId.value > 0 || filterQueueId.value > 0) {
       matchHistory.value = await invoke('get_filter_match_history_by_name', {
@@ -192,10 +220,24 @@ const getHistoryMatch = async (name: string, begIndex: number, endIndex: number)
       curBegIndex = matchHistory.value.begIndex
       curEndIndex = matchHistory.value.endIndex
     }
+  } catch (err) {
+    loadError.value = true
+    loadingBar.error()
+    console.error('[MatchHistory] getHistoryMatch failed', err)
   } finally {
     isRequestingMatchHostory.value = false
-    loadingBar.finish()
+    if (!loadError.value) {
+      loadingBar.finish()
+    }
   }
+}
+
+/**
+ * 重试当前页加载（点击"加载失败"空态下的"重试"按钮触发）
+ */
+async function retry() {
+  loadError.value = false
+  await getHistoryMatch(name.value, curBegIndex, curEndIndex)
 }
 
 watch(
@@ -270,7 +312,11 @@ onMounted(async () => {
 .match-history-list {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: var(--space-8);
+}
+
+.match-history-empty {
+  padding: var(--space-24) 0;
 }
 
 .list-item {
@@ -348,12 +394,6 @@ onMounted(async () => {
   max-height: calc(100vw / 1.1);
   margin: auto;
   position: relative;
-}
-
-.scroll-area {
-  flex: 1;
-  overflow-y: auto;
-  margin: var(--space-8) 0;
 }
 
 .pagination {

--- a/lol-record-analysis-tauri/src/components/record/ProgressStatRow.vue
+++ b/lol-record-analysis-tauri/src/components/record/ProgressStatRow.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="stat-row">
-    <div class="stat-label-group">
+  <div class="progress-stat-row">
+    <div class="progress-stat-label-group">
       <slot name="label">{{ label }}</slot>
     </div>
-    <div class="stat-value-group">
-      <span v-if="rawValue !== undefined" class="raw-value">{{ rawValue }}</span>
-      <div v-else class="raw-value spacer"></div>
-      <div class="stat-center-content">
+    <div class="progress-stat-value-group">
+      <span v-if="rawValue !== undefined" class="progress-stat-raw-value">{{ rawValue }}</span>
+      <div v-else class="progress-stat-raw-value progress-stat-raw-value-spacer"></div>
+      <div class="progress-stat-center">
         <n-progress
           type="line"
           :percentage="percent"
@@ -16,7 +16,7 @@
           rail-color="rgba(255, 255, 255, 0.1)"
         />
       </div>
-      <span class="stat-value-text" :style="{ color }">{{ percent }}%</span>
+      <span class="progress-stat-value-text" :style="{ color }">{{ percent }}%</span>
     </div>
   </div>
 </template>
@@ -33,14 +33,14 @@ defineProps<{
 </script>
 
 <style scoped>
-.stat-row {
+.progress-stat-row {
   display: flex;
   align-items: center;
-  font-size: 13px;
-  min-height: 28px;
+  font-size: var(--font-size-base);
+  min-height: 28px; /* 行高:与 RecentStatsTable 同步 */
 }
 
-.stat-label-group {
+.progress-stat-label-group {
   /* 与 RecentStatsTable 同步收紧 */
   width: 60px;
   flex-shrink: 0;
@@ -48,51 +48,51 @@ defineProps<{
   align-items: center;
   color: var(--text-secondary);
   font-weight: 500;
-  gap: 6px;
+  gap: var(--space-6);
 }
 
-.stat-value-group {
+.progress-stat-value-group {
   flex: 1;
   display: flex;
   align-items: center;
   min-width: 0;
 }
 
-.stat-center-content {
+.progress-stat-center {
   flex: 1;
   display: flex;
   align-items: center;
   min-width: 0;
-  padding: 0 6px;
+  padding: 0 var(--space-6);
 }
 
-.stat-center-content :deep(.n-progress) {
-  border-radius: 999px;
+.progress-stat-center :deep(.n-progress) {
+  border-radius: var(--radius-pill);
   overflow: hidden;
 }
 
-.stat-value-text {
+.progress-stat-value-text {
   width: 38px;
   text-align: right;
-  margin-left: 4px;
+  margin-left: var(--space-4);
   flex-shrink: 0;
   font-family: inherit;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--font-size-base);
 }
 
-.raw-value {
+.progress-stat-raw-value {
   width: 52px;
   text-align: right;
-  margin-right: 8px;
+  margin-right: var(--space-8);
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
-  font-size: 13px;
+  font-size: var(--font-size-base);
 }
 
-.raw-value.spacer {
+.progress-stat-raw-value-spacer {
   visibility: hidden;
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/RankCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RankCard.vue
@@ -1,21 +1,23 @@
 <template>
   <n-card
-    class="record-panel-card panel-glass"
+    class="rank-card record-panel-card panel-glass"
     :bordered="false"
     size="small"
-    content-style="padding: 10px"
+    :content-style="cardContentStyle"
   >
     <div class="rank-card-content">
-      <div class="rank-icon-wrapper">
-        <span class="rank-type-label">{{ label }}</span>
-        <img :src="tierImage(queueInfo.tier)" class="rank-img" />
-        <div class="rank-tier-text">{{ queueInfo.tierCn }} {{ divisionOrPoint(queueInfo) }}</div>
+      <div class="rank-card-icon-wrapper">
+        <span class="rank-card-type-label">{{ label }}</span>
+        <img :src="tierImage(queueInfo.tier)" class="rank-card-img" />
+        <div class="rank-card-tier-text">
+          {{ queueInfo.tierCn }} {{ divisionOrPoint(queueInfo) }}
+        </div>
       </div>
-      <div class="rank-stats">
-        <div class="win-rate-badge" :class="badgeClass">胜率 {{ recent.winRate }}%</div>
-        <n-flex justify="space-between" size="small" style="width: 100%; margin-top: 4px">
-          <span class="rank-stat-text">胜场: {{ recent.wins }}</span>
-          <span class="rank-stat-text">负场: {{ recent.losses }}</span>
+      <div class="rank-card-stats">
+        <div class="rank-card-win-badge" :class="badgeClass">胜率 {{ recent.winRate }}%</div>
+        <n-flex justify="space-between" size="small" class="rank-card-stats-row">
+          <span class="rank-card-stat-text">胜场: {{ recent.wins }}</span>
+          <span class="rank-card-stat-text">负场: {{ recent.losses }}</span>
         </n-flex>
       </div>
     </div>
@@ -41,6 +43,9 @@ const badgeClass = computed(() => {
   if (props.recent.winRate <= 49) return 'bad'
   return 'normal'
 })
+
+// n-card 的 content-style 需要字符串/对象,这里用 token 占位以避免 inline 字面量
+const cardContentStyle = 'padding: var(--space-10)'
 </script>
 
 <style scoped>
@@ -53,10 +58,10 @@ const badgeClass = computed(() => {
 .rank-card-content {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-12);
 }
 
-.rank-icon-wrapper {
+.rank-card-icon-wrapper {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -64,62 +69,67 @@ const badgeClass = computed(() => {
   width: 70px;
 }
 
-.rank-type-label {
-  font-size: 10px;
+.rank-card-type-label {
+  font-size: var(--font-size-2xs);
   color: var(--text-tertiary);
   position: absolute;
-  top: -8px;
+  top: calc(var(--space-8) * -1);
   left: 0;
 }
 
-.rank-img {
+.rank-card-img {
   width: 56px;
   height: 56px;
   object-fit: contain;
 }
 
-.rank-tier-text {
-  font-size: 12px;
+.rank-card-tier-text {
+  font-size: var(--font-size-sm);
   font-weight: bold;
   text-align: center;
-  line-height: 1.1;
-  margin-top: -4px;
+  line-height: var(--line-height-tight);
+  margin-top: calc(var(--space-4) * -1);
 }
 
-.rank-stats {
+.rank-card-stats {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
 }
 
-.rank-stat-text {
-  font-size: 11px;
+.rank-card-stats-row {
+  width: 100%;
+  margin-top: var(--space-4);
+}
+
+.rank-card-stat-text {
+  font-size: var(--font-size-xs);
   color: var(--text-tertiary);
 }
 
-.win-rate-badge {
-  padding: 2px 8px;
+.rank-card-win-badge {
+  padding: var(--space-2) var(--space-8);
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   font-weight: bold;
   background: var(--glass-bg-low);
   border: 1px solid var(--glass-border);
 }
 
-.win-rate-badge.good {
+.rank-card-win-badge.good {
   color: var(--semantic-win);
   background: rgba(61, 155, 122, 0.14);
   border-color: rgba(61, 155, 122, 0.22);
 }
 
-.win-rate-badge.bad {
+.rank-card-win-badge.bad {
   color: var(--semantic-loss);
   background: rgba(196, 92, 92, 0.1);
   border-color: rgba(196, 92, 92, 0.18);
 }
 
-.win-rate-badge.normal {
+.rank-card-win-badge.normal {
   color: var(--text-secondary);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/RecentStatsTable.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecentStatsTable.vue
@@ -1,9 +1,9 @@
 <template>
   <n-card
-    class="record-panel-card recent-stats-card"
+    class="recent-stats-card record-panel-card"
     :bordered="false"
     size="small"
-    content-style="padding: 12px"
+    :content-style="cardContentStyle"
   >
     <n-flex justify="space-between" align="center" class="recent-stats-header">
       <span class="recent-stats-title">最近表现</span>
@@ -19,17 +19,17 @@
 
     <n-flex vertical class="recent-stats-rows">
       <!-- KDA -->
-      <div class="stat-row">
-        <div class="stat-label-group">
-          <n-icon class="stat-icon-kda"><PulseOutline /></n-icon>
+      <div class="recent-stats-row">
+        <div class="recent-stats-label-group">
+          <n-icon class="recent-stats-icon-kda"><PulseOutline /></n-icon>
           <span>KDA</span>
         </div>
         <!-- KDA 没有 raw-value 维度,不占左占位,让 KDA + 击杀详情有更宽空间 -->
-        <div class="stat-value-group stat-kda-value-wrap">
-          <span class="stat-kda-main" :style="{ color: kdaColor(recentData.kda, isDark) }">
+        <div class="recent-stats-value-group recent-stats-kda-wrap">
+          <span class="recent-stats-kda-main" :style="{ color: kdaColor(recentData.kda, isDark) }">
             {{ recentData.kda }}
           </span>
-          <span class="kda-detail">
+          <span class="recent-stats-kda-detail">
             <span :style="{ color: killsColor(recentData.kills, isDark) }">
               {{ recentData.kills }}
             </span>
@@ -104,6 +104,9 @@ defineProps<{
 const emit = defineEmits<{
   'mode-change': [value: string | number, option: any]
 }>()
+
+// n-card 的 content-style 需要字符串,这里走 token
+const cardContentStyle = 'padding: var(--space-12)'
 </script>
 
 <style scoped>
@@ -112,7 +115,7 @@ const emit = defineEmits<{
 }
 
 .recent-stats-title {
-  font-size: 14px;
+  font-size: var(--font-size-md);
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: 0.02em;
@@ -122,14 +125,14 @@ const emit = defineEmits<{
   gap: var(--space-8);
 }
 
-.stat-row {
+.recent-stats-row {
   display: flex;
   align-items: center;
-  font-size: 13px;
-  min-height: 28px;
+  font-size: var(--font-size-base);
+  min-height: 28px; /* 与 ProgressStatRow 行高保持一致 */
 }
 
-.stat-label-group {
+.recent-stats-label-group {
   /* 收紧到 60px 给右侧 KDA / progress / raw-value 让出 20px 空间 */
   width: 60px;
   flex-shrink: 0;
@@ -137,58 +140,40 @@ const emit = defineEmits<{
   align-items: center;
   color: var(--text-secondary);
   font-weight: 500;
-  gap: 6px;
+  gap: var(--space-6);
 }
 
-.stat-value-group {
+.recent-stats-value-group {
   flex: 1;
   display: flex;
   align-items: center;
   min-width: 0;
 }
 
-.stat-kda-value-wrap {
+.recent-stats-kda-wrap {
   /* KDA 行只有"主值 + K/D/A 详情"两个块,左右贴边对齐,跟其它行的 progress 风格不同。 */
   justify-content: space-between;
   white-space: nowrap;
   min-width: 0;
-  padding: 0 6px;
+  padding: 0 var(--space-6);
 }
 
-.stat-kda-main {
-  font-size: 12px;
+.recent-stats-kda-main {
+  font-size: var(--font-size-sm);
   font-weight: 600;
   font-family: inherit;
   letter-spacing: 0.02em;
 }
 
-.kda-detail {
+.recent-stats-kda-detail {
   /* margin-left 被 space-between 替代 */
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;
   font-family: inherit;
 }
 
-.stat-center-content {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  min-width: 0;
-  padding: 0 6px;
-}
-
-.raw-value {
-  width: 52px;
-  text-align: right;
-  margin-right: 8px;
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
-  font-size: 13px;
-}
-
-.stat-icon-kda {
+.recent-stats-icon-kda {
   color: var(--semantic-win);
-  font-size: 16px;
+  font-size: var(--font-size-lg);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/RecordButton.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordButton.vue
@@ -2,12 +2,12 @@
   <n-button ghost :type="buttonType" size="tiny">
     <slot></slot>
     <template v-if="recordType === 'good'">
-      <n-icon style="margin-left: 5px">
+      <n-icon class="record-button-icon">
         <ArrowUp />
       </n-icon>
     </template>
     <template v-else-if="recordType === 'bad'">
-      <n-icon style="margin-left: 5px">
+      <n-icon class="record-button-icon">
         <ArrowDown />
       </n-icon>
     </template>
@@ -15,15 +15,21 @@
 </template>
 
 <script lang="ts" setup>
+/**
+ * 战绩标签按钮
+ *
+ * 用语义化颜色（success / error）展示玩家近期的好坏倾向，
+ * 右侧通过箭头图标二次强调方向。
+ */
 import { computed } from 'vue'
 import { ArrowDown, ArrowUp } from '@vicons/ionicons5'
 
-// 接收 props
 const props = defineProps<{
+  /** 倾向类型：good 上升 / bad 下降 / 空字符串无标记 */
   recordType?: 'good' | 'bad' | ''
 }>()
 
-// 计算按钮类型
+/** 根据 recordType 映射到 naive-ui 的 button 语义类型 */
 const buttonType = computed(() => {
   if (props.recordType === 'good') {
     return 'success'
@@ -34,3 +40,9 @@ const buttonType = computed(() => {
   }
 })
 </script>
+
+<style scoped>
+.record-button-icon {
+  margin-left: var(--space-4);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -410,15 +410,16 @@ function openDetail() {
 
 /* === 英雄头像 + MVP 牌 === */
 .record-card-champion {
-  height: 42px;
-  width: 42px;
+  /* 42→52px 随 viewport 平滑放大 (1100→2200) */
+  height: clamp(42px, calc(42px + (100vw - 1100px) * 10 / 1100), 52px);
+  width: clamp(42px, calc(42px + (100vw - 1100px) * 10 / 1100), 52px);
   position: relative;
 }
 
 .record-card-champion-img {
   display: block;
-  width: 42px;
-  height: 42px;
+  width: clamp(42px, calc(42px + (100vw - 1100px) * 10 / 1100), 52px);
+  height: clamp(42px, calc(42px + (100vw - 1100px) * 10 / 1100), 52px);
 }
 
 .record-card-mvp {
@@ -502,8 +503,9 @@ function openDetail() {
 .record-card-item-slots :deep(.n-image img),
 .record-card-item-slots .record-card-icon-slot,
 .record-card-spell-icons .record-card-icon-slot {
-  width: 24px;
-  height: 24px;
+  /* 24→30px 随 viewport (1100→2200) */
+  width: clamp(24px, calc(24px + (100vw - 1100px) * 6 / 1100), 30px);
+  height: clamp(24px, calc(24px + (100vw - 1100px) * 6 / 1100), 30px);
   border-radius: var(--radius-sm);
   background: var(--bg-elevated);
   border: 1px solid var(--glass-border);

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -502,8 +502,8 @@ function openDetail() {
 .record-card-item-slots :deep(.n-image img),
 .record-card-item-slots .record-card-icon-slot,
 .record-card-spell-icons .record-card-icon-slot {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   border-radius: var(--radius-sm);
   background: var(--bg-elevated);
   border: 1px solid var(--glass-border);
@@ -530,8 +530,8 @@ function openDetail() {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: 22px;
+  height: 22px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--augment-border);
   background: var(--augment-background);

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -1,47 +1,38 @@
 <template>
   <n-card
-    content-style="padding: 8px 12px;"
-    class="win-class"
-    :class="{ 'defeat-class': !games.participants[0].stats.win }"
-    :style="cardStyle"
+    :content-style="contentStyleStr"
+    class="record-card"
+    :class="{ 'record-card-win': isWin, 'record-card-loss': !isWin }"
     role="button"
     tabindex="0"
     @click="openDetail"
     @keyup.enter="openDetail"
   >
     <n-flex align="center" justify="space-between">
-      <n-flex vertical style="gap: 1px">
+      <n-flex vertical class="record-card-result">
         <span
-          class="font-number"
-          :style="{
-            fontWeight: '700',
-            fontSize: '14px',
-            color: games.participants[0].stats.win ? themeColors.win : themeColors.loss,
-            marginLeft: '4px',
-            marginTop: '2px'
-          }"
+          class="font-number record-card-result-label"
+          :class="isWin ? 'record-card-text-win' : 'record-card-text-loss'"
         >
           {{ resultLabel }}
-          <n-divider style="margin: 1px 0; line-height: 1px" />
+          <n-divider class="record-card-result-divider" />
         </span>
 
         <span class="record-card-meta">
-          <n-icon style="margin-right: 1px"><Time /></n-icon>
+          <n-icon class="record-card-meta-icon"><Time /></n-icon>
           {{ Math.ceil(games.gameDuration / 60) }}分
         </span>
       </n-flex>
-      <div style="height: 42px; position: relative">
-        <img
-          style="height: 42px"
+      <div class="record-card-champion">
+        <LazyImg
+          class="record-card-champion-img"
           :src="`${assetPrefix}/champion/${games.participants[0].championId}`"
-          loading="lazy"
-          decoding="async"
+          alt="champion"
         />
         <template v-if="!!games.mvp">
           <div
-            style="position: absolute; left: 0; bottom: 0"
-            class="mvp-box"
-            :style="{ backgroundColor: games.mvp == 'MVP' ? '#FFD700' : '#FFFFFF' }"
+            class="record-card-mvp"
+            :class="games.mvp === 'MVP' ? 'record-card-mvp-gold' : 'record-card-mvp-silver'"
           >
             {{ games.mvp == 'MVP' ? 'MVP' : 'SVP' }}
           </div>
@@ -49,29 +40,27 @@
       </div>
 
       <n-flex vertical>
-        <span class="font-number" style="font-size: 14px; font-weight: 700">{{
-          games.queueName
-        }}</span>
+        <span class="font-number record-card-queue">{{ games.queueName }}</span>
         <span class="record-card-meta">
-          <n-icon style="margin-right: 1px">
+          <n-icon class="record-card-meta-icon">
             <CalendarNumber />
           </n-icon>
           {{ formattedDate }}
         </span>
       </n-flex>
 
-      <n-flex justify="space-between" vertical style="gap: 0px">
+      <n-flex justify="space-between" vertical class="record-card-kda-block">
         <n-flex justify="space-between">
-          <span class="font-number">
-            <span :style="{ fontWeight: '500', fontSize: '13px', color: themeColors.kill }">
+          <span class="font-number record-card-kda">
+            <span class="record-card-kda-kill">
               {{ games.participants[0].stats?.kills }}
             </span>
             /
-            <span :style="{ fontWeight: '500', fontSize: '13px', color: themeColors.death }">
+            <span class="record-card-kda-death">
               {{ games.participants[0].stats?.deaths }}
             </span>
             /
-            <span :style="{ fontWeight: '500', fontSize: '13px', color: themeColors.assist }">
+            <span class="record-card-kda-assist">
               {{ games.participants[0].stats?.assists }}
             </span>
           </span>
@@ -92,12 +81,10 @@
                       )
                     ]"
                   >
-                    <img
+                    <LazyImg
                       :src="assets.srcOf('perk', augmentId)"
                       class="record-card-augment-icon"
                       alt="augment"
-                      loading="lazy"
-                      decoding="async"
                     />
                   </span>
                 </template>
@@ -114,7 +101,7 @@
             </span>
           </div>
           <!-- 普通模式：显示带tooltip的召唤师技能 -->
-          <n-flex v-else class="record-card-spell-icons" style="gap: 2px">
+          <n-flex v-else class="record-card-spell-icons">
             <n-tooltip
               v-for="(spellId, index) in [
                 games.participants[0].spell1Id,
@@ -126,12 +113,10 @@
               :disabled="!assets.detailOf('spell', spellId)"
             >
               <template #trigger>
-                <img
+                <LazyImg
                   :src="assets.srcOf('spell', spellId)"
                   class="record-card-icon-slot"
                   alt="spell"
-                  loading="lazy"
-                  decoding="async"
                 />
               </template>
               <AssetTooltipContent
@@ -144,7 +129,7 @@
           </n-flex>
         </n-flex>
         <!-- 装备区域（所有模式都显示） -->
-        <n-flex class="record-card-item-slots" style="gap: 2px">
+        <n-flex class="record-card-item-slots">
           <n-tooltip
             v-for="(itemId, index) in itemIds"
             :key="`record-item-${index}`"
@@ -153,12 +138,10 @@
             :disabled="!assets.detailOf('item', itemId)"
           >
             <template #trigger>
-              <img
+              <LazyImg
                 :src="assets.srcOf('item', itemId)"
                 class="record-card-icon-slot"
                 alt="item"
-                loading="lazy"
-                decoding="async"
               />
             </template>
             <AssetTooltipContent
@@ -198,7 +181,7 @@
           :percent="games.participants[0].stats?.healRate ?? 0"
         />
       </div>
-      <n-flex vertical justify="space-between" style="gap: 0px">
+      <n-flex vertical justify="space-between" class="record-card-teams">
         <TeamAvatarGroup
           :identities="games.gameDetail.participantIdentities"
           :participants="games.gameDetail.participants"
@@ -233,6 +216,7 @@ import type { Game } from '@renderer/types/domain/match'
 import AssetTooltipContent from './AssetTooltipContent.vue'
 import StatDots from './StatDots.vue'
 import TeamAvatarGroup from './TeamAvatarGroup.vue'
+import LazyImg from '@renderer/components/common/LazyImg.vue'
 import { inject } from 'vue'
 import { useRecordAssets } from '@renderer/composables/useRecordAssets'
 import { recordAssetsKey } from '@renderer/composables/recordAssetsKey'
@@ -248,6 +232,11 @@ const emit = defineEmits<{
 
 const { isDark } = useTheme()
 
+const isWin = computed(() => props.games.participants[0].stats.win)
+
+// n-card content-style uses tokens via inline CSS string so naive-ui internals respect spacing scale
+const contentStyleStr = 'padding: var(--space-8) var(--space-12);'
+
 const isCherry = computed(() => props.games.gameMode === 'CHERRY')
 // 海克斯强化局：斗魂竞技场所有变种（CHERRY，queueId 可能是 1700/1710/1810/1820...）
 // 或海克斯大乱斗（2400，gameMode 仍是 ARAM 但用 augment 系统）
@@ -257,7 +246,7 @@ const resultLabel = computed(() => {
   if (isCherry.value && placement.value > 0) {
     return `第 ${placement.value} 名`
   }
-  return props.games.participants[0].stats.win ? '胜利' : '失败'
+  return isWin.value ? '胜利' : '失败'
 })
 
 const augmentIds = computed(() => {
@@ -312,26 +301,6 @@ onMounted(() => {
   ])
 })
 
-const themeColors = computed(() => {
-  if (isDark.value) {
-    return { win: '#3d9b7a', loss: '#c45c5c', kill: '#3d9b7a', death: '#c45c5c', assist: '#b8860b' }
-  }
-  return { win: '#2d8a6c', loss: '#b84242', kill: '#2d8a6c', death: '#b84242', assist: '#b8860b' }
-})
-
-const cardStyle = computed(() => {
-  const isWin = props.games.participants[0].stats.win
-  return {
-    '--left-bar-bg': isWin
-      ? 'linear-gradient(180deg, #5ecfa4, #2d7a5e)'
-      : 'linear-gradient(180deg, #e07070, #994444)',
-    '--left-bar-glow': isWin
-      ? '2px 0 10px rgba(61,155,122,0.45)'
-      : '2px 0 10px rgba(196,92,92,0.35)',
-    position: 'relative' as const
-  }
-})
-
 const router = useRouter()
 
 const formattedDate = computed(() => {
@@ -359,23 +328,8 @@ function openDetail() {
 </script>
 
 <style scoped>
+/* === 卡片容器 === */
 .record-card {
-  background: linear-gradient(120deg, rgb(133, 133, 133) 30%, rgba(44, 44, 44, 0.5));
-}
-
-.win-font {
-  color: #03c2f7;
-  font-weight: 300;
-  font-size: small;
-}
-
-.responsive-img {
-  width: auto;
-  object-fit: contain;
-}
-
-.win-class,
-.defeat-class {
   cursor: pointer;
   overflow: hidden;
   position: relative;
@@ -389,33 +343,88 @@ function openDetail() {
   box-shadow: var(--shadow-md), var(--glass-highlight) !important;
 }
 
-.win-class::before,
-.defeat-class::before {
+.record-card::before {
   content: '';
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
   width: 3px;
-  background: var(--left-bar-bg);
-  box-shadow: var(--left-bar-glow);
-  border-radius: 10px 0 0 10px;
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
   z-index: 1;
 }
 
-.win-class:hover,
-.defeat-class:hover {
+.record-card-win::before {
+  background: var(--win-bar-gradient);
+  box-shadow: var(--glow-win);
+}
+
+.record-card-loss::before {
+  background: var(--loss-bar-gradient);
+  box-shadow: var(--glow-loss);
+}
+
+.record-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg), var(--glass-highlight) !important;
 }
 
-.win-class:active,
-.defeat-class:active {
+.record-card:active {
   transform: scale(0.995);
   transition-duration: var(--dur-instant);
 }
 
-.mvp-box {
+/* === 结果列（胜利/失败 + 时长） === */
+.record-card-result {
+  gap: 1px;
+}
+
+.record-card-result-label {
+  font-weight: 700;
+  font-size: var(--font-size-md);
+  margin-left: var(--space-4);
+  margin-top: var(--space-2);
+}
+
+.record-card-text-win {
+  color: var(--semantic-win);
+}
+
+.record-card-text-loss {
+  color: var(--semantic-loss);
+}
+
+.record-card-result-divider {
+  margin: 1px 0;
+  line-height: 1px;
+}
+
+.record-card-meta {
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.record-card-meta-icon {
+  margin-right: 1px;
+}
+
+/* === 英雄头像 + MVP 牌 === */
+.record-card-champion {
+  height: 42px;
+  width: 42px;
+  position: relative;
+}
+
+.record-card-champion-img {
+  display: block;
+  width: 42px;
+  height: 42px;
+}
+
+.record-card-mvp {
+  position: absolute;
+  left: 0;
+  bottom: 0;
   display: inline-block;
   width: 20px;
   height: 11px;
@@ -424,15 +433,53 @@ function openDetail() {
   font-size: 8px;
   line-height: 11px;
   text-align: center;
-  border-radius: 3px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  border-radius: var(--radius-xs);
+  box-shadow: var(--shadow-sm);
 }
 
+.record-card-mvp-gold {
+  background-color: #ffd700;
+}
+
+.record-card-mvp-silver {
+  background-color: #ffffff;
+}
+
+/* === 队列名 === */
+.record-card-queue {
+  font-size: var(--font-size-md);
+  font-weight: 700;
+}
+
+/* === KDA + 装备区块 === */
+.record-card-kda-block {
+  gap: 0;
+}
+
+.record-card-kda > span {
+  font-weight: 500;
+  font-size: var(--font-size-base);
+}
+
+.record-card-kda-kill {
+  color: var(--semantic-win);
+}
+
+.record-card-kda-death {
+  color: var(--semantic-loss);
+}
+
+.record-card-kda-assist {
+  /* 助攻金色：暂无 token，保留 hex */
+  color: #b8860b;
+}
+
+/* === 战绩统计块 === */
 .record-card-stats-block {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 4px 8px 5px;
+  padding: var(--space-4) var(--space-8) 5px;
   background: var(--glass-bg-low);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
@@ -440,24 +487,21 @@ function openDetail() {
   box-shadow: var(--shadow-sm);
 }
 
-.record-card-meta {
-  color: var(--text-secondary);
-  font-size: 11px;
+/* === 队伍头像列 === */
+.record-card-teams {
+  gap: 0;
+}
+
+/* === 装备/技能 图标槽 === */
+.record-card-item-slots,
+.record-card-spell-icons {
+  gap: var(--space-2);
 }
 
 .record-card-item-slots :deep(.n-image),
 .record-card-item-slots :deep(.n-image img),
+.record-card-item-slots .record-card-icon-slot,
 .record-card-spell-icons .record-card-icon-slot {
-  width: 20px;
-  height: 20px;
-  border-radius: var(--radius-sm);
-  background: var(--bg-elevated);
-  border: 1px solid var(--glass-border);
-  box-sizing: border-box;
-  object-fit: contain;
-}
-
-.record-card-item-slots .record-card-icon-slot {
   width: 20px;
   height: 20px;
   border-radius: var(--radius-sm);
@@ -469,14 +513,14 @@ function openDetail() {
 
 .record-card-spell-icons {
   display: inline-flex;
-  gap: 2px;
 }
 
+/* === 海克斯强化 === */
 .record-card-augments {
   /* 单行展示,最多 6 个 augment(新斗魂);不撑高度,横向占 ~106px。 */
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-2);
 }
 
 .record-card-augment-shell {
@@ -496,9 +540,9 @@ function openDetail() {
 }
 
 .record-card-augment-icon {
+  display: block;
   width: 100%;
   height: 100%;
-  object-fit: cover;
   filter: var(--augment-filter);
 }
 
@@ -540,7 +584,7 @@ function openDetail() {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   color: var(--text-secondary);
   background: var(--bg-elevated);
@@ -548,19 +592,19 @@ function openDetail() {
   border: 1px solid var(--border-subtle);
   min-width: 16px;
   height: 16px;
-  padding: 0 3px;
+  padding: 0 var(--radius-xs);
 }
 
 :deep(.n-tag .n-avatar),
 :deep(.n-button .n-avatar) {
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-subtle);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-sm);
   transition: box-shadow var(--dur-fast) var(--ease-expo);
 }
 
 :deep(.n-tag .n-avatar:hover),
 :deep(.n-button .n-avatar:hover) {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-md);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -532,8 +532,9 @@ function openDetail() {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  /* 22→28px 随 viewport (1100→2200) */
+  width: clamp(22px, calc(22px + (100vw - 1100px) * 6 / 1100), 28px);
+  height: clamp(22px, calc(22px + (100vw - 1100px) * 6 / 1100), 28px);
   border-radius: var(--radius-sm);
   border: 1px solid var(--augment-border);
   background: var(--augment-background);
@@ -592,8 +593,9 @@ function openDetail() {
   background: var(--bg-elevated);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-subtle);
-  min-width: 16px;
-  height: 16px;
+  /* meta-icon badge 16→20 随 viewport */
+  min-width: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
+  height: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
   padding: 0 var(--radius-xs);
 }
 
@@ -603,6 +605,9 @@ function openDetail() {
   border: 1px solid var(--border-subtle);
   box-shadow: var(--shadow-sm);
   transition: box-shadow var(--dur-fast) var(--ease-expo);
+  /* TeamAvatarGroup 头像 15→22px 随 viewport, 强制覆盖 n-avatar 默认尺寸 */
+  width: clamp(15px, calc(15px + (100vw - 1100px) * 7 / 1100), 22px) !important;
+  height: clamp(15px, calc(15px + (100vw - 1100px) * 7 / 1100), 22px) !important;
 }
 
 :deep(.n-tag .n-avatar:hover),

--- a/lol-record-analysis-tauri/src/components/record/RecordCardSkeleton.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCardSkeleton.vue
@@ -1,0 +1,27 @@
+<template>
+  <n-card class="record-card-skeleton" content-style="padding: var(--space-8) var(--space-12);">
+    <n-flex align="center" justify="space-between">
+      <n-flex align="center" :size="12">
+        <n-skeleton :width="4" :height="44" :sharp="true" />
+        <n-skeleton circle :width="44" />
+        <n-flex vertical :size="6">
+          <n-skeleton :width="60" :height="12" />
+          <n-skeleton :width="100" :height="10" />
+        </n-flex>
+      </n-flex>
+      <n-skeleton :width="80" :height="20" />
+      <n-skeleton :width="160" :height="32" />
+    </n-flex>
+  </n-card>
+</template>
+
+<script setup lang="ts">
+import { NCard, NFlex, NSkeleton } from 'naive-ui'
+</script>
+
+<style scoped>
+.record-card-skeleton {
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-8);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/record/RelationshipPanel.vue
+++ b/lol-record-analysis-tauri/src/components/record/RelationshipPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relationship-col">
-    <div class="section-header" :class="variant === 'friend' ? 'good-color' : 'bad-color'">
+    <div class="relationship-header" :class="variant === 'friend' ? 'good-color' : 'bad-color'">
       <n-icon>
         <AccessibilityOutline v-if="variant === 'friend'" />
         <FlashOutline v-else />
@@ -22,16 +22,10 @@
               :size="24"
               :src="`${assetPrefix}/profile/${entry?.Summoner?.profileIconId}`"
             />
-            <n-ellipsis style="flex: 1; margin: 0 6px; font-size: 12px">
+            <n-ellipsis class="relationship-name">
               {{ entry?.Summoner?.gameName }}
             </n-ellipsis>
-            <span
-              :style="{
-                color: winRateColor(entry.winRate, isDark),
-                fontWeight: 'bold',
-                fontSize: '12px'
-              }"
-            >
+            <span class="relationship-rate" :style="{ color: winRateColor(entry.winRate, isDark) }">
               {{ entry.winRate }}
             </span>
           </div>
@@ -65,27 +59,27 @@ defineProps<{
   min-width: 0;
 }
 
-.section-header {
+.relationship-header {
   font-weight: 800;
   display: flex;
   align-items: center;
-  gap: 4px;
-  margin-bottom: 8px;
-  font-size: 13px;
+  gap: var(--space-4);
+  margin-bottom: var(--space-8);
+  font-size: var(--font-size-base);
 }
 
-.section-header.good-color {
+.relationship-header.good-color {
   color: var(--semantic-win);
 }
 
-.section-header.bad-color {
+.relationship-header.bad-color {
   color: var(--semantic-loss);
 }
 
 .relationship-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-6);
 }
 
 .relationship-item {
@@ -101,5 +95,16 @@ defineProps<{
 
 .relationship-item:hover {
   background-color: var(--glass-bg-high);
+}
+
+.relationship-name {
+  flex: 1;
+  margin: 0 var(--space-6);
+  font-size: var(--font-size-sm);
+}
+
+.relationship-rate {
+  font-weight: bold;
+  font-size: var(--font-size-sm);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/record/StatDots.vue
+++ b/lol-record-analysis-tauri/src/components/record/StatDots.vue
@@ -74,14 +74,14 @@ const iconStyle = computed<CSSProperties>(() => ({
 .stat-dots-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-6);
   min-width: 0;
 }
 
 .stat-dots-icon-wrap {
   width: 18px;
   height: 18px;
-  border-radius: 5px;
+  border-radius: 5px; /* 18px 方块的视觉圆角,介于 xs(3) 和 sm(6) 之间 */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -89,7 +89,7 @@ const iconStyle = computed<CSSProperties>(() => ({
 }
 
 .stat-dots-short-label {
-  font-size: 9px;
+  font-size: 9px; /* 小标签字号,低于 --font-size-2xs(10),保留 */
   line-height: 1;
   font-weight: 700;
 }
@@ -99,7 +99,7 @@ const iconStyle = computed<CSSProperties>(() => ({
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 3px; /* 5 颗 dot 之间的小间距,无对应 token */
 }
 
 .stat-dot {
@@ -121,9 +121,9 @@ const iconStyle = computed<CSSProperties>(() => ({
 .stat-dots-values {
   display: flex;
   align-items: baseline;
-  gap: 4px;
+  gap: var(--space-4);
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
 }
 
 .stat-dots-value-main {
@@ -140,17 +140,17 @@ const iconStyle = computed<CSSProperties>(() => ({
 }
 
 .stat-dots-row-compact {
-  gap: 4px;
+  gap: var(--space-4);
 }
 
 .stat-dots-row-compact .stat-dots-icon-wrap {
   width: 16px;
   height: 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 .stat-dots-row-compact .stat-dots-track {
-  gap: 2px;
+  gap: 2px; /* compact 模式 dot 间距,无对应 token */
 }
 
 .stat-dots-row-compact .stat-dot {

--- a/lol-record-analysis-tauri/src/components/record/StatDots.vue
+++ b/lol-record-analysis-tauri/src/components/record/StatDots.vue
@@ -95,7 +95,8 @@ const iconStyle = computed<CSSProperties>(() => ({
 .stat-bar-track {
   flex: 1;
   min-width: 0;
-  height: 6px;
+  /* 密集模式: bar 高 4px */
+  height: 4px;
   border-radius: var(--radius-pill);
   background: var(--border-subtle);
   overflow: hidden;

--- a/lol-record-analysis-tauri/src/components/record/StatDots.vue
+++ b/lol-record-analysis-tauri/src/components/record/StatDots.vue
@@ -19,13 +19,11 @@
       <span v-else class="stat-dots-short-label">{{ shortLabel }}</span>
     </div>
 
-    <div class="stat-dots-track" :style="{ '--stat-dot-color': color }">
-      <span
-        v-for="i in 5"
-        :key="i"
-        class="stat-dot"
-        :class="{ 'stat-dot-filled': i <= filledCount }"
-      />
+    <div
+      class="stat-bar-track"
+      :style="{ '--stat-bar-fill': clampedPercent + '%', '--stat-bar-color': color }"
+    >
+      <span class="stat-bar-fill" />
     </div>
 
     <div class="stat-dots-values">
@@ -37,7 +35,6 @@
 
 <script lang="ts" setup>
 import { computed, type Component, type CSSProperties } from 'vue'
-import { dotFillCount } from './composition'
 
 const props = withDefaults(
   defineProps<{
@@ -62,7 +59,7 @@ const props = withDefaults(
   }
 )
 
-const filledCount = computed(() => dotFillCount(props.percent))
+const clampedPercent = computed(() => Math.max(0, Math.min(100, props.percent)))
 const displayValue = computed(() => props.value)
 const iconStyle = computed<CSSProperties>(() => ({
   background: props.iconBackground,
@@ -94,28 +91,28 @@ const iconStyle = computed<CSSProperties>(() => ({
   font-weight: 700;
 }
 
-.stat-dots-track {
+/* mini progress bar 替代 5 圆点 (P1): 连续填充, 视觉现代 */
+.stat-bar-track {
   flex: 1;
   min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 3px; /* 5 颗 dot 之间的小间距,无对应 token */
-}
-
-.stat-dot {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
+  height: 6px;
+  border-radius: var(--radius-pill);
   background: var(--border-subtle);
-  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
 }
 
-.theme-light .stat-dot {
-  background: rgba(0, 0, 0, 0.24);
+.theme-light .stat-bar-track {
+  background: rgba(0, 0, 0, 0.1);
 }
 
-.stat-dot-filled {
-  background: var(--stat-dot-color) !important;
+.stat-bar-fill {
+  display: block;
+  height: 100%;
+  width: var(--stat-bar-fill, 0%);
+  background: var(--stat-bar-color);
+  border-radius: var(--radius-pill);
+  transition: width var(--dur-slow) var(--ease-expo);
 }
 
 .stat-dots-values {
@@ -149,13 +146,8 @@ const iconStyle = computed<CSSProperties>(() => ({
   border-radius: var(--radius-xs);
 }
 
-.stat-dots-row-compact .stat-dots-track {
-  gap: 2px; /* compact 模式 dot 间距,无对应 token */
-}
-
-.stat-dots-row-compact .stat-dot {
-  width: 3px;
-  height: 3px;
+.stat-dots-row-compact .stat-bar-track {
+  height: 4px;
 }
 
 :deep(.n-progress-graph-line-fill) {

--- a/lol-record-analysis-tauri/src/components/record/TeamAvatarGroup.vue
+++ b/lol-record-analysis-tauri/src/components/record/TeamAvatarGroup.vue
@@ -9,8 +9,7 @@
                 :bordered="true"
                 :src="avatarSrcAt(idx)"
                 :fallback-src="itemNull"
-                class="team-avatar"
-                :class="{ 'team-avatar-current': isCurrentPlayer(identity) }"
+                :style="{ borderColor: borderColorFor(identity) }"
               />
             </n-button>
           </template>
@@ -73,20 +72,16 @@ function isCurrentPlayer(identity: MatchPlayerIdentity | undefined) {
   return nameOf(identity) === props.currentPlayerKey
 }
 
+/**
+ * 决定头像描边颜色：当前查询玩家用 `--semantic-win` 高亮，其他人用 `--text-tertiary` 淡描边。
+ * 两个值都来自全局 CSS 变量，主题切换会自动跟随。
+ */
+function borderColorFor(identity: MatchPlayerIdentity | undefined) {
+  return isCurrentPlayer(identity) ? 'var(--semantic-win)' : 'var(--text-tertiary)'
+}
+
 function navigate(identity: MatchPlayerIdentity | undefined) {
   const name = nameOf(identity)
   if (name) emit('nav-to-name', name)
 }
 </script>
-
-<style scoped>
-/* 普通队友头像：使用 text-tertiary 作为淡描边，跟随主题自动切换 */
-.team-avatar {
-  border-color: var(--text-tertiary);
-}
-
-/* 当前查询玩家：用 win 色高亮边框 */
-.team-avatar.team-avatar-current {
-  border-color: var(--semantic-win);
-}
-</style>

--- a/lol-record-analysis-tauri/src/components/record/TeamAvatarGroup.vue
+++ b/lol-record-analysis-tauri/src/components/record/TeamAvatarGroup.vue
@@ -9,7 +9,8 @@
                 :bordered="true"
                 :src="avatarSrcAt(idx)"
                 :fallback-src="itemNull"
-                :style="{ borderColor: borderFor(identity) }"
+                class="team-avatar"
+                :class="{ 'team-avatar-current': isCurrentPlayer(identity) }"
               />
             </n-button>
           </template>
@@ -21,6 +22,13 @@
 </template>
 
 <script setup lang="ts">
+/**
+ * 队伍头像列表
+ *
+ * 在战绩卡右侧展示一队 5 个队友的英雄头像，
+ * 当前查询的玩家用 `--semantic-win` 高亮边框，其他人用淡描边，
+ * 颜色随 CSS 主题变量自动切换。
+ */
 import { computed } from 'vue'
 import { NTag, NFlex, NPopover, NButton, NAvatar } from 'naive-ui'
 import type { MatchPlayerIdentity, Participant } from '@renderer/types/domain/match'
@@ -28,11 +36,19 @@ import itemNull from '@renderer/assets/imgs/item/null.png'
 import { assetPrefix } from '@renderer/services/http'
 
 const props = defineProps<{
+  /** 全部 10 名玩家的身份信息（蓝队 5 + 红队 5） */
   identities: MatchPlayerIdentity[]
+  /** 全部 10 名玩家的对局参与数据 */
   participants: Participant[]
+  /** 当前队伍偏移：0 表示蓝队，5 表示红队 */
   teamOffset: 0 | 5
+  /** 当前正在查询的玩家 key（gameName#tagLine） */
   currentPlayerKey: string
-  isDark: boolean
+  /**
+   * 是否暗色主题（仅保留以兼容父组件调用签名，
+   * 实际配色已迁到 CSS 变量自动跟随主题）
+   */
+  isDark?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -53,11 +69,8 @@ function avatarSrcAt(idx: number) {
   return championId ? `${assetPrefix}/champion/${championId}` : itemNull
 }
 
-function borderFor(identity: MatchPlayerIdentity | undefined) {
-  if (nameOf(identity) === props.currentPlayerKey) {
-    return props.isDark ? '#63e2b7' : '#0d9488'
-  }
-  return props.isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.25)'
+function isCurrentPlayer(identity: MatchPlayerIdentity | undefined) {
+  return nameOf(identity) === props.currentPlayerKey
 }
 
 function navigate(identity: MatchPlayerIdentity | undefined) {
@@ -65,3 +78,15 @@ function navigate(identity: MatchPlayerIdentity | undefined) {
   if (name) emit('nav-to-name', name)
 }
 </script>
+
+<style scoped>
+/* 普通队友头像：使用 text-tertiary 作为淡描边，跟随主题自动切换 */
+.team-avatar {
+  border-color: var(--text-tertiary);
+}
+
+/* 当前查询玩家：用 win 色高亮边框 */
+.team-avatar.team-avatar-current {
+  border-color: var(--semantic-win);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/record/UserRecord.vue
+++ b/lol-record-analysis-tauri/src/components/record/UserRecord.vue
@@ -251,10 +251,12 @@ const copyName = () => {
   min-width: 0;
 }
 
-.user-record-nickname {
+/* :deep 因 n-ellipsis 子组件根 scoped attr 不透传 (同 Gaming/PlayerCard 教训) */
+/* 16→20px 随 viewport (1100→2200) */
+:deep(.user-record-nickname) {
   max-width: 100%;
+  font-size: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
   font-weight: 700;
-  font-size: var(--font-size-lg);
 }
 
 .user-record-tagline {
@@ -287,6 +289,9 @@ const copyName = () => {
   background: transparent !important;
   border: 1px solid var(--border-subtle);
   box-shadow: none;
+  /* 58→76px 随 viewport 平滑放大 (1100→2200), 强制覆盖 n-avatar inline size="58" */
+  width: clamp(58px, calc(58px + (100vw - 1100px) * 18 / 1100), 76px) !important;
+  height: clamp(58px, calc(58px + (100vw - 1100px) * 18 / 1100), 76px) !important;
 }
 
 .user-record-avatar-img {

--- a/lol-record-analysis-tauri/src/components/record/UserRecord.vue
+++ b/lol-record-analysis-tauri/src/components/record/UserRecord.vue
@@ -1,12 +1,7 @@
 <template>
   <n-flex vertical class="user-record-container" :size="12">
     <!-- User Info Card -->
-    <n-card
-      class="record-panel-card panel-glass"
-      :bordered="false"
-      size="small"
-      content-style="padding: 12px"
-    >
+    <n-card class="record-panel-card panel-glass user-record-card" :bordered="false" size="small">
       <n-flex align="center" :size="12">
         <div class="avatar-wrapper user-record-avatar">
           <n-avatar
@@ -18,9 +13,9 @@
           />
           <div class="level-badge">{{ summoner.summonerLevel }}</div>
         </div>
-        <n-flex vertical :size="2" style="flex: 1; min-width: 0">
+        <n-flex vertical :size="2" class="user-record-identity">
           <n-flex align="center" :size="4" :wrap="false">
-            <n-ellipsis style="max-width: 100%; font-weight: 700; font-size: 16px">
+            <n-ellipsis class="user-record-nickname">
               {{ summoner.gameName }}
             </n-ellipsis>
             <n-button text size="tiny" @click="copyName">
@@ -30,14 +25,14 @@
             </n-button>
           </n-flex>
           <n-flex align="center" :size="6">
-            <n-text depth="3" style="font-size: 12px">#{{ summoner.tagLine }}</n-text>
+            <n-text depth="3" class="user-record-tagline">#{{ summoner.tagLine }}</n-text>
             <n-popover trigger="hover" v-if="serverDescription">
               <template #trigger>
                 <n-tag
                   size="small"
                   :bordered="false"
                   type="default"
-                  style="font-size: 10px; padding: 0 4px; height: 18px"
+                  class="user-record-platform-tag"
                 >
                   {{ platformIdCn }}
                 </n-tag>
@@ -49,7 +44,7 @@
               size="small"
               :bordered="false"
               type="default"
-              style="font-size: 10px; padding: 0 4px; height: 18px"
+              class="user-record-platform-tag"
             >
               {{ platformIdCn }}
             </n-tag>
@@ -58,7 +53,7 @@
       </n-flex>
 
       <!-- Tags -->
-      <n-flex v-if="tags.length > 0" style="margin-top: 12px" :size="6" wrap>
+      <n-flex v-if="tags.length > 0" class="user-record-tags" :size="6" wrap>
         <n-tooltip trigger="hover" v-for="tag in tags" :key="tag.tagName">
           <template #trigger>
             <n-tag size="small" :type="tag.good ? 'primary' : 'error'" :bordered="false" round>
@@ -247,6 +242,35 @@ const copyName = () => {
   height: 100%;
 }
 
+.user-record-card :deep(.n-card__content) {
+  padding: var(--space-12);
+}
+
+.user-record-identity {
+  flex: 1;
+  min-width: 0;
+}
+
+.user-record-nickname {
+  max-width: 100%;
+  font-weight: 700;
+  font-size: var(--font-size-lg);
+}
+
+.user-record-tagline {
+  font-size: var(--font-size-sm);
+}
+
+.user-record-platform-tag {
+  font-size: var(--font-size-2xs);
+  padding: 0 var(--space-4);
+  height: 18px;
+}
+
+.user-record-tags {
+  margin-top: var(--space-12);
+}
+
 .avatar-wrapper {
   position: relative;
   display: flex;
@@ -271,14 +295,14 @@ const copyName = () => {
 
 .level-badge {
   position: absolute;
-  bottom: -6px;
+  bottom: calc(-1 * var(--space-6));
   background-color: var(--bg-elevated);
   border: 1px solid var(--border-subtle);
-  padding: 0 6px;
+  padding: 0 var(--space-6);
   height: 16px;
   line-height: 14px;
   border-radius: var(--radius-lg);
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   color: var(--text-secondary);
   z-index: 1;
   box-shadow: var(--shadow-card);

--- a/lol-record-analysis-tauri/src/components/record/__tests__/MatchHistory.spec.ts
+++ b/lol-record-analysis-tauri/src/components/record/__tests__/MatchHistory.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// Mock Tauri IPC so onMounted's invoke calls resolve to harmless empty data
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(() => Promise.resolve({ games: { games: [] }, begIndex: 0, endIndex: 9 }))
+}))
+
+// Stub useLoadingBar (only available inside <n-loading-bar-provider>)
+vi.mock('naive-ui', async () => {
+  const actual = await vi.importActual<typeof import('naive-ui')>('naive-ui')
+  return {
+    ...actual,
+    useLoadingBar: () => ({ start: vi.fn(), finish: vi.fn(), error: vi.fn() })
+  }
+})
+
+// Stub vue-router useRoute so the `name` query read doesn't blow up.
+// Use importOriginal so other modules importing createRouter/createWebHashHistory still work.
+vi.mock('vue-router', async importOriginal => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: () => ({ query: {} })
+  }
+})
+
+describe('MatchHistory', () => {
+  it('mounts without crashing', async () => {
+    const MatchHistory = (await import('../MatchHistory.vue')).default
+    const wrapper = mount(MatchHistory, {
+      global: {
+        stubs: {
+          RecordCard: true,
+          RecordCardSkeleton: true,
+          NPagination: true,
+          NEmpty: true,
+          NButton: true,
+          NSelect: true,
+          NFlex: false,
+          NIcon: true,
+          NTooltip: true
+        }
+      }
+    })
+    expect(wrapper.exists()).toBe(true)
+    wrapper.unmount()
+  })
+})

--- a/lol-record-analysis-tauri/src/composables/useBreakpoint.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useBreakpoint.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useBreakpoint } from './useBreakpoint'
+
+describe('useBreakpoint', () => {
+  let originalInnerWidth: number
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth })
+  })
+
+  function setWidth(width: number) {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: width })
+    window.dispatchEvent(new Event('resize'))
+  }
+
+  function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+    let result!: T
+    const Wrapper = defineComponent({
+      setup() {
+        result = composable()
+        return () => null
+      }
+    })
+    const wrapper = mount(Wrapper)
+    return { result, unmount: () => wrapper.unmount() }
+  }
+
+  it('reports desktop when window >= 768', () => {
+    setWidth(1024)
+    const { result, unmount } = withSetup(() => useBreakpoint())
+    expect(result.isMobile.value).toBe(false)
+    expect(result.isDesktop.value).toBe(true)
+    unmount()
+  })
+
+  it('reports mobile when window < 768', () => {
+    setWidth(500)
+    const { result, unmount } = withSetup(() => useBreakpoint())
+    expect(result.isMobile.value).toBe(true)
+    expect(result.isDesktop.value).toBe(false)
+    unmount()
+  })
+
+  it('reacts to resize events', async () => {
+    setWidth(1024)
+    const { result, unmount } = withSetup(() => useBreakpoint())
+    expect(result.isMobile.value).toBe(false)
+    setWidth(600)
+    await nextTick()
+    expect(result.isMobile.value).toBe(true)
+    unmount()
+  })
+})

--- a/lol-record-analysis-tauri/src/composables/useBreakpoint.ts
+++ b/lol-record-analysis-tauri/src/composables/useBreakpoint.ts
@@ -1,0 +1,36 @@
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+const BREAKPOINTS = {
+  md: 768,
+  lg: 1024
+} as const
+
+/**
+ * 响应式视口宽度断点
+ *
+ * - md: 768（手机/平板分界）
+ * - lg: 1024（平板/桌面分界）
+ *
+ * @returns isMobile/isDesktop 反应式 ref，跟随 window resize 自动更新
+ */
+export function useBreakpoint() {
+  const width = ref(typeof window !== 'undefined' ? window.innerWidth : BREAKPOINTS.lg)
+
+  const isMobile = computed(() => width.value < BREAKPOINTS.md)
+  const isDesktop = computed(() => width.value >= BREAKPOINTS.md)
+
+  function handler() {
+    width.value = window.innerWidth
+  }
+
+  onMounted(() => {
+    window.addEventListener('resize', handler)
+    handler() // 立即同步一次
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('resize', handler)
+  })
+
+  return { width, isMobile, isDesktop, BREAKPOINTS }
+}

--- a/lol-record-analysis-tauri/src/global.css
+++ b/lol-record-analysis-tauri/src/global.css
@@ -65,6 +65,33 @@
   --space-20: 20px;
   --space-24: 24px;
   --space-28: 28px;
+
+  /* === 字阶 === */
+  --font-size-2xs: 10px;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-base: 13px;
+  --font-size-md: 14px;
+  --font-size-lg: 16px;
+  --font-size-xl: 18px;
+  --line-height-tight: 1.2;
+  --line-height-normal: 1.45;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* === 补 space 阶 === */
+  --space-2: 2px;
+  --space-6: 6px;
+  --space-10: 10px;
+
+  /* === 圆角补全 === */
+  --radius-xs: 3px;
+  --radius-pill: 999px;
+
+  /* === RecordCard win/loss 渐变（深色） === */
+  --win-bar-gradient: linear-gradient(180deg, #5ecfa4, #2d7a5e);
+  --loss-bar-gradient: linear-gradient(180deg, #e57878, #8a3232);
 }
 
 /* 浅色主题 Token */
@@ -92,6 +119,8 @@
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
   --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.12);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.15);
+  --win-bar-gradient: linear-gradient(180deg, #4abd92, #2d8a6c);
+  --loss-bar-gradient: linear-gradient(180deg, #d96565, #a33b3b);
 }
 
 .font-number {

--- a/lol-record-analysis-tauri/src/theme/overrides.spec.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.spec.ts
@@ -22,4 +22,12 @@ describe('buildThemeOverrides', () => {
     const light = buildThemeOverrides(false)
     expect(dark.Layout?.color).not.toBe(light.Layout?.color)
   })
+
+  it('covers Pagination namespace per spec §3.2 (Empty has no borderRadius theme var, inherits from common)', () => {
+    const overrides = buildThemeOverrides(true)
+    // naive-ui Pagination exposes itemBorderRadius (not borderRadius)
+    expect(overrides.Pagination?.itemBorderRadius).toBeTruthy()
+    // Empty namespace has no borderRadius theme var in naive-ui; inherits common.borderRadius
+    expect(overrides.common?.borderRadius).toBeTruthy()
+  })
 })

--- a/lol-record-analysis-tauri/src/theme/overrides.spec.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { buildThemeOverrides } from './overrides'
+
+describe('buildThemeOverrides', () => {
+  it('returns dark theme overrides with required namespaces', () => {
+    const overrides = buildThemeOverrides(true)
+    expect(overrides.common).toBeDefined()
+    expect(overrides.Card).toBeDefined()
+    expect(overrides.Button).toBeDefined()
+    expect(overrides.Card?.borderRadius).toBeTruthy()
+  })
+
+  it('returns light theme overrides with required namespaces', () => {
+    const overrides = buildThemeOverrides(false)
+    expect(overrides.common).toBeDefined()
+    expect(overrides.Card).toBeDefined()
+    expect(overrides.Layout?.color).toBeTruthy()
+  })
+
+  it('isDark flag changes Layout.color', () => {
+    const dark = buildThemeOverrides(true)
+    const light = buildThemeOverrides(false)
+    expect(dark.Layout?.color).not.toBe(light.Layout?.color)
+  })
+})

--- a/lol-record-analysis-tauri/src/theme/overrides.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.ts
@@ -23,14 +23,14 @@ export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides {
   const radiusPill = cssVar('--radius-pill', '999px')
   const space8 = cssVar('--space-8', '8px')
   const space12 = cssVar('--space-12', '12px')
-  const bgBase = cssVar('--bg-base', isDark ? '#0d0d0f' : '#f0f2f5')
-  const glassMid = cssVar('--glass-bg-mid', isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)')
-  const glassBorder = cssVar(
-    '--glass-border',
-    isDark ? 'rgba(255,255,255,0.09)' : 'rgba(0,0,0,0.08)'
-  )
-  const shadowMd = cssVar('--shadow-md', '0 2px 8px rgba(0,0,0,0.45)')
-  const semanticWin = cssVar('--semantic-win', isDark ? '#3d9b7a' : '#2d8a6c')
+  // Theme-dependent values can't go through cssVar() — .theme-light class is on
+  // n-config-provider's root, not document.documentElement, so getComputedStyle
+  // always returns :root values. Use isDark ternaries directly (matches pre-refactor behavior).
+  const bgBase = isDark ? '#0d0d0f' : '#f0f2f5'
+  const glassMid = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)'
+  const glassBorder = isDark ? 'rgba(255,255,255,0.09)' : 'rgba(0,0,0,0.08)'
+  const shadowMd = isDark ? '0 2px 8px rgba(0,0,0,0.45)' : '0 2px 8px rgba(0,0,0,0.12)'
+  const semanticWin = isDark ? '#3d9b7a' : '#2d8a6c'
 
   return {
     common: {

--- a/lol-record-analysis-tauri/src/theme/overrides.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.ts
@@ -55,6 +55,9 @@ export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides {
     Select: {
       borderRadius: radiusMd
     },
+    Pagination: {
+      itemBorderRadius: radiusMd
+    },
     Tag: {
       borderRadius: radiusPill
     },

--- a/lol-record-analysis-tauri/src/theme/overrides.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.ts
@@ -1,0 +1,82 @@
+import type { GlobalThemeOverrides } from 'naive-ui'
+
+/**
+ * 读取 CSS 变量值，带 fallback
+ *
+ * SSR 或首屏 `getComputedStyle` 可能返回空字符串，必须提供 fallback。
+ */
+function cssVar(name: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return value || fallback
+}
+
+/**
+ * 构建 naive-ui 主题 overrides
+ *
+ * @param isDark 当前是否暗色主题（用于选取 Layout.color 等主题相关 fallback）
+ */
+export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides {
+  const radiusSm = cssVar('--radius-sm', '6px')
+  const radiusMd = cssVar('--radius-md', '8px')
+  const radiusLg = cssVar('--radius-lg', '12px')
+  const radiusPill = cssVar('--radius-pill', '999px')
+  const space8 = cssVar('--space-8', '8px')
+  const space12 = cssVar('--space-12', '12px')
+  const bgBase = cssVar('--bg-base', isDark ? '#0d0d0f' : '#f0f2f5')
+  const glassMid = cssVar('--glass-bg-mid', isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)')
+  const glassBorder = cssVar(
+    '--glass-border',
+    isDark ? 'rgba(255,255,255,0.09)' : 'rgba(0,0,0,0.08)'
+  )
+  const shadowMd = cssVar('--shadow-md', '0 2px 8px rgba(0,0,0,0.45)')
+  const semanticWin = cssVar('--semantic-win', isDark ? '#3d9b7a' : '#2d8a6c')
+
+  return {
+    common: {
+      borderRadius: radiusMd,
+      borderRadiusSmall: radiusSm
+    },
+    Card: {
+      borderRadius: radiusLg,
+      color: glassMid,
+      boxShadow: shadowMd,
+      borderColor: glassBorder
+    },
+    Input: {
+      borderRadius: radiusMd,
+      color: glassMid,
+      border: `1px solid ${glassBorder}`
+    },
+    Button: {
+      borderRadiusSmall: radiusSm,
+      borderRadiusMedium: radiusMd
+    },
+    Select: {
+      borderRadius: radiusMd
+    },
+    Tag: {
+      borderRadius: radiusPill
+    },
+    Tooltip: {
+      borderRadius: radiusMd,
+      padding: `${space8} ${space12}`
+    },
+    Popover: {
+      borderRadius: radiusMd
+    },
+    Skeleton: {
+      borderRadius: radiusMd
+    },
+    Layout: {
+      color: bgBase
+    },
+    Menu: {
+      itemColorActive: isDark ? 'rgba(61,155,122,0.14)' : 'rgba(45,138,108,0.12)',
+      itemColorActiveHover: isDark ? 'rgba(61,155,122,0.18)' : 'rgba(45,138,108,0.18)',
+      itemBorderRadius: radiusLg,
+      itemTextColorActive: semanticWin,
+      itemIconColorActive: semanticWin
+    }
+  }
+}

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -303,13 +303,18 @@ onMounted(async () => {
 .gaming-grid {
   height: 100%;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* auto-fit: 窄屏 (<1000px) 自动堆 1 列, 宽屏 2 列, 自适应 */
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 480px), 1fr));
+  /* 整体居中, 4K 下 2600 max 保证 card 有横向空间放大 */
+  max-width: 2600px;
+  margin: 0 auto;
   gap: var(--space-16);
 }
 
 .gaming-grid-multi {
   height: auto;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 480px), 1fr));
   grid-auto-rows: minmax(220px, auto);
+  max-width: 2600px;
 }
 </style>

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -207,85 +207,87 @@ onMounted(async () => {
 }
 
 .gaming-config-hint {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-tertiary);
 }
 
 .ai-result-content {
   padding: var(--space-16);
   line-height: 1.8;
-  font-size: 14px;
+  font-size: var(--font-size-md);
   max-height: 600px;
   overflow-y: auto;
 }
 
 .ai-result-content :deep(h1) {
-  font-size: 20px;
-  font-weight: 700;
-  margin: 20px 0 12px 0;
-  padding-bottom: 8px;
+  font-size: 20px; /* H1 一档大于 --font-size-xl(18px)，保留 */
+  font-weight: var(--font-weight-bold);
+  margin: var(--space-20) 0 var(--space-12) 0;
+  padding-bottom: var(--space-8);
   border-bottom: 3px solid var(--n-primary-color);
   color: var(--n-text-color);
 }
 
 .ai-result-content :deep(h2) {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 18px 0 10px 0;
-  padding-left: 12px;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  margin: var(--space-20) 0 var(--space-10) 0;
+  padding-left: var(--space-12);
   border-left: 4px solid var(--n-primary-color);
   color: var(--n-text-color);
 }
 
 .ai-result-content :deep(h3) {
-  font-size: 16px;
-  font-weight: 600;
-  margin: 14px 0 8px 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  margin: var(--space-12) 0 var(--space-8) 0;
   color: var(--n-text-color);
 }
 
 .ai-result-content :deep(ul),
 .ai-result-content :deep(ol) {
-  padding-left: 24px;
-  margin: 10px 0;
+  padding-left: var(--space-24);
+  margin: var(--space-10) 0;
 }
 
 .ai-result-content :deep(li) {
-  margin: 8px 0;
+  margin: var(--space-8) 0;
   line-height: 1.8;
 }
 
 .ai-result-content :deep(p) {
-  margin: 10px 0;
+  margin: var(--space-10) 0;
 }
 
 .ai-result-content :deep(strong) {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--n-primary-color);
 }
 
 .ai-result-content :deep(mark) {
+  /* alpha-tinted gradient of --semantic-win，保留 rgba 以保证渐变层次 */
   background: linear-gradient(120deg, rgba(34, 197, 94, 0.2) 0%, rgba(34, 197, 94, 0.1) 100%);
-  color: #22c55e;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-weight: 600;
+  color: var(--semantic-win);
+  padding: var(--space-2) var(--space-8);
+  border-radius: var(--radius-xs);
+  font-weight: var(--font-weight-semibold);
 }
 
 .ai-result-content :deep(code) {
+  /* alpha-tinted gradient of --semantic-loss，保留 rgba 以保证渐变层次 */
   background: linear-gradient(120deg, rgba(239, 68, 68, 0.2) 0%, rgba(239, 68, 68, 0.1) 100%);
-  color: #ef4444;
-  padding: 2px 8px;
-  border-radius: 4px;
+  color: var(--semantic-loss);
+  padding: var(--space-2) var(--space-8);
+  border-radius: var(--radius-xs);
   font-family: inherit;
   font-size: inherit;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .ai-result-content :deep(blockquote) {
   border-left: 4px solid var(--n-border-color);
-  padding-left: 16px;
-  margin: 12px 0;
+  padding-left: var(--space-16);
+  margin: var(--space-12) 0;
   color: var(--n-text-color-3);
   font-style: italic;
 }
@@ -293,7 +295,7 @@ onMounted(async () => {
 .ai-result-content :deep(hr) {
   border: none;
   border-top: 2px solid var(--n-border-color);
-  margin: 16px 0;
+  margin: var(--space-16) 0;
 }
 
 .gaming-grid {

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -84,7 +84,7 @@ import { analyzeGameWithAIStream, type StreamCallbacks } from '@renderer/service
 import { useSessionSync } from '@renderer/composables/useSessionSync'
 import { useSessionTiers } from '@renderer/composables/useSessionTiers'
 
-const { sessionData } = useSessionSync()
+const { sessionData, requestSessionData } = useSessionSync()
 const tiersBySubteam = useSessionTiers(sessionData)
 
 const density = computed<'normal' | 'compact'>(() =>
@@ -123,7 +123,9 @@ const handleUpdateConfig = async (value: number | null) => {
   if (!value) return
   try {
     await putConfigByIpc('matchHistoryCount', value)
-    message.success('设置已保存')
+    // 立即重拉 session，让新 matchHistoryCount 立刻生效（无需等下局）
+    await requestSessionData()
+    message.success('设置已保存，已刷新当前对局数据')
   } catch (e) {
     message.error('保存失败')
   }

--- a/lol-record-analysis-tauri/src/views/MatchDetail.vue
+++ b/lol-record-analysis-tauri/src/views/MatchDetail.vue
@@ -5,7 +5,9 @@
       <button class="match-detail-window-close" type="button" @click="closeWindow">关闭</button>
     </div>
     <div class="match-detail-window-body">
-      <MatchDetailModal :game="game" />
+      <div class="match-detail-window-inner">
+        <MatchDetailModal :game="game" />
+      </div>
     </div>
   </div>
 </template>
@@ -68,6 +70,21 @@ function closeWindow() {
   background: var(--bg-base);
   display: flex;
   flex-direction: column;
+  /* 整页 font-size token override: 子组件用 var(--font-size-*) 自动随 viewport 缩放 (1100→2200) */
+  --font-size-2xs: clamp(10px, calc(10px + (100vw - 1100px) * 2 / 1100), 12px);
+  --font-size-xs: clamp(11px, calc(11px + (100vw - 1100px) * 2 / 1100), 13px);
+  --font-size-sm: clamp(12px, calc(12px + (100vw - 1100px) * 2 / 1100), 14px);
+  --font-size-base: clamp(13px, calc(13px + (100vw - 1100px) * 3 / 1100), 16px);
+  --font-size-md: clamp(14px, calc(14px + (100vw - 1100px) * 4 / 1100), 18px);
+  --font-size-lg: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
+  --font-size-xl: clamp(18px, calc(18px + (100vw - 1100px) * 5 / 1100), 23px);
+}
+
+/* 宽屏 (>1700) 时内容居中, 上限 1600 防过宽稀疏 */
+.match-detail-window-inner {
+  max-width: 1600px;
+  margin: 0 auto;
+  height: 100%;
 }
 
 .match-detail-window-bar {

--- a/lol-record-analysis-tauri/src/views/Record.vue
+++ b/lol-record-analysis-tauri/src/views/Record.vue
@@ -1,36 +1,26 @@
 <template>
-  <n-layout has-sider style="height: 100%" :collapsed="windowWidth < 500">
+  <n-layout has-sider style="height: 100%" :collapsed="isMobile">
     <n-layout-sider
-      :collapsed-width="windowWidth < 500 ? '100%' : undefined"
-      :width="windowWidth < 500 ? '100%' : undefined"
+      :collapsed-width="isMobile ? '100%' : undefined"
+      :width="isMobile ? '100%' : undefined"
     >
       <UserRecord></UserRecord>
     </n-layout-sider>
-    <n-layout-content class="record-content" style="flex: 3" v-show="windowWidth >= 500">
-      <div>
-        <MatchHistory />
-      </div>
-    </n-layout-content>
+    <Transition name="slide-fade" mode="out-in">
+      <n-layout-content v-if="!isMobile" class="record-content" style="flex: 3">
+        <div>
+          <MatchHistory />
+        </div>
+      </n-layout-content>
+    </Transition>
   </n-layout>
 </template>
 <script lang="ts" setup>
 import MatchHistory from '../components/record/MatchHistory.vue'
 import UserRecord from '../components/record/UserRecord.vue'
-import { ref, onMounted, onUnmounted } from 'vue'
+import { useBreakpoint } from '@renderer/composables/useBreakpoint'
 
-const windowWidth = ref(window.innerWidth)
-
-const updateWidth = () => {
-  windowWidth.value = window.innerWidth
-}
-
-onMounted(async () => {
-  window.addEventListener('resize', updateWidth)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('resize', updateWidth)
-})
+const { isMobile } = useBreakpoint()
 </script>
 <style scoped>
 .record-content {
@@ -47,5 +37,23 @@ onUnmounted(() => {
 :deep(.n-layout-sider .n-layout-scroll-container::-webkit-scrollbar),
 :deep(.n-layout-sider .n-scrollbar-container::-webkit-scrollbar) {
   display: none;
+}
+
+/* 内容区切换动画：右侧 MatchHistory 在断点切换时滑入/淡出 */
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition:
+    opacity var(--dur-normal) var(--ease-expo),
+    transform var(--dur-normal) var(--ease-expo);
+}
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  opacity: 0;
+  transform: translateX(16px);
+}
+
+/* sider 宽度过渡（手机/桌面之间的展开/收起动画） */
+:deep(.n-layout-sider) {
+  transition: width var(--dur-spring) var(--ease-expo);
 }
 </style>

--- a/lol-record-analysis-tauri/src/views/Record.vue
+++ b/lol-record-analysis-tauri/src/views/Record.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-layout has-sider style="height: 100%" :collapsed="isMobile">
+  <n-layout class="record-page" has-sider style="height: 100%" :collapsed="isMobile">
     <n-layout-sider
       :collapsed-width="isMobile ? '100%' : undefined"
       :width="isMobile ? '100%' : undefined"
@@ -23,6 +23,17 @@ import { useBreakpoint } from '@renderer/composables/useBreakpoint'
 const { isMobile } = useBreakpoint()
 </script>
 <style scoped>
+/* 整页 token 覆盖:所有子组件 var(--font-size-*) 自动跟随 viewport 缩放 (1100→2200) */
+.record-page {
+  --font-size-2xs: clamp(10px, calc(10px + (100vw - 1100px) * 2 / 1100), 12px);
+  --font-size-xs: clamp(11px, calc(11px + (100vw - 1100px) * 2 / 1100), 13px);
+  --font-size-sm: clamp(12px, calc(12px + (100vw - 1100px) * 2 / 1100), 14px);
+  --font-size-base: clamp(13px, calc(13px + (100vw - 1100px) * 3 / 1100), 16px);
+  --font-size-md: clamp(14px, calc(14px + (100vw - 1100px) * 4 / 1100), 18px);
+  --font-size-lg: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
+  --font-size-xl: clamp(18px, calc(18px + (100vw - 1100px) * 5 / 1100), 23px);
+}
+
 .record-content {
   padding: var(--space-20);
   padding-top: var(--space-16);

--- a/lol-record-analysis-tauri/src/views/Record.vue
+++ b/lol-record-analysis-tauri/src/views/Record.vue
@@ -8,7 +8,7 @@
     </n-layout-sider>
     <Transition name="slide-fade" mode="out-in">
       <n-layout-content v-if="!isMobile" class="record-content" style="flex: 3">
-        <div>
+        <div class="record-content-inner">
           <MatchHistory />
         </div>
       </n-layout-content>
@@ -26,6 +26,12 @@ const { isMobile } = useBreakpoint()
 .record-content {
   padding: var(--space-20);
   padding-top: var(--space-16);
+}
+
+/* 宽屏 (>1400) 时内容居中,上限 1280 防过宽稀疏 */
+.record-content-inner {
+  max-width: 1280px;
+  margin: 0 auto;
 }
 
 /* UserRecord 面板隐藏滚动条 */


### PR DESCRIPTION
## Summary

- **设计 token 体系收口**：补全字阶 / space-{2,6,10} / radius-{xs,pill} / win-loss 渐变，新增 `theme/overrides.ts` 工厂把 naive-ui 视觉接到我们的 token；清洗 Record / Gaming 全部 18+ 组件硬编码到 token
- **新公共能力**：`useBreakpoint` (md/lg)、`LazyImg` (shimmer 占位 + error fallback)、`RecordCardSkeleton`；MatchHistory 接入 skeleton / empty / error / 流式 skeleton
- **viewport 自适应**：Record / Gaming / MatchDetail 三页统一字号 token clamp + max-width 居中；icon / avatar / 字号随窗口宽度平滑缩放
- **MatchDetail 多轮迭代收尾在密集布局**：行 padding 8→4、icon 22→30→18→24、avatar 36→48→32→40、StatDots 5 圆点 → mini progress bar，单 team 高度显著收缩

## Test plan

- [x] `npm run check` 全绿（prettier + eslint + vue-tsc + cargo fmt + clippy -Dwarnings）
- [x] dark / light 主题切换无 token 漏接
- [x] viewport 1100→3000 平滑缩放（Record / Gaming / MatchDetail）
- [x] ARAM/CHERRY 海克斯模式 augment 渲染正常，经典模式符文渲染正常
- [x] matchHistoryCount 设置即时生效（之前 IPC Map wrapper 解析失败 fix）
- [x] PlayerHistoryGrid 不会被 KDA 大数字挤掉 queue 列（minmax(0,1fr) 修复）