### PR TITLE
feat: 玩家备注与遇见记录，及 Sentry 首次同意弹窗

### DIFF
--- a/docs/superpowers/specs/2026-05-29-player-notes-and-sentry-consent-design.md
+++ b/docs/superpowers/specs/2026-05-29-player-notes-and-sentry-consent-design.md
@@ -1,0 +1,137 @@
+# 玩家备注 + Sentry 首次同意弹窗 设计
+
+日期: 2026-05-29
+关联: issue #67(标记玩家)、commit 6163f86(Sentry opt-in)
+
+## Context（为什么做）
+
+两个独立但相关的需求：
+
+1. **玩家备注（issue #67）**：用户希望给碰到过的人留"备注 + 颜色标记"（友好 / 一般 / 小心 / 拉黑），
+   在对局玩家卡和玩家详情页都能看到，并能在设置里集中管理。社区讨论结论是
+   **单机本地版即可**（区里人少、常遇到重复的人，留个提醒就够，不追求"挂人"共享）。
+
+2. **Sentry 首次同意弹窗**：#70 已接入 opt-in 错误上报（release 默认关闭）。
+   现在没有任何首次提示，用户不知道这功能存在。目标是**提高透明度并适度抬高开启率**，
+   做法是首次启动弹一次说明 + 默认推荐启用，但**保留真实拒绝、不强制**。
+
+两个功能都**零 Rust 改动**：存储复用现有 `config` IPC，不新增 Tauri command、不碰 `config.rs`。
+
+## 设计一：玩家备注
+
+### 数据模型
+
+新建 `src/types/domain/playerNote.ts`：
+
+```ts
+export type NoteLabel = 'friendly' | 'normal' | 'careful' | 'blacklist'
+
+export interface PlayerNote {
+  note: string        // 备注文本，可为空（只标颜色不写字）
+  label: NoteLabel
+  gameName: string    // 冗余存一份，用于设置列表展示（puuid 不可读）
+  tagLine: string
+  updatedAt: number   // 毫秒时间戳
+}
+```
+
+存储：复用 config 系统，key = `"playerNotes"`，值为 `Record<puuid, PlayerNote>`。
+通过现有 `putConfigByIpc('playerNotes', map)` / `getConfigByIpc('playerNotes')`（`src/services/ipc.ts`）。
+
+### 状态层
+
+新建 Pinia store `src/pinia/playerNotes.ts`（仿 `src/pinia/setting.ts` 结构）：
+
+- `notes: Ref<Record<string, PlayerNote>>` 内存副本
+- `init()`：从 `getConfigByIpc('playerNotes')` 载入，由 `main.ts` 启动时调用（仿 `initTheme()`）
+- `getNote(puuid): PlayerNote | undefined`
+- `setNote(puuid, { note, label, gameName, tagLine })`：写内存 + 整体 `putConfigByIpc` 落盘 + 盖 `updatedAt`
+- `removeNote(puuid)`：删内存 + 落盘
+
+组件只读 store / 调 store 方法，**不直接碰 IPC**。
+
+### 颜色映射（纯函数，可测）
+
+在 `playerNote.ts` 导出 `NOTE_LABELS`（含 `value / text / naiveType / cssVar`）：
+
+| label | 文案 | 颜色（复用现有 CSS 变量） | naive type |
+|---|---|---|---|
+| friendly | 友好 | `--semantic-win`（绿） | success |
+| normal | 一般 | 默认灰 | default |
+| careful | 小心 | warning（橙） | warning |
+| blacklist | 拉黑 | `--semantic-loss`（红） | error |
+
+### 展示组件
+
+新建 `src/components/common/PlayerNoteBadge.vue`（props: `puuid`, `gameName`, `tagLine`, 可选 `size`）：
+
+- **有备注**：显示对应颜色的小色块/圆点 + `n-popover`，hover/点击弹出备注文字 + 「编辑」入口。
+- **无备注**：显示一个淡色"加备注"小图标按钮。
+- **编辑态**：`n-popover` 内嵌四档颜色选择（`n-radio-group` 或色块按钮）+ `n-input` 文本框 + 保存/删除。
+  不再单开 modal，就地编辑。
+- 保存时调 `store.setNote(puuid, ...)`，把 `gameName/tagLine` 一起传入用于列表展示。
+
+### 接入点
+
+- `src/components/gaming/PlayerCard.vue`：在复制按钮（L74 附近）旁放一个 `<PlayerNoteBadge>`。
+- `src/components/record/UserRecord.vue`：在复制按钮（L21 附近）旁放一个 `<PlayerNoteBadge>`。
+
+### 设置页：我标记过的人
+
+- `src/views/settings/PlayerNotes.vue`（新页面，仿 `Tags.vue` 的 `n-data-table`）：
+  列出 名字#tag、颜色标签（`n-tag`）、备注、更新时间、删除按钮（`n-popconfirm`）。
+  空状态友好提示。
+- `src/views/Settings.vue`：`menuOptions` 加一项 `{ label: '我标记过的人', key: 'PlayerNotes', icon: ... }`。
+- `src/router/index.ts`：`/Settings` children 加 `PlayerNotes` 路由。
+
+### 已知局限（写进 README/CHANGELOG）
+
+纯本地存储，换机 / 重装会丢失，无法跨设备同步。冗余存 `gameName/tagLine` 仅供展示，
+玩家改名后列表可能显示旧名（备注仍按 puuid 生效）。
+
+## 设计二：Sentry 首次同意弹窗
+
+### 保持现状
+
+`errorReportingEnabled` 默认 false 不变；`General.vue` 的开关不动。
+
+### 新增配置键
+
+`"errorReportingConsentShown"`（非自动默认键，读出 `undefined` 即视为"未问过"）。
+
+### 首次弹窗逻辑
+
+在 `src/components/Framework.vue` 的 `onMounted` 中（已能用 `currentWindow.label` 排除
+`match-detail-` 子窗口，避免多窗口重复弹）：
+
+1. 若是 `match-detail-` 子窗口 → 跳过。
+2. `getConfigByIpc('errorReportingConsentShown')`，已问过 → 跳过。
+3. 未问过 → `useDialog().info(...)`：
+   - 标题：「帮助改进应用？」
+   - 正文（利己 + 开源可查 + 脱敏清单，3 行内）：
+     说明仅上报已脱敏的崩溃/报错堆栈，**不含**召唤师名 / puuid / 对局数据；
+     本项目开源，上报内容可在代码中查看；默认关闭，随时可在设置→常规修改。
+   - **正向按钮（primary、强调，预选效果）**：「好，帮忙改进」→ `putConfigByIpc('errorReportingEnabled', true)`，提示重启生效。
+   - **否定按钮（中性、真实可点）**：「不，保持关闭」→ 不改 enabled。**不使用 confirmshaming 文案。**
+   - 两个分支都写 `putConfigByIpc('errorReportingConsentShown', true)`，永久不再弹。
+   - `closable: false` / `maskClosable: false` / `closeOnEsc: false`：逼用户明确二选一（否则下次还弹）。
+
+### 不做
+
+- 不做"出错时弹 / N 天后 banner 轻推"——ROI 最低、状态最多、最难维护。
+- 不做预勾选 + 强制同意（不让用就退出）——非必要功能不该当门票，开源项目尤其招黑，且是 #70 的回退。
+- "预选"仅通过**正向按钮强调 + 默认推荐启用**实现，不剥夺真实拒绝权。
+
+## 测试
+
+- `src/pinia/__tests__/playerNotes.spec.ts`：mock IPC，测 set/get/remove + 落盘调用 + updatedAt。
+- `src/types/domain/__tests__/playerNote.spec.ts`（或并入上）：测 `NOTE_LABELS` 映射完整。
+- 组件层依赖 naive-ui，优先保证 store/纯函数覆盖；UI 用运行中客户端 + Tauri MCP 手动验证。
+
+## 验证（端到端）
+
+1. `cd lol-record-analysis-tauri && npm run check && npm run test` 全绿。
+2. LoL 客户端运行下，借 Tauri MCP（webview 截图/交互）验证：
+   - 对局卡 / 详情页能加备注、选颜色、看到色块、编辑、删除。
+   - 设置「我标记过的人」列表正确展示与删除。
+   - 首启弹窗：选「启用」后 `errorReportingEnabled=true`；选「不」后保持 false；二者都不再弹。

