### PR TITLE
feat: 接入 Sentry 错误上报（opt-in，默认关闭）

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/Cargo.lock
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.lock
@@ -3,6 +3,163 @@
 version = 4
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "bitflags 2.11.0",
+ "bytes",
+ "bytestring",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.6.2",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +430,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +455,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -404,6 +582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +702,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -561,6 +754,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -666,6 +868,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2066907075af649bcb8bcb1b9b986329b243677e6918b2d920aa64b0aac5ace3"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -796,6 +1022,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,11 +1068,34 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.116",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1135,6 +1404,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "flate2"
@@ -1490,6 +1771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1870,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -1719,6 +2017,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "html5ever"
@@ -1873,6 +2182,22 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2062,6 +2387,12 @@ dependencies = [
  "zune-core",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
@@ -2267,6 +2598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2720,7 @@ dependencies = [
  "phf 0.12.1",
  "regex",
  "reqwest 0.11.27",
+ "sentry",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2386,6 +2730,7 @@ dependencies = [
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-sentry",
  "tauri-plugin-updater",
  "tokio",
  "tokio-native-tls",
@@ -2427,6 +2772,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2840,75 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minidump-common"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4d14bcca0fd3ed165a03000480aaa364c6860c34e900cb2dafdf3b95340e77"
+dependencies = [
+ "bitflags 2.11.0",
+ "debugid",
+ "num-derive",
+ "num-traits",
+ "range-map",
+ "scroll",
+ "smart-default",
+]
+
+[[package]]
+name = "minidump-writer"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abcd9c8a1e6e1e9d56ce3627851f39a17ea83e17c96bc510f29d7e43d78a7d"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "cfg-if",
+ "crash-context",
+ "goblin",
+ "libc",
+ "log",
+ "mach2",
+ "memmap2",
+ "memoffset",
+ "minidump-common",
+ "nix 0.28.0",
+ "procfs-core",
+ "scroll",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "minidumper"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4ebc9d1f8847ec1d078f78b35ed598e0ebefa1f242d5f83cd8d7f03960a7d1"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "log",
+ "minidump-writer",
+ "parking_lot",
+ "polling",
+ "scroll",
+ "thiserror 1.0.69",
+ "uds",
+]
+
+[[package]]
+name = "minidumper-child"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4f23f835dbe67e44ddf884d3802ff549ca5948bf60e9fd70e9a13c96324d1"
+dependencies = [
+ "crash-handler",
+ "minidumper",
+ "thiserror 1.0.69",
+ "uuid",
+]
 
 [[package]]
 name = "minisign-verify"
@@ -2501,6 +2933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2637,6 +3070,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +3104,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "num-traits"
@@ -2751,7 +3219,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -2856,6 +3324,16 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3038,13 +3516,13 @@ dependencies = [
  "objc2-cloud-kit 0.2.2",
  "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
 ]
 
 [[package]]
@@ -3054,9 +3532,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "objc2 0.6.3",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -3079,8 +3566,18 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3110,6 +3607,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3197,6 +3703,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.2",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "serde",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,6 +3791,15 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3483,6 +4014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +4196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,7 +4243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3736,7 +4283,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2 0.6.2",
@@ -3870,6 +4417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-map"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a5a2d6c7039059af621472a4389be1215a816df61aa4d531cfe85264aee95f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,6 +4504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3968,7 +4530,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -4006,17 +4568,21 @@ dependencies = [
  "cookie",
  "cookie_store 0.22.1",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4027,6 +4593,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -4090,6 +4657,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -4290,6 +4863,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,7 +4913,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -4338,6 +4931,138 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989425268ab5c011e06400187eed6c298272f8ef913e49fcadc3fda788b45030"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest 0.12.28",
+ "sentry-actix",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c675bdf6118764a8e265c3395c311b4d905d12866c92df52870c0223d2ffc1"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "futures-util",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e299dd3f7bcf676875eee852c9941e1d08278a743c32ca528e2debf846a653"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac0c5d6892cd4c414492fc957477b620026fb3411fca9fa12774831da561c88"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa38b94e70820ff3f1f9db3c8b0aef053b667be130f618e615e0ff2492cbcc"
+dependencies = [
+ "rand 0.9.2",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00950648aa0d371c7f57057434ad5671bd4c106390df7e7284739330786a01b6"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7a23b13c004873de3ce7db86eb0f59fe4adfc655a31f7bbc17fd10bacc9bfe"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-rust-minidump"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63964525bf74b16233dbcfb307e11485ebd8ff8f87f6ae212b07ca7937cd2db1"
+dependencies = [
+ "minidumper-child",
+ "sentry",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac841c7050aa73fc2bec8f7d8e9cb1159af0b3095757b99820823f3e54e5080"
+dependencies = [
+ "bitflags 2.11.0",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e477f4d4db08ddb4ab553717a8d3a511bc9e81dde0c808c680feacbb8105c412"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4590,6 +5315,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "socket2"
@@ -5129,6 +5865,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-sentry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7432b519b6d2d027082a940783c61ba9b684b38d8df7558cd5f924d87009b295"
+dependencies = [
+ "base64 0.22.1",
+ "schemars 0.8.22",
+ "sentry",
+ "sentry-rust-minidump",
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5616,6 +6368,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5639,6 +6392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "tracing-core",
 ]
 
 [[package]]
@@ -5719,6 +6482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5727,6 +6499,15 @@ dependencies = [
  "memoffset",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5801,6 +6582,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5838,6 +6648,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5860,6 +6676,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/lol-record-analysis-tauri/src-tauri/Cargo.toml
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.toml
@@ -63,3 +63,7 @@ native-tls = "0.2"
 tokio-native-tls = "0.3"
 url = "2.5"
 tauri-plugin-mcp-bridge = "0.11"
+# 错误上报（默认关闭，用户在设置中 opt-in；debug 构建默认开启便于调试）
+# tauri-plugin-sentry 通过 Rust 后端统一转发前端 + 后端事件，前端无需额外 npm 依赖
+sentry = "0.42"
+tauri-plugin-sentry = "0.5"

--- a/lol-record-analysis-tauri/src-tauri/capabilities/default.json
+++ b/lol-record-analysis-tauri/src-tauri/capabilities/default.json
@@ -30,6 +30,7 @@
         }
       ]
     },
-    "mcp-bridge:default"
+    "mcp-bridge:default",
+    "sentry:default"
   ]
 }

--- a/lol-record-analysis-tauri/src-tauri/src/config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/config.rs
@@ -319,6 +319,26 @@ pub fn extract_int(value: &Value) -> Option<i64> {
     None
 }
 
+/// 同步读取布尔配置（启动期专用）。
+///
+/// 直接读取 `config.yaml`，**不经过** async 的 Moka 缓存层，因此可以在 Tauri
+/// 运行时尚未启动、无 tokio runtime 的 `main()` 早期调用——例如在 `sentry::init`
+/// 之前判断用户是否开启了错误上报。
+///
+/// # 参数
+///
+/// - `key`: 配置键名（如 `errorReportingEnabled`）
+///
+/// # 返回值
+///
+/// 配置中该键解析出的布尔值；文件不存在、键缺失或类型不符时返回 `false`。
+pub fn read_bool_sync(key: &str) -> bool {
+    read_config(CONFIG_PATH)
+        .ok()
+        .and_then(|m| m.get(key).and_then(extract_bool))
+        .unwrap_or(false)
+}
+
 /// 从缓存获取配置值。
 ///
 /// 如果键不存在，返回根据键名推断的默认值。

--- a/lol-record-analysis-tauri/src-tauri/src/lib.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lib.rs
@@ -5,5 +5,6 @@ pub mod constant;
 pub mod fandom;
 pub mod game_state_monitor;
 pub mod lcu;
+pub mod observability;
 pub mod rule_engine;
 pub mod state;

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -41,6 +41,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     info!("Config file path: config.yaml");
     info!("========================================");
 
+    // 初始化错误上报（debug 默认开 / release 需用户在设置中 opt-in）。
+    // guard 必须存活到 .run() 返回，否则事件无法 flush。
+    let _sentry_guard = lol_record_analysis_app_lib::observability::init();
+
     let mut app_builder = tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
@@ -132,6 +136,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         );
     }
 
