### PR TITLE
docs: 修正 BINARY_CACHE 注释（实际无 TTL/上限、weigher 未生效）

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
@@ -281,7 +281,10 @@ const CDRAGON_STRINGTABLE_URL: &str =
 const CDRAGON_STRINGTABLE_FALLBACK_URL: &str =
     "https://raw.communitydragon.org/latest/game/en_us/data/menu/en_us/lol.stringtable.json";
 
-// Keep binary cache as moka for weighted size-based eviction (still useful) - optional future refactor.
+// BINARY_CACHE：图片字节的进程内缓存。无 TTL、无 max_capacity ——
+// 即**永不过期、永不驱逐**，首次取过后常驻到进程退出（asset 集合有限，内存可控）。
+// 注意：下面的 weigher 已设但**当前不生效** —— moka 仅在配了 max_capacity 时才按权重驱逐。
+// 如需容量上限，给 builder 补 `.max_capacity(...)` 即可激活（代价是冷数据可能被淘汰后重下）。
 use moka::future::Cache; // retained only for BINARY_CACHE
 static BINARY_CACHE: LazyLock<Cache<String, (Vec<u8>, String)>> = LazyLock::new(|| {
     Cache::builder()


### PR DESCRIPTION
## Summary
- `asset.rs` 里 `BINARY_CACHE` 原注释写"weighted size-based eviction (still useful)"，与实现不符：builder 设了 `weigher` 但**没有 `max_capacity`**，moka 只有在配了 `max_capacity` 时才按权重驱逐 → 当前**永不过期、永不驱逐**，weigher 形同虚设。
- 仅改注释，准确描述：无 TTL / 无上限 / 进程内常驻，并说明如何激活容量上限。无行为变更。

## 背景
排查"图标偶发不显示"时确认：图标闪烁仅来自冷启动缓存填充窗口，与缓存淘汰无关（因为根本不淘汰）。顺手把误导性注释修正。

## Test plan
- [x] `cargo fmt --check` 通过
- [x] `cargo clippy --all-targets --all-features -Dwarnings` 通过
- 注释级改动，无逻辑变化