--- a/lol-record-analysis-tauri/src/components/Framework.vue
+++ b/lol-record-analysis-tauri/src/components/Framework.vue
@@ -145,13 +145,14 @@ function revealConsent(): void {
  */
 async function onConsentDecide(enabled: boolean): Promise<void> {
   showConsent.value = false
-  if (enabled) {
-    try {
-      await putConfigByIpc('errorReportingEnabled', true)
-      message.success('已开启，重启后生效')
-    } catch {
-      message.error('保存失败')
-    }
+  try {
+    // 无论"启用"还是"保持关闭"，都把用户的明确选择持久化到 errorReportingEnabled。
+    // 否则当用户此前已在设置里开过（配置为 true）时，点"保持关闭"不会真正关掉，
+    // 与按钮文案不符。
+    await putConfigByIpc('errorReportingEnabled', enabled)
+    if (enabled) message.success('已开启，重启后生效')
+  } catch {
+    message.error('保存失败')
   }
   putConfigByIpc('errorReportingConsentShown', true).catch(() => {})
 }

--- a/lol-record-analysis-tauri/src/components/Framework.vue
+++ b/lol-record-analysis-tauri/src/components/Framework.vue
@@ -2,6 +2,7 @@
   <div class="full-container">
     <MatchDetail v-if="isStandaloneDetailWindow" />
     <n-flex v-else vertical size="large">
+      <ErrorReportingConsentDialog v-model:show="showConsent" @decide="onConsentDecide" />
       <!-- 整体布局 -->
       <n-layout>
         <!-- 顶部区域 -->
@@ -31,14 +32,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { getCurrentWindow } from '@tauri-apps/api/window'
+import { useMessage } from 'naive-ui'
 
 import Header from './Header.vue'
 import SideNavigation from './SideNavigation.vue'
 import MatchDetail from '@renderer/views/MatchDetail.vue'
+import ErrorReportingConsentDialog from '@renderer/components/common/ErrorReportingConsentDialog.vue'
 import { useGameState } from '@renderer/composables/useGameState'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 
 /**
  * 应用主布局框架组件
@@ -76,10 +80,84 @@ const isStandaloneDetailWindow = computed(() => currentWindow.label.startsWith('
  * 初始化游戏状态监听
  * 包含自动跳转逻辑：当检测到游戏开始时自动切换到对局页面
  */
-useGameState()
+const { isConnected } = useGameState()
+
+const message = useMessage()
+
+/** 是否展示错误上报首次同意弹窗 */
+const showConsent = ref(false)
+
+/** 防止"连接事件"与"兜底超时"重复弹窗 */
+let consentRevealed = false
+
+/**
+ * 首次启动征求错误上报同意。
+ *
+ * Sentry 上报本身默认关闭（opt-in）；此弹窗只在首次启动出现一次，提高透明度并
+ * 默认推荐启用，但保留真实的"保持关闭"选项、不强制。仅主窗口弹，排除 match-detail
+ * 子窗口。UI 见 {@link ErrorReportingConsentDialog}。
+ *
+ * 关键：**不在首屏加载阶段弹**。首屏（Record）依赖客户端连接事件跳转并拉取数据，
+ * 若此时弹模态框会打断首屏的关键路径、让人误以为"弹窗导致加载失败"。因此这里等
+ * `isConnected`（客户端已连、首屏就绪）后再延时弹出；若长时间未连接则兜底弹出，
+ * 避免永远问不到。
+ *
+ * @see commit 6163f86（Sentry opt-in 接入）
+ */
+async function maybeAskErrorReportingConsent(): Promise<void> {
+  if (isStandaloneDetailWindow.value) return
+  try {
+    const shown = await getConfigByIpc<boolean>('errorReportingConsentShown')
+    if (shown) return
+  } catch {
+    // 读不到配置时按"未问过"处理
+  }
+
+  if (isConnected.value) {
+    revealConsent()
+    return
+  }
+  // 等首屏就绪后再弹；最多兜底等待 8s
+  const stop = watch(isConnected, connected => {
+    if (connected) {
+      stop()
+      revealConsent()
+    }
+  })
+  window.setTimeout(() => {
+    stop()
+    revealConsent()
+  }, 8000)
+}
+
+/** 首屏稳定后再弹（留 500ms 让首屏渲染/动画落定），仅弹一次 */
+function revealConsent(): void {
+  if (consentRevealed) return
+  consentRevealed = true
+  window.setTimeout(() => {
+    showConsent.value = true
+  }, 500)
+}
+
+/**
+ * 处理用户在同意弹窗中的选择。无论选择什么都标记"已问过"，之后不再弹。
+ * @param enabled - true 启用上报，false 保持关闭
+ */
+async function onConsentDecide(enabled: boolean): Promise<void> {
+  showConsent.value = false
+  if (enabled) {
+    try {
+      await putConfigByIpc('errorReportingEnabled', true)
+      message.success('已开启，重启后生效')
+    } catch {
+      message.error('保存失败')
+    }
+  }
+  putConfigByIpc('errorReportingConsentShown', true).catch(() => {})
+}
 
 onMounted(() => {
-  // Framework mounted
+  maybeAskErrorReportingConsent()
 })
 
 /**

--- a/lol-record-analysis-tauri/src/components/Framework.vue
+++ b/lol-record-analysis-tauri/src/components/Framework.vue
@@ -43,6 +43,7 @@ import MatchDetail from '@renderer/views/MatchDetail.vue'
 import ErrorReportingConsentDialog from '@renderer/components/common/ErrorReportingConsentDialog.vue'
 import { useGameState } from '@renderer/composables/useGameState'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { CONFIG_KEYS } from '@renderer/services/configKeys'
 
 /**
  * 应用主布局框架组件
@@ -107,7 +108,7 @@ let consentRevealed = false
 async function maybeAskErrorReportingConsent(): Promise<void> {
   if (isStandaloneDetailWindow.value) return
   try {
-    const shown = await getConfigByIpc<boolean>('errorReportingConsentShown')
+    const shown = await getConfigByIpc<boolean>(CONFIG_KEYS.errorReportingConsentShown)
     if (shown) return
   } catch {
     // 读不到配置时按"未问过"处理
@@ -149,12 +150,12 @@ async function onConsentDecide(enabled: boolean): Promise<void> {
     // 无论"启用"还是"保持关闭"，都把用户的明确选择持久化到 errorReportingEnabled。
     // 否则当用户此前已在设置里开过（配置为 true）时，点"保持关闭"不会真正关掉，
     // 与按钮文案不符。
-    await putConfigByIpc('errorReportingEnabled', enabled)
+    await putConfigByIpc(CONFIG_KEYS.errorReportingEnabled, enabled)
     if (enabled) message.success('已开启，重启后生效')
   } catch {
     message.error('保存失败')
   }
-  putConfigByIpc('errorReportingConsentShown', true).catch(() => {})
+  putConfigByIpc(CONFIG_KEYS.errorReportingConsentShown, true).catch(() => {})
 }
 
 onMounted(() => {

--- a/lol-record-analysis-tauri/src/components/common/ErrorReportingConsentDialog.vue
+++ b/lol-record-analysis-tauri/src/components/common/ErrorReportingConsentDialog.vue
@@ -1,0 +1,274 @@
+<template>
+  <n-modal
+    :show="show"
+    :mask-closable="false"
+    :close-on-esc="false"
+    transform-origin="center"
+    @update:show="$emit('update:show', $event)"
+  >
+    <div class="consent-card" role="dialog" aria-labelledby="consent-title">
+      <!-- 顶部柔光 -->
+      <div class="consent-glow" aria-hidden="true" />
+
+      <!-- 图标光环 -->
+      <div class="consent-icon-halo">
+        <n-icon class="consent-icon"><ShieldCheckmarkOutline /></n-icon>
+      </div>
+
+      <h2 id="consent-title" class="consent-title">帮助改进应用？</h2>
+      <p class="consent-lead">崩溃和报错自动上报，让我能更快修掉你遇到的问题。</p>
+
+      <!-- 隐私要点 -->
+      <ul class="consent-points">
+        <li class="consent-point" style="--i: 0">
+          <span class="consent-point-icon"
+            ><n-icon><LockClosedOutline /></n-icon
+          ></span>
+          <span class="consent-point-text">
+            <span class="consent-point-title">只发报错堆栈</span>
+            <span class="consent-point-sub">不含召唤师名 / puuid / 任何对局数据</span>
+          </span>
+        </li>
+        <li class="consent-point" style="--i: 1">
+          <span class="consent-point-icon"
+            ><n-icon><CodeSlashOutline /></n-icon
+          ></span>
+          <span class="consent-point-text">
+            <span class="consent-point-title">开源可查</span>
+            <span class="consent-point-sub">上报了什么，代码里都能看到</span>
+          </span>
+        </li>
+        <li class="consent-point" style="--i: 2">
+          <span class="consent-point-icon"
+            ><n-icon><ToggleOutline /></n-icon
+          ></span>
+          <span class="consent-point-text">
+            <span class="consent-point-title">默认关闭，随时可关</span>
+            <span class="consent-point-sub">设置 → 常规设置 里随时改</span>
+          </span>
+        </li>
+      </ul>
+
+      <div class="consent-actions">
+        <n-button class="consent-btn-ghost" size="medium" @click="$emit('decide', false)">
+          不，保持关闭
+        </n-button>
+        <n-button
+          type="primary"
+          size="medium"
+          class="consent-btn-primary"
+          @click="$emit('decide', true)"
+        >
+          好，帮忙改进
+        </n-button>
+      </div>
+    </div>
+  </n-modal>
+</template>
+
+<script setup lang="ts">
+/**
+ * 错误上报首次同意弹窗（视觉组件）
+ *
+ * 只负责展示与发出用户选择，不读写配置——由父组件（Framework）持久化。
+ * 视觉风格对齐应用的玻璃暗色 + 绿色品牌调，强调"隐私可控 / 开源透明"的信任感。
+ *
+ * @see commit 6163f86（Sentry opt-in 接入）
+ */
+import { NModal, NIcon, NButton } from 'naive-ui'
+import {
+  ShieldCheckmarkOutline,
+  LockClosedOutline,
+  CodeSlashOutline,
+  ToggleOutline
+} from '@vicons/ionicons5'
+
+defineProps<{
+  /** 是否显示 */
+  show: boolean
+}>()
+
+defineEmits<{
+  /** 受控显隐 */
+  (e: 'update:show', value: boolean): void
+  /** 用户选择：true = 启用上报，false = 保持关闭 */
+  (e: 'decide', enabled: boolean): void
+}>()
+</script>
+
+<style scoped>
+.consent-card {
+  position: relative;
+  width: 408px;
+  max-width: calc(100vw - 48px);
+  padding: var(--space-28, 28px) var(--space-24, 24px) var(--space-24, 24px);
+  background: var(--bg-surface, #141418);
+  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.09));
+  border-radius: var(--radius-xl, 16px);
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.55));
+  overflow: hidden;
+  animation: consent-pop var(--dur-normal, 0.28s) var(--ease-expo, cubic-bezier(0.16, 1, 0.3, 1))
+    both;
+}
+
+/* 顶部品牌柔光 */
+.consent-glow {
+  position: absolute;
+  top: -90px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 260px;
+  height: 180px;
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in srgb, var(--semantic-win) 26%, transparent) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.consent-icon-halo {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto var(--space-16, 16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--semantic-win) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--semantic-win) 36%, transparent);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--semantic-win) 7%, transparent);
+  animation: consent-halo var(--dur-slow, 0.45s) var(--ease-expo, cubic-bezier(0.16, 1, 0.3, 1))
+    both;
+}
+.consent-icon {
+  font-size: 28px;
+  color: var(--semantic-win);
+}
+
+.consent-title {
+  margin: 0 0 var(--space-6, 6px);
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  color: var(--text-primary);
+}
+.consent-lead {
+  margin: 0 auto var(--space-20, 20px);
+  max-width: 320px;
+  text-align: center;
+  font-size: var(--font-size-base, 13px);
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.consent-points {
+  list-style: none;
+  margin: 0 0 var(--space-24, 24px);
+  padding: var(--space-12, 12px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12, 12px);
+  background: var(--glass-bg-low, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.09));
+  border-radius: var(--radius-lg, 12px);
+}
+.consent-point {
+  display: flex;
+  align-items: center;
+  gap: var(--space-10, 10px);
+  animation: consent-rise var(--dur-normal, 0.28s) var(--ease-expo, cubic-bezier(0.16, 1, 0.3, 1))
+    both;
+  animation-delay: calc(0.06s * var(--i) + 0.1s);
+}
+.consent-point-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md, 8px);
+  background: color-mix(in srgb, var(--semantic-win) 12%, transparent);
+  color: var(--semantic-win);
+  font-size: 16px;
+}
+.consent-point-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.consent-point-title {
+  font-size: var(--font-size-base, 13px);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.consent-point-sub {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+
+.consent-actions {
+  display: flex;
+  gap: var(--space-10, 10px);
+}
+.consent-btn-ghost,
+.consent-btn-primary {
+  flex: 1;
+  height: 38px;
+  font-weight: 600;
+  border-radius: var(--radius-md, 8px);
+}
+/* 否定项：真实可点的中性按钮，不弱化到看不见，但不与主操作争视觉 */
+.consent-btn-ghost {
+  background: var(--glass-bg-low, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.12));
+}
+.consent-btn-primary {
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--semantic-win) 30%, transparent);
+}
+
+@keyframes consent-pop {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes consent-halo {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes consent-rise {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* 降低动态偏好时关闭入场动画 */
+@media (prefers-reduced-motion: reduce) {
+  .consent-card,
+  .consent-icon-halo,
+  .consent-point {
+    animation: none;
+  }
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/common/PlayerNoteBadge.vue
+++ b/lol-record-analysis-tauri/src/components/common/PlayerNoteBadge.vue
@@ -1,0 +1,339 @@
+<template>
+  <n-popover
+    trigger="click"
+    placement="bottom-start"
+    :show="show"
+    :style="{ padding: '0' }"
+    @update:show="onToggle"
+  >
+    <template #trigger>
+      <!-- 有备注：彩色圆点（hover 微亮）；无备注：淡色"加备注"图标 -->
+      <button
+        class="note-trigger"
+        :class="{ 'has-note': hasNote, [`size-${size}`]: true }"
+        :title="hasNote ? `${meta.text}${note!.note ? '：' + note!.note : ''}` : '添加备注'"
+        type="button"
+      >
+        <span v-if="hasNote" class="note-dot" :style="{ background: meta.cssVar }" />
+        <n-icon v-else class="note-add-icon"><BookmarkOutline /></n-icon>
+      </button>
+    </template>
+
+    <!-- 弹层：读写合一 -->
+    <div class="note-panel" :class="{ 'has-encounters': encounters.length > 0 }">
+      <div class="note-panel-header">
+        <span class="note-panel-title">玩家备注</span>
+        <n-ellipsis class="note-panel-name" style="max-width: 140px">
+          {{ gameName }}<span class="note-panel-tag">#{{ tagLine }}</span>
+        </n-ellipsis>
+      </div>
+
+      <!-- 颜色四档 -->
+      <div class="note-swatches">
+        <button
+          v-for="l in NOTE_LABELS"
+          :key="l.value"
+          type="button"
+          class="note-swatch"
+          :class="{ active: draftLabel === l.value }"
+          :style="{ '--swatch-color': l.cssVar }"
+          @click="draftLabel = l.value"
+        >
+          <span class="note-swatch-dot" :style="{ background: l.cssVar }" />
+          {{ l.text }}
+        </button>
+      </div>
+
+      <!-- 备注文本 -->
+      <n-input
+        v-model:value="draftNote"
+        type="textarea"
+        size="small"
+        placeholder="可选：写点备注，比如「上次一起赢的辅助」"
+        :autosize="{ minRows: 2, maxRows: 4 }"
+        :maxlength="100"
+        show-count
+        class="note-input"
+      />
+
+      <!-- 遇见记录（复刻"遇见过"，点一条可开那局详情） -->
+      <div v-if="encounters.length" class="note-encounters">
+        <div class="note-encounters-head">
+          遇见记录
+          <span class="note-encounters-count">{{ encounters.length }}</span>
+        </div>
+        <div class="note-encounters-scroll">
+          <MettingPlayersCard :meet-games="encounters" />
+        </div>
+      </div>
+
+      <div class="note-panel-footer">
+        <n-button v-if="hasNote" text size="small" type="error" @click="onDelete">删除</n-button>
+        <span class="note-footer-spacer" />
+        <n-button size="small" @click="show = false">取消</n-button>
+        <n-button size="small" type="primary" :loading="saving" @click="onSave">保存</n-button>
+      </div>
+    </div>
+  </n-popover>
+</template>
+
+<script setup lang="ts">
+/**
+ * 玩家备注徽标
+ *
+ * 在玩家卡 / 详情页展示一个色块（有备注）或"加备注"图标（无备注），
+ * 点击弹出读写合一的编辑面板：四档颜色 + 文本框 + 保存/删除。
+ * 数据走 {@link usePlayerNotesStore}，组件不直接碰 IPC。
+ *
+ * @see issue #67
+ */
+import { computed, ref, watch } from 'vue'
+import { NPopover, NIcon, NInput, NButton, NEllipsis, useMessage } from 'naive-ui'
+import { BookmarkOutline } from '@vicons/ionicons5'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import { NOTE_LABELS, getNoteLabelMeta, type NoteLabel } from '@renderer/types/domain/playerNote'
+import type { OneGamePlayer } from '@renderer/types/domain/analysis'
+import MettingPlayersCard from '@renderer/components/gaming/MettingPlayersCard.vue'
+
+interface Props {
+  /** 玩家唯一标识 */
+  puuid: string
+  /** 游戏名（保存时冗余写入，供设置列表展示） */
+  gameName: string
+  /** 标签 */
+  tagLine: string
+  /** 尺寸：卡片用 small，详情页用 normal */
+  size?: 'small' | 'normal'
+  /**
+   * 当前所在对局上下文（仅战绩详情页等"单局"场景传入）。
+   * 保存备注时会并入该玩家的遇见记录，复刻"遇见过"效果。
+   */
+  encounter?: OneGamePlayer
+}
+const props = withDefaults(defineProps<Props>(), { size: 'small', encounter: undefined })
+
+const store = usePlayerNotesStore()
+const message = useMessage()
+
+const show = ref(false)
+const saving = ref(false)
+const draftLabel = ref<NoteLabel>('normal')
+const draftNote = ref('')
+
+/** 当前已保存的备注（响应式跟随 store） */
+const note = computed(() => store.getNote(props.puuid))
+const hasNote = computed(() => !!note.value)
+const meta = computed(() => getNoteLabelMeta(note.value?.label ?? 'normal'))
+/** 已记录的遇见对局（最近在前） */
+const encounters = computed<OneGamePlayer[]>(() => note.value?.encounters ?? [])
+
+/** 打开面板时把草稿同步成当前值 */
+function onToggle(next: boolean) {
+  if (next) {
+    draftLabel.value = note.value?.label ?? 'normal'
+    draftNote.value = note.value?.note ?? ''
+  }
+  show.value = next
+}
+
+// puuid 变化（卡片复用）时复位草稿
+watch(
+  () => props.puuid,
+  () => {
+    show.value = false
+  }
+)
+
+async function onSave() {
+  if (!props.puuid) {
+    message.error('无法获取玩家标识')
+    return
+  }
+  saving.value = true
+  try {
+    await store.setNote(props.puuid, {
+      note: draftNote.value.trim(),
+      label: draftLabel.value,
+      gameName: props.gameName,
+      tagLine: props.tagLine,
+      encounter: props.encounter
+    })
+    message.success('备注已保存')
+    show.value = false
+  } catch {
+    message.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function onDelete() {
+  try {
+    await store.removeNote(props.puuid)
+    message.success('备注已删除')
+    show.value = false
+  } catch {
+    message.error('删除失败')
+  }
+}
+</script>
+
+<style scoped>
+.note-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius-pill);
+  transition: background var(--dur-fast, 0.15s) var(--ease-expo, ease);
+}
+.note-trigger:hover {
+  background: var(--glass-bg-low, rgba(255, 255, 255, 0.06));
+}
+.note-trigger.size-normal {
+  padding: 3px;
+}
+
+.note-dot {
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--bg-base, transparent);
+}
+.size-normal .note-dot {
+  width: 11px;
+  height: 11px;
+}
+
+.note-add-icon {
+  font-size: 13px;
+  color: var(--text-quaternary, var(--text-tertiary));
+  opacity: 0.55;
+  transition: opacity var(--dur-fast, 0.15s) var(--ease-expo, ease);
+}
+.note-trigger:hover .note-add-icon {
+  opacity: 1;
+  color: var(--text-secondary);
+}
+.size-normal .note-add-icon {
+  font-size: 16px;
+}
+
+/* ---- 弹层 ---- */
+.note-panel {
+  width: 248px;
+  padding: var(--space-12, 12px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10, 10px);
+  transition: width var(--dur-normal, 0.28s) var(--ease-expo, ease);
+}
+/* 有遇见记录时加宽，容纳 MettingPlayersCard 的双列卡片 */
+.note-panel.has-encounters {
+  width: 360px;
+}
+
+.note-encounters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6, 6px);
+}
+.note-encounters-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6, 6px);
+  font-size: var(--font-size-xs, 12px);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.note-encounters-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--radius-pill, 999px);
+  background: var(--glass-bg-low, rgba(255, 255, 255, 0.06));
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+.note-encounters-scroll {
+  max-height: 196px;
+  overflow-y: auto;
+  margin: 0 calc(-1 * var(--space-4, 4px));
+  padding: 0 var(--space-4, 4px);
+}
+.note-panel-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-8, 8px);
+}
+.note-panel-title {
+  font-size: var(--font-size-sm, 13px);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.note-panel-name {
+  font-size: var(--font-size-xs, 12px);
+  color: var(--text-tertiary);
+}
+.note-panel-tag {
+  opacity: 0.7;
+}
+
+.note-swatches {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-6, 6px);
+}
+.note-swatch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 5px 2px;
+  font-size: var(--font-size-xs, 12px);
+  color: var(--text-secondary);
+  background: var(--glass-bg-low, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--glass-border, transparent);
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+  transition:
+    border-color var(--dur-fast, 0.15s) var(--ease-expo, ease),
+    background var(--dur-fast, 0.15s) var(--ease-expo, ease);
+}
+.note-swatch:hover {
+  border-color: var(--swatch-color);
+}
+.note-swatch.active {
+  border-color: var(--swatch-color);
+  background: color-mix(in srgb, var(--swatch-color) 16%, transparent);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.note-swatch-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.note-input {
+  font-size: var(--font-size-xs, 12px);
+}
+
+.note-panel-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6, 6px);
+}
+.note-footer-spacer {
+  flex: 1;
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/common/PlayerNoteBadge.vue
+++ b/lol-record-analysis-tauri/src/components/common/PlayerNoteBadge.vue
@@ -11,7 +11,7 @@
       <button
         class="note-trigger"
         :class="{ 'has-note': hasNote, [`size-${size}`]: true }"
-        :title="hasNote ? `${meta.text}${note!.note ? '：' + note!.note : ''}` : '添加备注'"
+        :title="triggerTitle"
         type="button"
       >
         <span v-if="hasNote" class="note-dot" :style="{ background: meta.cssVar }" />
@@ -126,6 +126,13 @@ const hasNote = computed(() => !!note.value)
 const meta = computed(() => getNoteLabelMeta(note.value?.label ?? 'normal'))
 /** 已记录的遇见对局（最近在前） */
 const encounters = computed<OneGamePlayer[]>(() => note.value?.encounters ?? [])
+
+/** 触发按钮的 hover 提示：无备注显示"添加备注"，有备注显示档位（+备注文本） */
+const triggerTitle = computed(() => {
+  const n = note.value
+  if (!n) return '添加备注'
+  return n.note ? `${meta.value.text}：${n.note}` : meta.value.text
+})
 
 /** 打开面板时把草稿同步成当前值 */
 function onToggle(next: boolean) {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -81,6 +81,13 @@
                 >
                   <n-icon><copy-outline /></n-icon>
                 </n-button>
+                <PlayerNoteBadge
+                  v-if="sessionSummoner.summoner.puuid"
+                  :puuid="sessionSummoner.summoner.puuid"
+                  :game-name="sessionSummoner.summoner.gameName"
+                  :tag-line="sessionSummoner.summoner.tagLine"
+                  size="small"
+                />
               </n-flex>
 
               <n-flex align="center" class="meta-row">
@@ -193,6 +200,7 @@ import { useAramBalance } from '@renderer/composables/useAramBalance'
 import PlayerHistoryGrid from './PlayerHistoryGrid.vue'
 import PlayerStatsCard from './PlayerStatsCard.vue'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
+import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 
 interface Props {
   sessionSummoner: SessionSummoner

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -160,6 +160,15 @@
                             <n-icon><CopyOutline /></n-icon>
                           </template>
                         </n-button>
+                        <span v-if="player.puuid" @click.stop>
+                          <PlayerNoteBadge
+                            :puuid="player.puuid"
+                            :game-name="player.gameName"
+                            :tag-line="player.tagLine"
+                            :encounter="buildEncounter(player)"
+                            size="normal"
+                          />
+                        </span>
                         <n-tag v-if="player.isMe" size="small" :bordered="false" type="info"
                           >我</n-tag
                         >
@@ -412,6 +421,7 @@ import AssetTooltipContent from './AssetTooltipContent.vue'
 import StatDots from './StatDots.vue'
 import MatchAIPanel from './MatchAIPanel.vue'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
+import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 import {
   assistsColor,
   deathsColor,
@@ -423,8 +433,12 @@ import {
 import { formatCompactNumber } from '@renderer/utils/format'
 import { augmentRarityClass } from '@renderer/utils/augment'
 import { useRecordAssets } from '@renderer/composables/useRecordAssets'
-import { useMatchDetailPlayers } from '@renderer/composables/useMatchDetailPlayers'
+import {
+  useMatchDetailPlayers,
+  type DetailPlayer
+} from '@renderer/composables/useMatchDetailPlayers'
 import { useMatchAIAnalysis } from '@renderer/composables/useMatchAIAnalysis'
+import type { OneGamePlayer } from '@renderer/types/domain/analysis'
 
 const props = defineProps<{ game: Game | null }>()
 
@@ -488,6 +502,31 @@ const formattedDate = computed(() => {
     hour12: false
   }).format(new Date(props.game.gameCreationDate))
 })
+
+/**
+ * 由某玩家 + 当前对局拼出一条"遇见记录"（{@link OneGamePlayer}），
+ * 保存备注时并入该玩家的遇见列表，复刻"遇见过"效果。
+ * @param player - 详情页玩家
+ */
+function buildEncounter(player: DetailPlayer): OneGamePlayer | undefined {
+  const g = props.game
+  if (!g || !player.puuid) return undefined
+  return {
+    gameCreatedAt: g.gameCreationDate,
+    index: 0,
+    gameId: g.gameId,
+    puuid: player.puuid,
+    gameName: player.gameName,
+    tagLine: player.tagLine,
+    championId: player.championId,
+    win: player.win,
+    kills: player.stats.kills,
+    deaths: player.stats.deaths,
+    assists: player.stats.assists,
+    isMyTeam: player.teamId === mySummary.value?.teamId,
+    queueIdCn: g.queueName ?? ''
+  }
+}
 
 const durationLabel = computed(() => {
   if (!props.game) return ''

--- a/lol-record-analysis-tauri/src/components/record/UserRecord.vue
+++ b/lol-record-analysis-tauri/src/components/record/UserRecord.vue
@@ -23,6 +23,13 @@
                 <n-icon><copy-outline /></n-icon>
               </template>
             </n-button>
+            <PlayerNoteBadge
+              v-if="summoner.puuid"
+              :puuid="summoner.puuid"
+              :game-name="summoner.gameName"
+              :tag-line="summoner.tagLine"
+              size="normal"
+            />
           </n-flex>
           <n-flex align="center" :size="6">
             <n-text depth="3" class="user-record-tagline">#{{ summoner.tagLine }}</n-text>
@@ -142,6 +149,7 @@ import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import RelationshipPanel from './RelationshipPanel.vue'
 import RankCard from './RankCard.vue'
 import RecentStatsTable from './RecentStatsTable.vue'
+import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 
 const settingsStore = useSettingsStore()
 const isDark = computed(

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
@@ -34,6 +34,10 @@ export interface DetailPlayer {
   spell2Id: number
   stats: ParticipantStats
   displayName: string
+  /** 玩家唯一标识，来自 participantIdentity，用于玩家备注 */
+  puuid: string
+  gameName: string
+  tagLine: string
   isMe: boolean
   win: boolean
   badges: PlayerBadge[]
@@ -164,6 +168,9 @@ export function useMatchDetailPlayers(
           spell2Id: p.spell2Id,
           stats: p.stats,
           displayName,
+          puuid: identity?.player.puuid ?? '',
+          gameName: identity?.player.gameName ?? '',
+          tagLine: identity?.player.tagLine ?? '',
           isMe: displayName === toValue(currentPlayerKey),
           win: p.stats.win,
           badges: badgeConfigs

--- a/lol-record-analysis-tauri/src/main.ts
+++ b/lol-record-analysis-tauri/src/main.ts
@@ -4,6 +4,7 @@ import router from './router'
 import naive from 'naive-ui'
 import { createPinia } from 'pinia'
 import { useSettingsStore } from './pinia/setting'
+import { usePlayerNotesStore } from './pinia/playerNotes'
 import './global.css'
 
 const app = createApp(App)
@@ -14,5 +15,7 @@ app.use(naive)
 
 // 显式初始化主题，避免 store 定义时的隐式副作用
 useSettingsStore().initTheme()
+// 载入本地玩家备注（issue #67）
+usePlayerNotesStore().init()
 
 app.mount('#app')

--- a/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
@@ -203,4 +203,29 @@ describe('usePlayerNotesStore', () => {
       expect(store.getNote('p')?.encounters?.length).toBe(1)
     })
   })
+
+  describe('健壮性（review 修复）', () => {
+    it('reload 后单调时钟不回退：新保存的 updatedAt 大于已载入的最大值（C1）', async () => {
+      const big = 9_000_000_000_000_000
+      mockGet.mockResolvedValue({
+        old: { note: 'x', label: 'normal', gameName: 'O', tagLine: '1', updatedAt: big }
+      })
+      const store = usePlayerNotesStore()
+      await store.init()
+      await store.setNote('new', { note: 'y', label: 'normal', gameName: 'N', tagLine: '2' })
+
+      expect(store.getNote('new')!.updatedAt).toBeGreaterThan(big)
+      // 列表"最近优先"：new 排在 old 之前
+      expect(store.list[0].puuid).toBe('new')
+    })
+
+    it('落盘失败时 setNote 抛出而非静默成功（C2）', async () => {
+      const store = usePlayerNotesStore()
+      mockPut.mockRejectedValueOnce(new Error('disk full'))
+
+      await expect(
+        store.setNote('p', { note: 'x', label: 'normal', gameName: 'G', tagLine: 'T' })
+      ).rejects.toThrow()
+    })
+  })
 })

--- a/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * usePlayerNotesStore 单元测试
+ * @module pinia/playerNotes
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// Mock config IPC，避免触达 Tauri runtime
+vi.mock('@renderer/services/ipc', () => ({
+  getConfigByIpc: vi.fn(),
+  putConfigByIpc: vi.fn(() => Promise.resolve())
+}))
+
+// Mock Tauri 事件（跨窗口同步用），jsdom 下无 Tauri runtime
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(() => Promise.resolve()),
+  listen: vi.fn(() => Promise.resolve(() => {}))
+}))
+
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { usePlayerNotesStore } from '../playerNotes'
+
+const mockGet = vi.mocked(getConfigByIpc)
+const mockPut = vi.mocked(putConfigByIpc)
+
+describe('usePlayerNotesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockPut.mockResolvedValue(undefined)
+  })
+
+  describe('init', () => {
+    it('从 config 载入已有备注', async () => {
+      mockGet.mockResolvedValue({
+        'puuid-1': { note: '坑', label: 'careful', gameName: 'A', tagLine: '1', updatedAt: 1 }
+      })
+      const store = usePlayerNotesStore()
+      await store.init()
+
+      expect(store.getNote('puuid-1')?.label).toBe('careful')
+    })
+
+    it('config 为空时安全降级为空表', async () => {
+      mockGet.mockResolvedValue(undefined)
+      const store = usePlayerNotesStore()
+      await store.init()
+
+      expect(store.getNote('whatever')).toBeUndefined()
+      expect(store.count).toBe(0)
+    })
+
+    it('getConfigByIpc 抛错时不崩，保持空表', async () => {
+      mockGet.mockRejectedValue(new Error('ipc down'))
+      const store = usePlayerNotesStore()
+      await store.init()
+
+      expect(store.count).toBe(0)
+    })
+  })
+
+  describe('setNote', () => {
+    it('写入内存并整体落盘', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('puuid-2', {
+        note: '一起上分',
+        label: 'friendly',
+        gameName: 'Hide on bush',
+        tagLine: 'KR1'
+      })
+
+      const saved = store.getNote('puuid-2')
+      expect(saved?.note).toBe('一起上分')
+      expect(saved?.label).toBe('friendly')
+      expect(saved?.gameName).toBe('Hide on bush')
+      expect(saved?.updatedAt).toBeGreaterThan(0)
+
+      // 落盘：put 收到的是整张表
+      expect(mockPut).toHaveBeenCalledWith(
+        'playerNotes',
+        expect.objectContaining({ 'puuid-2': expect.any(Object) })
+      )
+    })
+
+    it('对同一 puuid 再次写入会覆盖', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', { note: 'a', label: 'normal', gameName: 'G', tagLine: 'T' })
+      await store.setNote('p', { note: 'b', label: 'blacklist', gameName: 'G', tagLine: 'T' })
+
+      expect(store.getNote('p')?.note).toBe('b')
+      expect(store.getNote('p')?.label).toBe('blacklist')
+      expect(store.count).toBe(1)
+    })
+  })
+
+  describe('removeNote', () => {
+    it('删除内存条目并落盘', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', { note: 'x', label: 'normal', gameName: 'G', tagLine: 'T' })
+      mockPut.mockClear()
+
+      await store.removeNote('p')
+
+      expect(store.getNote('p')).toBeUndefined()
+      expect(mockPut).toHaveBeenCalledWith(
+        'playerNotes',
+        expect.not.objectContaining({ p: expect.anything() })
+      )
+    })
+
+    it('删除不存在的 puuid 不报错', async () => {
+      const store = usePlayerNotesStore()
+      await expect(store.removeNote('ghost')).resolves.not.toThrow()
+    })
+  })
+
+  describe('list', () => {
+    it('返回按 updatedAt 倒序的 [puuid, note] 列表', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('old', { note: '1', label: 'normal', gameName: 'O', tagLine: 'T' })
+      await store.setNote('new', { note: '2', label: 'normal', gameName: 'N', tagLine: 'T' })
+
+      const list = store.list
+      expect(list.length).toBe(2)
+      // new 的 updatedAt >= old，排前面
+      expect(list[0].puuid).toBe('new')
+    })
+  })
+
+  describe('encounters（遇见记录）', () => {
+    const makeEncounter = (gameId: number, gameCreatedAt: string) => ({
+      gameCreatedAt,
+      index: 0,
+      gameId,
+      puuid: 'p',
+      gameName: 'G',
+      tagLine: 'T',
+      championId: 1,
+      win: true,
+      kills: 1,
+      deaths: 2,
+      assists: 3,
+      isMyTeam: false,
+      queueIdCn: '极地大乱斗'
+    })
+
+    it('保存时带 encounter 会记入遇见列表', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', {
+        note: '',
+        label: 'careful',
+        gameName: 'G',
+        tagLine: 'T',
+        encounter: makeEncounter(1001, '2026-05-20T10:00:00Z')
+      })
+      expect(store.getNote('p')?.encounters?.length).toBe(1)
+      expect(store.getNote('p')?.encounters?.[0].gameId).toBe(1001)
+    })
+
+    it('多局累积、按 gameId 去重、最近在前', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', {
+        note: '',
+        label: 'careful',
+        gameName: 'G',
+        tagLine: 'T',
+        encounter: makeEncounter(1, '2026-05-20T10:00:00Z')
+      })
+      await store.setNote('p', {
+        note: '',
+        label: 'careful',
+        gameName: 'G',
+        tagLine: 'T',
+        encounter: makeEncounter(2, '2026-05-22T10:00:00Z')
+      })
+      // 重复 gameId=1 不应新增，且较旧
+      await store.setNote('p', {
+        note: '',
+        label: 'careful',
+        gameName: 'G',
+        tagLine: 'T',
+        encounter: makeEncounter(1, '2026-05-20T10:00:00Z')
+      })
+
+      const enc = store.getNote('p')?.encounters
+      expect(enc?.length).toBe(2)
+      expect(enc?.[0].gameId).toBe(2) // 最近在前
+    })
+
+    it('不传 encounter 时保留已有遇见记录', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', {
+        note: 'a',
+        label: 'careful',
+        gameName: 'G',
+        tagLine: 'T',
+        encounter: makeEncounter(1, '2026-05-20T10:00:00Z')
+      })
+      await store.setNote('p', { note: 'b', label: 'blacklist', gameName: 'G', tagLine: 'T' })
+
+      expect(store.getNote('p')?.note).toBe('b')
+      expect(store.getNote('p')?.encounters?.length).toBe(1)
+    })
+  })
+})