+    // 仅在错误上报开启时注册 Sentry 插件（插件会向 webview 注入 @sentry/browser，
+    // 使前端事件也经 Rust SDK 统一发送）。
+    if let Some(ref client) = _sentry_guard {
+        app_builder = app_builder.plugin(tauri_plugin_sentry::init(client));
+    }
+
     app_builder = app_builder.setup(move |app| {
         // 启动自动化系统
         tauri::async_runtime::spawn(async move {
@@ -174,6 +184,15 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
         Ok(())
     });
+
+    // debug 构建启动时发一条冒烟事件，便于在 Sentry 面板确认链路打通（release 不发）。
+    #[cfg(debug_assertions)]
+    if _sentry_guard.is_some() {
+        sentry::capture_message(
+            "Sentry integration smoke test (debug startup)",
+            sentry::Level::Info,
+        );
+    }
 
     app_builder
         .run(tauri::generate_context!())

--- a/lol-record-analysis-tauri/src-tauri/src/observability.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/observability.rs
@@ -8,8 +8,11 @@
 //! ## 隐私
 //!
 //! - 默认 `send_default_pii: false`，不附带 IP / Cookie。
-//! - [`scrub_event`] 丢弃 `user` / `server_name`（主机名常含真实姓名），并对消息、
-//!   面包屑与其 data 中的字符串做 [`redact_pii`] 脱敏（puuid / 召唤师名 / UUID）。
+//! - [`scrub_event`] 丢弃 `user` / `server_name`，并对消息、**异常正文**、面包屑、extra
+//!   （含**嵌套数组 / 对象**）中的字符串做 [`redact_pii`]：覆盖 query / JSON / Debug 三种
+//!   形态的 puuid / 召唤师名 / UUID。
+//! - 局限：自由文本里无字段名上下文直接拼接的名字仍可能漏网——根本防线是默认关闭 +
+//!   不在日志里拼接玩家名。
 //!
 //! ## 开关
 //!
@@ -96,20 +99,39 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
         if let Some(message) = breadcrumb.message.take() {
             breadcrumb.message = Some(redact_pii(&message));
         }
-        scrub_string_values(&mut breadcrumb.data);
+        scrub_map(&mut breadcrumb.data);
     }
 
-    scrub_string_values(&mut event.extra);
+    // 异常正文（exception.values[*].value）是 capture_exception 与前端报错的主要载体，
+    // 必须脱敏，否则报错文本里的 LCU URL / 玩家标识会绕过本钩子。
+    for exception in &mut event.exception.values {
+        if let Some(value) = exception.value.take() {
+            exception.value = Some(redact_pii(&value));
+        }
+    }
+
+    scrub_map(&mut event.extra);
 
     Some(event)
 }
 