--- a/lol-record-analysis-tauri/src/pinia/playerNotes.ts
+++ b/lol-record-analysis-tauri/src/pinia/playerNotes.ts
@@ -82,6 +82,12 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
     try {
       const saved = await getConfigByIpc<PlayerNotesMap>(STORAGE_KEY)
       notes.value = saved && typeof saved === 'object' ? saved : {}
+      // 跨窗口 / 重载后保持单调时钟不回退：把 lastTs 顶到已有最大 updatedAt。
+      // 否则 reload 后 lastTs 归 0，下次保存可能生成比现有更小的时间戳，
+      // 破坏列表"最近更新优先"的排序。
+      for (const note of Object.values(notes.value)) {
+        if (note.updatedAt > lastTs) lastTs = note.updatedAt
+      }
     } catch (error) {
       console.error('Failed to load player notes:', error)
       notes.value = {}
@@ -154,14 +160,20 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
     await persist()
   }
 
-  /** 整表落盘，并广播变更通知其他窗口重载 */
+  /**
+   * 整表落盘，并广播变更通知其他窗口重载。
+   * 落盘失败时**重新抛出**——否则 setNote/removeNote 即使写盘失败也会 resolve，
+   * 上层 try/catch 永远进不去，用户看到"已保存/已删除"却实际未持久化。
+   */
   async function persist(): Promise<void> {
     try {
       await putConfigByIpc(STORAGE_KEY, notes.value)
-      emit(NOTES_CHANGED_EVENT).catch(() => {})
     } catch (error) {
       console.error('Failed to persist player notes:', error)
+      throw error
     }
+    // 落盘成功后再广播
+    emit(NOTES_CHANGED_EVENT).catch(() => {})
   }
 
   return { notes, count, list, init, getNote, setNote, removeNote }

--- a/lol-record-analysis-tauri/src/pinia/playerNotes.ts
+++ b/lol-record-analysis-tauri/src/pinia/playerNotes.ts
@@ -1,0 +1,168 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { emit, listen } from '@tauri-apps/api/event'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import type { NoteLabel, PlayerNote, PlayerNotesMap } from '@renderer/types/domain/playerNote'
+import type { OneGamePlayer } from '@renderer/types/domain/analysis'
+
+/** 持久化 key，复用 config 系统，无需新增 Rust command */
+const STORAGE_KEY = 'playerNotes'
+
+/**
+ * 备注变更的跨窗口广播事件。
+ *
+ * 战绩详情是独立窗口（match-detail-*），与主窗口各自持有一份 pinia store。
+ * 在任一窗口写备注后，emit 此事件广播到所有窗口，各窗口收到后从 config 重载，
+ * 保证"详情页标记 → 主窗口/设置页"即时可见，无需重启。
+ */
+const NOTES_CHANGED_EVENT = 'player-notes-changed'
+
+/** 单个玩家最多保留的遇见记录条数（最近在前，超出截断） */
+const MAX_ENCOUNTERS = 20
+
+/** 时间字符串转毫秒，无效值归零（用于遇见记录排序） */
+function toTimestamp(date: string): number {
+  const t = new Date(date).getTime()
+  return Number.isNaN(t) ? 0 : t
+}
+
+/**
+ * 合并遇见记录：把新一局并入已有列表，按 gameId 去重、最近在前、截断到上限。
+ * @param existing - 已有遇见记录
+ * @param add - 本次要并入的对局（可空，为空时原样返回已有）
+ */
+function mergeEncounters(
+  existing: OneGamePlayer[] | undefined,
+  add: OneGamePlayer | undefined
+): OneGamePlayer[] | undefined {
+  const base = existing ?? []
+  if (!add) return base.length ? base : undefined
+  const deduped = base.filter(e => e.gameId !== add.gameId)
+  return [add, ...deduped]
+    .sort((a, b) => toTimestamp(b.gameCreatedAt) - toTimestamp(a.gameCreatedAt))
+    .slice(0, MAX_ENCOUNTERS)
+}
+
+/**
+ * 玩家备注 store
+ *
+ * 内存维护一张 `puuid -> 备注` 表，所有写操作（set/remove）会整体落盘到
+ * config（`playerNotes` key）。组件只读 store / 调 store 方法，不直接碰 IPC。
+ *
+ * @see issue #67
+ * @see types/domain/playerNote
+ */
+export const usePlayerNotesStore = defineStore('playerNotes', () => {
+  /** 内存副本：puuid -> 备注 */
+  const notes = ref<PlayerNotesMap>({})
+
+  /**
+   * 单调递增时间戳：保证同一毫秒内的多次写入仍有稳定先后，
+   * 用于列表"最近更新优先"排序的确定性。
+   */
+  let lastTs = 0
+  function nextTs(): number {
+    const now = Date.now()
+    lastTs = now > lastTs ? now : lastTs + 1
+    return lastTs
+  }
+
+  /** 备注总数 */
+  const count = computed(() => Object.keys(notes.value).length)
+
+  /** 列表视图：按更新时间倒序的 `{ puuid, ...note }` 数组，供设置页表格使用 */
+  const list = computed(() =>
+    Object.entries(notes.value)
+      .map(([puuid, note]) => ({ puuid, ...note }))
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  )
+
+  /** 从 config 读取备注到内存（不注册监听，供 init 与跨窗口事件复用） */
+  async function loadFromConfig(): Promise<void> {
+    try {
+      const saved = await getConfigByIpc<PlayerNotesMap>(STORAGE_KEY)
+      notes.value = saved && typeof saved === 'object' ? saved : {}
+    } catch (error) {
+      console.error('Failed to load player notes:', error)
+      notes.value = {}
+    }
+  }
+
+  /** 是否已注册跨窗口同步监听（每窗口一次） */
+  let syncRegistered = false
+
+  /**
+   * 从持久化配置载入备注，并注册跨窗口同步监听。
+   * 由 `main.ts` 在 app 启动时显式调用（每个窗口都会执行）。
+   * 失败时安全降级为空表，不阻断启动。
+   */
+  async function init(): Promise<void> {
+    await loadFromConfig()
+    if (!syncRegistered) {
+      syncRegistered = true
+      // 收到其他窗口的变更广播后重载；loadFromConfig 不再 emit，无回环。
+      listen(NOTES_CHANGED_EVENT, () => {
+        loadFromConfig()
+      }).catch(error => console.error('Failed to listen player-notes-changed:', error))
+    }
+  }
+
+  /**
+   * 读取某玩家的备注
+   * @param puuid - 玩家唯一标识
+   * @returns 备注，不存在返回 undefined
+   */
+  function getNote(puuid: string): PlayerNote | undefined {
+    return notes.value[puuid]
+  }
+
+  /**
+   * 写入 / 更新某玩家的备注，并整体落盘。
+   * @param puuid - 玩家唯一标识
+   * @param data - 备注内容（不含 updatedAt，由内部盖时间戳）；可选 `encounter`
+   *   为"本次标记所在的对局"，会并入该玩家的遇见记录（去重、最近在前）。
+   *   不传 `encounter` 时保留已有遇见记录不变。
+   */
+  async function setNote(
+    puuid: string,
+    data: {
+      note: string
+      label: NoteLabel
+      gameName: string
+      tagLine: string
+      encounter?: OneGamePlayer
+    }
+  ): Promise<void> {
+    const { encounter, ...rest } = data
+    const encounters = mergeEncounters(notes.value[puuid]?.encounters, encounter)
+    notes.value = {
+      ...notes.value,
+      [puuid]: { ...rest, updatedAt: nextTs(), ...(encounters ? { encounters } : {}) }
+    }
+    await persist()
+  }
+
+  /**
+   * 删除某玩家的备注，并整体落盘。不存在时静默返回。
+   * @param puuid - 玩家唯一标识
+   */
+  async function removeNote(puuid: string): Promise<void> {
+    if (!(puuid in notes.value)) return
+    const next = { ...notes.value }
+    delete next[puuid]
+    notes.value = next
+    await persist()
+  }
+
+  /** 整表落盘，并广播变更通知其他窗口重载 */
+  async function persist(): Promise<void> {
+    try {
+      await putConfigByIpc(STORAGE_KEY, notes.value)
+      emit(NOTES_CHANGED_EVENT).catch(() => {})
+    } catch (error) {
+      console.error('Failed to persist player notes:', error)
+    }
+  }
+
+  return { notes, count, list, init, getNote, setNote, removeNote }
+})