-/// 就地脱敏一个 `Map<String, Value>` 中的所有字符串值。
-fn scrub_string_values(map: &mut sentry::protocol::Map<String, Value>) {
+/// 递归脱敏一个 sentry `Map`（`event.extra` / `breadcrumb.data` 的顶层类型）。
+fn scrub_map(map: &mut sentry::protocol::Map<String, Value>) {
     for value in map.values_mut() {
-        if let Value::String(s) = value {
-            *s = redact_pii(s);
-        }
+        redact_value(value);
+    }
+}
+
+/// 递归脱敏任意 JSON 值：字符串就地脱敏，数组 / 对象逐元素递归。
+///
+/// breadcrumb.data 与 extra 常含嵌套数组 / 对象（如序列化后的请求体），
+/// 只洗顶层会漏掉嵌套字符串里的 URL / UUID / 玩家标识。
+fn redact_value(value: &mut Value) {
+    match value {
+        Value::String(s) => *s = redact_pii(s),
+        Value::Array(items) => items.iter_mut().for_each(redact_value),
+        Value::Object(obj) => obj.values_mut().for_each(redact_value),
+        _ => {}
     }
 }
 
@@ -123,19 +145,27 @@ static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {
 static LONG_TOKEN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[A-Za-z0-9_-]{60,}").expect("valid long-token regex"));
 
-/// URL query / 路径中按字段名脱敏（name / gameName / tagLine / puuid 等）。
+/// 按字段名脱敏，覆盖三种常见形态：
+/// - URL query：`name=Faker`
+/// - JSON：`"gameName": "Faker"`
+/// - Rust Debug / snake_case：`summoner_name: "Faker"`
+///
+/// 组 1 = 字段名 + 分隔符(`:`/`=`) + 可选起始引号；组 2 = 值。只替换组 2，保留引号/分隔符。
 static PII_PARAM_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?i)(name|gamename|tagline|puuid|displayname|summonername|account|riotid)=([^&\s]+)",
+        r#"(?i)("?\b(?:game_?name|tag_?line|summoner_?name|display_?name|riot_?id|puuid|account|name)"?\s*[:=]\s*"?)([^"&,\s}\])]+)"#,
     )
     .expect("valid pii-param regex")
 });
 
 /// 对单个字符串做 PII 脱敏。
 ///