--- a/lol-record-analysis-tauri/src/router/index.ts
+++ b/lol-record-analysis-tauri/src/router/index.ts
@@ -55,6 +55,12 @@ const routes: Array<RouteRecordRaw> = [
         meta: { title: '标签管理' }
       },
       {
+        path: '/Settings/PlayerNotes',
+        name: 'PlayerNotes',
+        component: () => import('@renderer/views/settings/PlayerNotes.vue'),
+        meta: { title: '我标记过的人' }
+      },
+      {
         path: '/Settings/About',
         name: 'About',
         component: () => import('@renderer/views/settings/About.vue'),

--- a/lol-record-analysis-tauri/src/services/configKeys.ts
+++ b/lol-record-analysis-tauri/src/services/configKeys.ts
@@ -1,0 +1,20 @@
+/**
+ * config 持久化键名（前端共享常量）
+ *
+ * 收口散落在多个组件里的裸字符串 key，避免改名时漏改一处。
+ * 与 `getConfigByIpc` / `putConfigByIpc`（{@link ./ipc}）配套使用。
+ *
+ * @module services/configKeys
+ */
+
+/**
+ * 错误上报（Sentry）相关配置键。
+ *
+ * `errorReportingEnabled` 与后端 `observability::REPORTING_KEY` 对应——改这里也要同步 Rust。
+ */
+export const CONFIG_KEYS = {
+  /** 是否开启 Sentry 错误上报 / 日志转发（opt-in，release 默认关、debug 默认开） */
+  errorReportingEnabled: 'errorReportingEnabled',
+  /** 是否已就错误上报询问过用户（首次同意弹窗用，问过即不再弹） */
+  errorReportingConsentShown: 'errorReportingConsentShown'
+} as const

--- a/lol-record-analysis-tauri/src/types/domain/playerNote.ts
+++ b/lol-record-analysis-tauri/src/types/domain/playerNote.ts
@@ -1,0 +1,88 @@
+/**
+ * 玩家备注（本地标记）类型定义
+ *
+ * 用户可按 puuid 给碰到过的玩家留"备注 + 颜色标记"，在对局玩家卡、
+ * 玩家详情页展示，并在设置页集中管理。纯本地存储（复用 config IPC，
+ * key = `playerNotes`），换机 / 重装会丢失，不跨设备同步。
+ *
+ * @see issue #67
+ * @module types/domain/playerNote
+ */
+
+import type { OneGamePlayer } from './analysis'
+
+/**
+ * 备注颜色标记档位
+ * - `friendly` 友好（绿）
+ * - `normal`   一般（灰）
+ * - `careful`  小心（橙）
+ * - `blacklist` 拉黑（红）
+ */
+export type NoteLabel = 'friendly' | 'normal' | 'careful' | 'blacklist'
+
+/**
+ * 单条玩家备注
+ * @property note - 备注文本，可为空（只标颜色不写字）
+ * @property label - 颜色档位
+ * @property gameName - 冗余存一份游戏名，用于设置列表展示（puuid 不可读）
+ * @property tagLine - 冗余存一份标签
+ * @property updatedAt - 最后更新时间（毫秒时间戳）
+ * @property encounters - 遇见记录（在哪些对局里标记/碰到过 ta），按 gameId 去重、
+ *   最近在前，复刻"遇见过"效果。复用 {@link OneGamePlayer} 以便直接用 MettingPlayersCard 渲染。
+ */
+export interface PlayerNote {
+  note: string
+  label: NoteLabel
+  gameName: string
+  tagLine: string
+  updatedAt: number
+  encounters?: OneGamePlayer[]
+}
+
+/**
+ * 持久化结构：puuid -> 备注
+ */
+export type PlayerNotesMap = Record<string, PlayerNote>
+
+/**
+ * naive-ui 标签 / 主题类型（用于 n-tag、n-button 的 type）
+ */
+export type NaiveLabelType = 'success' | 'default' | 'warning' | 'error'
+
+/**
+ * 颜色档位元信息
+ * @property value - 档位 key
+ * @property text - 中文文案
+ * @property naiveType - 对应 naive-ui 的 type，复用其语义色
+ * @property cssVar - 对应的 CSS 变量（用于自定义色块），无则回退主题色
+ */
+export interface NoteLabelMeta {
+  value: NoteLabel
+  text: string
+  naiveType: NaiveLabelType
+  cssVar: string
+}
+
+/**
+ * 四档颜色映射，复用 `global.css` 中既有的语义色变量，保证明暗主题一致。
+ */
+export const NOTE_LABELS: readonly NoteLabelMeta[] = [
+  { value: 'friendly', text: '友好', naiveType: 'success', cssVar: 'var(--semantic-win)' },
+  { value: 'normal', text: '一般', naiveType: 'default', cssVar: 'var(--text-tertiary)' },
+  {
+    value: 'careful',
+    text: '小心',
+    naiveType: 'warning',
+    cssVar: 'var(--semantic-warning, #e0a52e)'
+  },
+  { value: 'blacklist', text: '拉黑', naiveType: 'error', cssVar: 'var(--semantic-loss)' }
+] as const
+
+/**
+ * 按 label 取元信息，找不到回退到 `normal`。
+ * @param label - 颜色档位
+ * @returns 对应的元信息
+ */
+export function getNoteLabelMeta(label: NoteLabel): NoteLabelMeta {
+  return NOTE_LABELS.find(l => l.value === label) ?? NOTE_LABELS[1]
+}

--- a/lol-record-analysis-tauri/src/views/Settings.vue
+++ b/lol-record-analysis-tauri/src/views/Settings.vue
@@ -40,7 +40,8 @@ import {
   // BulbOutline
   AlertCircleOutline,
   SettingsOutline,
-  PricetagOutline
+  PricetagOutline,
+  BookmarksOutline
 } from '@vicons/ionicons5'
 
 const collapsed = ref(false)
@@ -75,6 +76,11 @@ const menuOptions = [
     label: '标签管理',
     key: 'Tags',
     icon: renderIcon(PricetagOutline)
+  },
+  {
+    label: '我标记过的人',
+    key: 'PlayerNotes',
+    icon: renderIcon(BookmarksOutline)
   },
   // {
   //     label: 'AI能力',

--- a/lol-record-analysis-tauri/src/views/settings/General.vue
+++ b/lol-record-analysis-tauri/src/views/settings/General.vue
@@ -24,6 +24,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import { useMessage } from 'naive-ui'
 
 const matchCount = ref(4)
@@ -40,7 +41,7 @@ onMounted(async () => {
     console.error(e)
   }
   try {
-    const enabled = await getConfigByIpc<boolean>('errorReportingEnabled')
+    const enabled = await getConfigByIpc<boolean>(CONFIG_KEYS.errorReportingEnabled)
     if (typeof enabled === 'boolean') {
       errorReporting.value = enabled
     }
@@ -61,7 +62,7 @@ const handleUpdate = async (value: number | null) => {
 
 const handleReportingUpdate = async (value: boolean) => {
   try {
-    await putConfigByIpc('errorReportingEnabled', value)
+    await putConfigByIpc(CONFIG_KEYS.errorReportingEnabled, value)
     message.success('设置已保存，重启后生效')
   } catch (e) {
     message.error('保存失败')

--- a/lol-record-analysis-tauri/src/views/settings/PlayerNotes.vue
+++ b/lol-record-analysis-tauri/src/views/settings/PlayerNotes.vue
@@ -1,0 +1,175 @@
+<template>
+  <n-space vertical :size="12">
+    <n-card title="我标记过的人" size="small">
+      <template #header-extra>
+        <n-text :depth="3" style="font-size: 12px"> 共 {{ store.count }} 人 </n-text>
+      </template>
+
+      <n-alert type="default" :bordered="false" style="margin-bottom: 12px">
+        <template #icon>
+          <n-icon><InformationCircleOutline /></n-icon>
+        </template>
+        备注仅保存在本机，换电脑或重装会丢失，也无法与他人共享。在对局玩家卡、玩家详情页点名字旁的标记即可添加。
+      </n-alert>
+
+      <n-data-table
+        v-if="store.count > 0"
+        :columns="columns"
+        :data="store.list"
+        :row-key="row => row.puuid"
+        :bordered="false"
+        :pagination="pagination"
+      />
+      <n-empty v-else description="还没有标记过任何人" style="padding: 32px 0">
+        <template #icon>
+          <n-icon><BookmarksOutline /></n-icon>
+        </template>
+      </n-empty>
+    </n-card>
+  </n-space>
+</template>
+
+<script setup lang="ts">
+/**
+ * 设置页：我标记过的人
+ *
+ * 集中展示 / 管理本地玩家备注（issue #67）。表格行复用
+ * {@link PlayerNoteBadge} 做行内编辑，配 popconfirm 删除。
+ */
+import { h, computed } from 'vue'
+import {
+  NSpace,
+  NCard,
+  NText,
+  NAlert,
+  NIcon,
+  NTag,
+  NButton,
+  NPopconfirm,
+  NEllipsis,
+  NEmpty,
+  NDataTable,
+  useMessage,
+  type DataTableColumns
+} from 'naive-ui'
+import { InformationCircleOutline, BookmarksOutline } from '@vicons/ionicons5'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import { getNoteLabelMeta } from '@renderer/types/domain/playerNote'
+import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
+import MettingPlayersCard from '@renderer/components/gaming/MettingPlayersCard.vue'
+
+const store = usePlayerNotesStore()
+const message = useMessage()
+
+const pagination = { pageSize: 12 } as const
+
+/** 行类型：store.list 元素（puuid + PlayerNote 展开） */
+type Row = (typeof store.list)[number]
+
+/** 时间戳 -> 本地可读时间 */
+function formatTime(ts: number): string {
+  if (!ts) return '-'
+  return new Date(ts).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+async function handleDelete(row: Row) {
+  try {
+    await store.removeNote(row.puuid)
+    message.success('已删除')
+  } catch {
+    message.error('删除失败')
+  }
+}
+
+const columns = computed<DataTableColumns<Row>>(() => [
+  {
+    type: 'expand',
+    expandable: row => (row.encounters?.length ?? 0) > 0,
+    renderExpand: row =>
+      h('div', { style: 'padding:4px 0 8px' }, [
+        h(MettingPlayersCard, { meetGames: row.encounters ?? [] })
+      ])
+  },
+  {
+    title: '标记',
+    key: 'label',
+    width: 90,
+    render(row) {
+      const meta = getNoteLabelMeta(row.label)
+      return h(
+        NTag,
+        { type: meta.naiveType, size: 'small', round: true, bordered: false },
+        { default: () => meta.text }
+      )
+    }
+  },
+  {
+    title: '玩家',
+    key: 'gameName',
+    render(row) {
+      return h('div', { style: 'display:flex;align-items:baseline;gap:2px;min-width:0' }, [
+        h(
+          NEllipsis,
+          { style: 'max-width:160px;font-weight:600' },
+          { default: () => row.gameName || '(未知)' }
+        ),
+        h('span', { style: 'color:var(--text-tertiary);font-size:12px' }, `#${row.tagLine}`)
+      ])
+    }
+  },
+  {
+    title: '备注',
+    key: 'note',
+    render(row) {
+      if (!row.note) return h('span', { style: 'color:var(--text-tertiary)' }, '—')
+      return h(NEllipsis, { style: 'max-width:240px' }, { default: () => row.note })
+    }
+  },
+  {
+    title: '遇见',
+    key: 'encounters',
+    width: 72,
+    render(row) {
+      const n = row.encounters?.length ?? 0
+      if (!n) return h('span', { style: 'color:var(--text-tertiary)' }, '—')
+      return h(NTag, { size: 'small', round: true, bordered: false }, { default: () => `${n} 局` })
+    }
+  },
+  {
+    title: '更新时间',
+    key: 'updatedAt',
+    width: 150,
+    render: row => formatTime(row.updatedAt)
+  },
+  {
+    title: '操作',
+    key: 'actions',
+    width: 110,
+    render(row) {
+      return h('div', { style: 'display:flex;align-items:center;gap:8px' }, [
+        h(PlayerNoteBadge, {
+          puuid: row.puuid,
+          gameName: row.gameName,
+          tagLine: row.tagLine,
+          size: 'normal'
+        }),
+        h(
+          NPopconfirm,
+          { onPositiveClick: () => handleDelete(row), positiveText: '删除', negativeText: '取消' },
+          {
+            trigger: () =>
+              h(NButton, { text: true, size: 'small', type: 'error' }, { default: () => '删除' }),
+            default: () => '确定删除该玩家的备注？'
+          }
+        )
+      ])
+    }
+  }
+])
+</script>


### PR DESCRIPTION
## Summary
- **玩家备注（issue #67）**：按 puuid 本地存"备注 + 颜色标记"（友好 / 一般 / 小心 / 拉黑），复用现有 config IPC，**零 Rust 改动**。
  - 接入点：对局玩家卡（`PlayerCard`）、玩家详情页（`UserRecord`）、战绩详情页每个玩家行（`MatchDetailModal`）。
  - 设置页新增「我标记过的人」列表（`views/settings/PlayerNotes.vue`），可查看 / 行内编辑 / 删除。
- **遇见记录（类似"遇见过"）**：在战绩详情页标记时，把当前对局拼成一条 `OneGamePlayer` 记入 `PlayerNote.encounters`（gameId / 英雄 / KDA / 胜负 / 敌我 / 日期 / 队列名），按 gameId 去重、最近在前、上限 20 条。徽标气泡与设置页（可展开行）均复用 `MettingPlayersCard` 展示，点卡片可开那局详情。
- **跨窗口实时同步**：备注变更通过 `player-notes-changed` Tauri 事件广播，战绩详情独立窗口与主窗口即时一致，无需重启。
- **Sentry 首次同意弹窗**：#70 的 opt-in 上报默认关闭不变；新增首启同意弹窗（`ErrorReportingConsentDialog`），等客户端连接、首屏就绪后弹一次，预选"启用"但保留真实拒绝、不强制；选择后写 `errorReportingConsentShown`，之后不再弹。

## Test plan
- [x] `npm run check` 通过（prettier + eslint 0 error + vue-tsc + cargo fmt + clippy -Dwarnings）
- [x] `npm run test` 通过（425 passed，含 store + 遇见记录合并测试）
- [x] 手动（运行中客户端 + Tauri MCP）：详情页 10 行标记、遇见记录累积/去重/展开、跨窗口实时同步、首启同意弹窗的启用/拒绝路径

Closes #67