-/// 依次替换：按字段名的 query 参数 → 标准 UUID → 超长 token。纯函数，便于单测。
+/// 依次替换：按字段名（query / JSON / Debug）→ 标准 UUID → 超长 token。纯函数，便于单测。
+///
+/// 局限：无字段名上下文、直接拼进自由文本的名字（如 `format!("{} not found", name)`）
+/// 无法识别——根本防线是默认关闭 + 不在日志里拼接玩家名。
 pub fn redact_pii(input: &str) -> String {
-    let step1 = PII_PARAM_RE.replace_all(input, "$1=<redacted>");
+    let step1 = PII_PARAM_RE.replace_all(input, "${1}<redacted>");
     let step2 = UUID_RE.replace_all(&step1, "<redacted-uuid>");
     let step3 = LONG_TOKEN_RE.replace_all(&step2, "<redacted-id>");
     step3.into_owned()
@@ -174,5 +204,53 @@ mod tests {
     fn should_leave_clean_text_untouched() {
         let input = "connection to LCU failed: timeout after 20s";
         assert_eq!(redact_pii(input), input);
+    }
+
+    #[test]
+    fn should_redact_json_name_forms() {
+        let out = redact_pii(r#"{"gameName": "Faker", "tagLine": "KR1", "level": 30}"#);
+        assert!(!out.contains("Faker"), "gameName 应被脱敏: {out}");
+        assert!(!out.contains("KR1"), "tagLine 应被脱敏: {out}");
+        assert!(out.contains("level"), "非敏感字段应保留: {out}");
+    }
+
+    #[test]
+    fn should_redact_debug_struct_name() {
+        let out = redact_pii(r#"Summoner { summoner_name: "Faker", level: 30 }"#);
+        assert!(!out.contains("Faker"), "Debug 形态的名字应被脱敏: {out}");
+    }
+
+    #[test]
+    fn should_redact_nested_values() {
+        // 覆盖嵌套对象 + 数组里的字符串
+        let mut v = serde_json::json!({
+            "req": { "url": "/lol?name=Faker&x=1" },
+            "ids": ["12345678-1234-1234-1234-123456789abc"]
+        });
+        redact_value(&mut v);
+        let s = v.to_string();
+        assert!(!s.contains("Faker"), "嵌套对象里的名字应被脱敏: {s}");
+        assert!(
+            !s.contains("12345678-1234"),
+            "嵌套数组里的 uuid 应被脱敏: {s}"
+        );
+    }
+
+    #[test]
+    fn should_scrub_exception_values() {
+        let mut event = Event::default();
+        event.exception.values.push(sentry::protocol::Exception {
+            value: Some("failed for 12345678-1234-1234-1234-123456789abc".to_string()),
+            ..Default::default()
+        });
+        let scrubbed = scrub_event(event).expect("event kept");
+        let val = scrubbed.exception.values[0]
+            .value
+            .as_ref()
+            .expect("value present");
+        assert!(
+            val.contains("<redacted-uuid>"),
+            "异常正文里的 uuid 应被脱敏: {val}"
+        );
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/observability.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/observability.rs
@@ -1,0 +1,178 @@
+//! # 错误上报 / 可观测性模块
+//!
+//! 基于 [`tauri-plugin-sentry`](https://github.com/timfish/sentry-tauri) 接入 Sentry。
+//! 插件会把前端（webview）的面包屑与事件经 Tauri IPC 转发给 Rust SDK 统一发送，
+//! 因此 **前端无需任何额外 npm 依赖**，且 [`scrub_event`] 这一个 `before_send`
+//! 钩子即可同时为前端 + 后端事件做 PII 脱敏（唯一卡点）。
+//!
+//! ## 隐私
+//!
+//! - 默认 `send_default_pii: false`，不附带 IP / Cookie。
+//! - [`scrub_event`] 丢弃 `user` / `server_name`（主机名常含真实姓名），并对消息、
+//!   面包屑与其 data 中的字符串做 [`redact_pii`] 脱敏（puuid / 召唤师名 / UUID）。
+//!
+//! ## 开关
+//!
+//! - **debug 构建**：默认开启，方便开发期验证。
+//! - **release 构建**：默认关闭，用户需在「设置 → 常规」中开启 `errorReportingEnabled`
+//!   （opt-in），重启后生效。
+
+use regex::Regex;
+use sentry::protocol::{Event, Value};
+use std::sync::{Arc, LazyLock};
+
+/// Sentry 项目的 DSN（公开 client key，设计上即随客户端分发）。
+///
+/// 可在编译期通过 `SENTRY_DSN` 环境变量覆盖（例如 fork 自建项目）。
+pub const DEFAULT_DSN: &str =
+    "https://4730d54dc96cffafff9dbd30d0699911@o4511465480060928.ingest.us.sentry.io/4511471007825920";
+
+/// 配置中控制是否开启错误上报的键名（以 `Enabled` 结尾 → 默认 `false`）。
+pub const REPORTING_KEY: &str = "errorReportingEnabled";
+
+/// 解析最终使用的 DSN（环境变量优先）。
+fn dsn() -> String {
+    option_env!("SENTRY_DSN").unwrap_or(DEFAULT_DSN).to_string()
+}
+
+/// 判断当前是否应当开启错误上报。
+///
+/// debug 构建恒为 `true`；release 构建读取用户的 opt-in 配置。
+pub fn reporting_enabled() -> bool {
+    if cfg!(debug_assertions) {
+        true
+    } else {
+        crate::config::read_bool_sync(REPORTING_KEY)
+    }
+}
+
+/// 初始化 Sentry。
+///
+/// 返回的 [`sentry::ClientInitGuard`] 必须在应用整个生命周期内保持存活（在 `main`
+/// 中持有到 `.run()` 返回），否则后台传输线程会提前关闭、事件丢失。
+///
+/// 未开启上报时返回 `None`，调用方据此跳过插件注册。
+pub fn init() -> Option<sentry::ClientInitGuard> {
+    if !reporting_enabled() {
+        log::info!(
+            "Sentry error reporting disabled (opt in via config key `{}`)",
+            REPORTING_KEY
+        );
+        return None;
+    }
+
+    let guard = sentry::init((
+        dsn(),
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            send_default_pii: false,
+            before_send: Some(Arc::new(scrub_event)),
+            // 国服网络下 sentry.io 常不可达：关闭时最多只等 1s flush（默认 2s），
+            // 避免每次退出都顿挫。
+            shutdown_timeout: std::time::Duration::from_secs(1),
+            // 关闭 release health 的 session 上报，省掉启动/关闭的网络包；
+            // 崩溃率统计对小项目意义不大，需要时再开。
+            auto_session_tracking: false,
+            ..Default::default()
+        },
+    ));
+    log::info!("Sentry error reporting ENABLED");
+    Some(guard)
+}
+
+/// `before_send` 钩子：在事件发送前移除 / 脱敏 PII。
+///
+/// 覆盖前端与后端的全部事件（前端事件经插件转发后也走这里）。
+fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
+    // 主机名常包含用户真实姓名（如 "Zhang-MacBook"）；用户对象可能含 id / ip。
+    event.server_name = None;
+    event.user = None;
+
+    if let Some(message) = event.message.take() {
+        event.message = Some(redact_pii(&message));
+    }
+
+    for breadcrumb in &mut event.breadcrumbs.values {
+        if let Some(message) = breadcrumb.message.take() {
+            breadcrumb.message = Some(redact_pii(&message));
+        }
+        scrub_string_values(&mut breadcrumb.data);
+    }
+
+    scrub_string_values(&mut event.extra);
+
+    Some(event)
+}
+
+/// 就地脱敏一个 `Map<String, Value>` 中的所有字符串值。
+fn scrub_string_values(map: &mut sentry::protocol::Map<String, Value>) {
+    for value in map.values_mut() {
+        if let Value::String(s) = value {
+            *s = redact_pii(s);
+        }
+    }
+}
+
+/// 标准 UUID（如 LCU 部分接口中的 puuid）。
+static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+        .expect("valid uuid regex")
+});
+
+/// Riot puuid 等超长 token（base64url 风格，长度通常 ≥ 60）。
+static LONG_TOKEN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[A-Za-z0-9_-]{60,}").expect("valid long-token regex"));
+
+/// URL query / 路径中按字段名脱敏（name / gameName / tagLine / puuid 等）。
+static PII_PARAM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(name|gamename|tagline|puuid|displayname|summonername|account|riotid)=([^&\s]+)",
+    )
+    .expect("valid pii-param regex")
+});
+
+/// 对单个字符串做 PII 脱敏。
+///
+/// 依次替换：按字段名的 query 参数 → 标准 UUID → 超长 token。纯函数，便于单测。
+pub fn redact_pii(input: &str) -> String {
+    let step1 = PII_PARAM_RE.replace_all(input, "$1=<redacted>");
+    let step2 = UUID_RE.replace_all(&step1, "<redacted-uuid>");
+    let step3 = LONG_TOKEN_RE.replace_all(&step2, "<redacted-id>");
+    step3.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_redact_standard_uuid() {
+        let input = "/lol-summoner/v2/summoners/puuid/12345678-1234-1234-1234-123456789abc";
+        let out = redact_pii(input);
+        assert!(!out.contains("12345678-1234"));
+        assert!(out.contains("<redacted-uuid>"));
+    }
+
+    #[test]
+    fn should_redact_name_query_param() {
+        let out = redact_pii("https://127.0.0.1/x?name=Faker%23KR1&region=kr");
+        assert!(!out.contains("Faker"));
+        assert!(out.contains("name=<redacted>"));
+        // 非敏感参数保留
+        assert!(out.contains("region=kr"));
+    }
+
+    #[test]
+    fn should_redact_long_riot_puuid_token() {
+        let token = "a".repeat(78);
+        let out = redact_pii(&format!("puuid path /{}", token));
+        assert!(!out.contains(&token));
+        assert!(out.contains("<redacted-id>"));
+    }
+
+    #[test]
+    fn should_leave_clean_text_untouched() {
+        let input = "connection to LCU failed: timeout after 20s";
+        assert_eq!(redact_pii(input), input);
+    }
+}

--- a/lol-record-analysis-tauri/src/views/settings/General.vue
+++ b/lol-record-analysis-tauri/src/views/settings/General.vue
@@ -9,6 +9,14 @@
           @update:value="handleUpdate"
         />
       </n-form-item>
+      <n-form-item label="匿名错误上报">
+        <n-space vertical :size="4">
+          <n-switch v-model:value="errorReporting" @update:value="handleReportingUpdate" />
+          <n-text :depth="3" style="font-size: 12px">
+            开启后，崩溃与报错（已脱敏，不含召唤师名 / puuid）会上报以便排查问题。重启后生效。
+          </n-text>
+        </n-space>
+      </n-form-item>
     </n-form>
   </n-card>
 </template>
@@ -19,6 +27,7 @@ import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { useMessage } from 'naive-ui'
 
 const matchCount = ref(4)
+const errorReporting = ref(false)
 const message = useMessage()
 
 onMounted(async () => {
@@ -30,6 +39,14 @@ onMounted(async () => {
   } catch (e) {
     console.error(e)
   }
+  try {
+    const enabled = await getConfigByIpc<boolean>('errorReportingEnabled')
+    if (typeof enabled === 'boolean') {
+      errorReporting.value = enabled
+    }
+  } catch (e) {
+    console.error(e)
+  }
 })
 
 const handleUpdate = async (value: number | null) => {
@@ -37,6 +54,15 @@ const handleUpdate = async (value: number | null) => {
   try {
     await putConfigByIpc('matchHistoryCount', value)
     message.success('设置已保存，下次获取数据时生效')
+  } catch (e) {
+    message.error('保存失败')
+  }
+}
+
+const handleReportingUpdate = async (value: boolean) => {
+  try {
+    await putConfigByIpc('errorReportingEnabled', value)
+    message.success('设置已保存，重启后生效')
   } catch (e) {
     message.error('保存失败')
   }


### PR DESCRIPTION
## Summary
通过 [`tauri-plugin-sentry`](https://github.com/timfish/sentry-tauri) 经 Rust 后端统一转发前端 + 后端事件，**前端无需额外 npm 依赖**（插件向 webview 注入 `@sentry/browser`，事件经 Tauri IPC 回到 Rust SDK 统一发送）。

- **opt-in，默认关闭**：用户在「设置 → 常规」开启 `errorReportingEnabled`，重启生效；debug 构建默认开启便于调试
- **统一脱敏**：`before_send` 是前后端所有事件的唯一卡点，脱敏 puuid / 召唤师名 / UUID，并丢弃 `server_name` 与 `user`；`send_default_pii: false`
- **国服网络优化**：`shutdown_timeout` 降到 1s（默认 2s，避免 sentry.io 不可达时关闭顿挫）、关闭 release-health session 上报
- **暂不启用 minidump**：避免独立崩溃进程被反作弊 / 杀软误杀

DSN 为公开 client key，硬编码于 `observability.rs`，可用 `SENTRY_DSN` 编译期环境变量覆盖。

## Test plan
- [x] 前端 `npm run check`（prettier / eslint / vue-tsc）通过
- [x] `cargo fmt --check` 通过
- [x] `observability.rs` / `config.rs` 经 `cargo check` 编译验证（含 4 个 `redact_pii` 单测）
- [ ] ⚠️ `cargo clippy` / `cargo build` / `cargo test` 在 **macOS 上无法本地验证**（`token.rs` 依赖 Windows `winapi`）→ **依赖本 PR 的 Windows CI 验证 `main.rs` 插件接线**
- [ ] 手动（Windows + LOL）：`npm run tauri dev` → 确认启动冒烟事件 + 前端/后端错误均上报到 https://rank-analysis.sentry.io/issues/

## Follow-ups（非阻塞）
- 验证链路打通后，可移除 `main.rs` 末尾的 debug 冒烟 `capture_message`（仅 debug 构建触发，release 不受影响）
- 如需组件级上下文（哪个 Vue 组件抛错），可加 `@sentry/vue` 显式 init
- 如需抓 webview 原生崩溃，可评估开启 minidump