### PR TITLE
feat(ai): stream 直连 DashScope，移除 Cloudflare Worker 代理

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_KEY_PASSWORD }}
           TAURI_SIGNING_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_KEY_PASSWORD }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_KEY_PASSWORD }} # 兼容旧版
+          # 编译期注入 DashScope 密钥：Rust 侧 option_env!("DASHSCOPE_API_KEY") 在
+          # cargo build 时读取并烤进二进制（线上 key）。需在仓库 Secrets 配置。
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
 
       # --- 文件重命名、压缩与路径整理 ---
       - name: 📝 Rename, Compress, and Set Paths

--- a/docs/superpowers/specs/2026-06-13-dashscope-direct-key-design.md
+++ b/docs/superpowers/specs/2026-06-13-dashscope-direct-key-design.md
@@ -1,0 +1,124 @@
+# DashScope 直连 + 打包密钥（移除 Cloudflare Worker）
+
+- 日期：2026-06-13
+- 状态：已设计，待实现
+- 关联：替换前端经 Cloudflare Worker (`https://ai.nuliyangguang.top`) 的 AI 代理
+
+## 背景与目标
+
+当前 AI 链路：前端 `services/ai/stream.ts` 用 `tauriFetch`（plugin-http，走 Rust reqwest，绕开
+CORS）POST 到自建 Cloudflare Worker，Worker 持有 DashScope 密钥、加 `Authorization` 头转发到
+DashScope（OpenAI 兼容端点），把 SSE 流回来。请求/响应已是 OpenAI 兼容形态
+（`{model, messages, stream:true}` → `choices[].delta.content`）。
+
+目标：**砍掉 Cloudflare Worker，客户端直连 DashScope**。密钥放 Rust 层——
+**测试用运行时环境变量、线上编译期注入打包**，明文密钥永不进源码 / git。
+
+### 已知并接受的风险
+
+打进二进制的共享密钥可被用户从二进制 / 抓包中提取并盗刷账单。混淆 / 打包无法消除此风险
+（客户端运行时总要解出明文发请求）。项目主已知情并接受，兜底是「密钥被滥用 → 吊销 + 轮换」。
+保留「用户可填自己的 key 覆盖」作为分流成本与密钥被封时的退路。
+
+> 密钥放 Rust 而非前端 JS：前端 JS bundle 是明文，比二进制更易提取；且「环境变量 / 编译期注入」
+> 本就是 Rust 概念，前端运行时读不到。
+
+## 架构（方案 A：流全走 Rust 命令）
+
+```
+前端 stream.ts.requestAIContentStream
+  → invoke('stream_ai_analysis', { request, onEvent: Channel })
+    → command/ai.rs: 解析密钥 → POST DashScope(兼容端点) → 流式 SSE
+    → Channel 事件 chunk/done/error 回传 → 映射到现有 StreamCallbacks
+```
+
+密钥全程留在 Rust，不进 JS。`requestAIContent`（sessionStorage 缓存包装）与所有 stage 调用方
+（attribution / critique / tagSuggest 等）**不动**——它们都经 `requestAIContentStream` 这一个入口。
+
+## 组件与改动
+
+### 1. Rust `command/ai.rs`（改造已注册的 `stream_ai_analysis`）
+
+**请求结构 `AiStreamRequest`**
+- 保留 `prompt: String`、`system_prompt: Option<String>`
+- 新增 `model: Option<String>`（前端按 stage 传，如 `qwen-plus`）
+- 新增 `api_key: Option<String>`（用户覆盖口子）
+- 删除 `account_id`、删除原必填 `api_token`
+
+**密钥解析（纯函数，可单测）**
+```rust
+fn resolve_api_key(
+    override_key: Option<&str>,
+    runtime_env: Option<&str>,
+    baked: Option<&str>,
+) -> Result<String, String>
+```
+优先级：`override_key`(非空) → `runtime_env`(非空) → `baked`(非空) → `Err("未配置 DashScope 密钥")`。
+空白串视同未配置（`trim().is_empty()`）。
+
+薄封装 `fn api_key(override_key: Option<&str>) -> Result<String, String>`：
+- `runtime_env` = `std::env::var("DASHSCOPE_API_KEY").ok()`（测试 / 开发）
+- `baked` = `option_env!("DASHSCOPE_API_KEY")`（编译期注入；CI 发布构建时设此环境变量）
+
+**端点与请求**
+- 常量 `DASHSCOPE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"`
+- 常量 `DEFAULT_MODEL = "qwen-plus"`（兜底；前端通常显式传 model）
+- 头：`Authorization: Bearer <resolved>`、`Content-Type: application/json`
+- 体：`{ "model": model, "messages": [system, user], "stream": true }`
+
+**SSE 解析（提取为纯函数，可单测）**
+```rust
+fn extract_delta_content(json_line: &str) -> Option<String>
+```
+只认 `choices[0].delta.content`；`data: [DONE]` 与坏 JSON 返回 `None`。删掉 Cloudflare 专用的
+顶层 `response` 字段分支。
+
+**日志 / 安全**
+- 不打印密钥、不打印 prompt / system_prompt 正文（含玩家数据）。
+- 错误事件可含 DashScope 返回的状态码 + 错误体；错误体不应含密钥（DashScope 不回显），可直接透传。
+
+### 2. 前端 `services/ai/stream.ts`
+
+- `requestAIContentStream`：用 `Channel<AiStreamEvent>` + `invoke('stream_ai_analysis', …)` 替换
+  `tauriFetch(AI_WORKER_URL)`。Channel 的 `onmessage` 按 `event` 分发到 `callbacks.onChunk/onDone/onError`。
+- 删除 `AI_WORKER_URL` 常量、手写 SSE 解析 `emitSseLine`、reader/decoder 逻辑。
+- 透传 `model`；从配置读用户覆盖 key（见 §3），非空时作为 `api_key` 传入。
+- 提取一个纯映射函数 `mapStreamEvent(event, callbacks)` 便于 vitest。
+- `requestAIContent`、`DEFAULT_SYSTEM_PROMPT`、各 stage 模型常量保持不变。
+
+事件去重：`onDone` 只由 Rust 的 `done` 事件触发；忽略 `invoke` Promise 的 resolve（命令返回
+仅表示流结束）。`invoke` reject（命令整体失败，如未配置密钥）映射到 `onError`。
+
+### 3. 设置项（覆盖口子）
+
+- 在 `services/configKeys.ts` 登记配置键 `dashscopeApiKey`（字符串，默认空）。
+- 在 `views/settings/General.vue` 加一个可选文本输入：「自定义 DashScope API Key（留空用内置）」，
+  经现有 `putConfigByIpc` 持久化。
+- `stream.ts` 启动请求前读该配置；空 → 不传 `api_key`（后端走 env / 打包）。
+
+### 4. 收尾（非纯代码）
+
+- CI 发布工作流（`.github/workflows/*`）注入 `DASHSCOPE_API_KEY` 构建 secret，使 `option_env!`
+  在 release 构建生效。开发 / 测试不设此编译期变量，仅设运行时环境变量。
+- 清理 Cloudflare 残留：`AI_WORKER_URL`、`command/ai.rs` 中 Cloudflare Workers AI 的旧 URL /
+  `account_id` 字段。Worker 本身（外部仓库）的下线由项目主自行处理。
+
+## 测试
+
+**Rust（TDD）**
+- `resolve_api_key`：覆盖 > env > baked > 报错；空白串视同未配置；各优先级边界。
+- `extract_delta_content`：正常 chunk 提取、`[DONE]`、坏 JSON、缺字段。
+
+**前端（vitest）**
+- `mapStreamEvent`：chunk → onChunk(data)，done → onDone，error → onError(data)。
+
+**发布前人工验证**
+- 用轮换后的新 key（设进运行时环境变量，不写文件）跑一轮 `qwen-turbo` vs `qwen-plus` 延迟 + 质量
+  对比，确认默认模型；各 stage 模型沿用已调好的选择。
+
+## 非目标
+
+- 不改各 stage 已调优的模型选型逻辑（仅设兜底默认）。
+- 不改 `requestAIContent` 的 sessionStorage 缓存行为。
+- 不实现密钥混淆 / 加固（无意义，已述）。
+- 不接管 Worker 外部仓库的下线。

--- a/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
@@ -146,7 +146,10 @@ pub async fn stream_ai_analysis(
     );
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
-    // 构建请求体
+    // 构建请求体。
+    // 注意：canonical 系统提示词在前端 `stream.ts` 的 `DEFAULT_SYSTEM_PROMPT`，
+    // 所有调用路径都会带上非空 systemPrompt，下面仅是 systemPrompt 缺省时的兜底，
+    // 不要在此处维护"权威"提示词（避免与前端分叉）。
     let system_prompt = request
         .system_prompt
         .unwrap_or_else(|| "你是一个LOL游戏分析师，擅长分析玩家战绩和给出游戏建议。请用简洁、专业、直接的中文回复。".to_string());

--- a/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
@@ -1,21 +1,21 @@
 //! # AI 分析命令模块
 //!
-//! 提供流式 AI 分析功能，调用 Cloudflare Workers AI API。
+//! 提供流式 AI 分析功能，直连 DashScope (通义千问) OpenAI 兼容端点。
 //!
 //! ## 主要功能
 //!
 //! - **流式 AI 请求**: 通过 Tauri Channel 实现 SSE 流式输出到前端
-//! - **Cloudflare AI**: 调用 @cf/qwen/qwen2.5-coder-14b-instruct 模型
+//! - **DashScope (通义千问)**: 调 OpenAI 兼容端点，密钥在 Rust 层解析（见 resolve_api_key）
 //!
 //! ## 使用示例
 //!
-//! ```rust,ignore
-//! // 前端调用
-//! let (rx, tx) = channel::<String>();
-//! invoke('stream_ai_analysis', {
-//!   prompt: "分析这段战绩...",
-//!   system_prompt: "你是LOL分析师...",
-//!   onChunk: (chunk) => console.log(chunk)
+//! ```ts
+//! // 前端调用（参数为 camelCase，与 AiStreamRequest 的 serde rename 对应）
+//! const channel = new Channel<AiStreamEvent>()
+//! channel.onmessage = (e) => { /* e.event: 'chunk' | 'done' | 'error' */ }
+//! await invoke('stream_ai_analysis', {
+//!   request: { prompt: '分析这段战绩...', systemPrompt: '你是LOL分析师...' },
+//!   onEvent: channel
 //! })
 //! ```
 
@@ -38,12 +38,10 @@ fn resolve_api_key(
     runtime_env: Option<&str>,
     baked: Option<&str>,
 ) -> Result<String, String> {
-    for candidate in [override_key, runtime_env, baked] {
-        if let Some(k) = candidate {
-            let trimmed = k.trim();
-            if !trimmed.is_empty() {
-                return Ok(trimmed.to_string());
-            }
+    for k in [override_key, runtime_env, baked].into_iter().flatten() {
+        let trimmed = k.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
         }
     }
     Err("未配置 DashScope 密钥（设置 DASHSCOPE_API_KEY 环境变量，或在设置中填入）".to_string())
@@ -83,12 +81,18 @@ fn extract_delta_content(line: &str) -> Option<String> {
 }
 
 /// AI 请求参数
+///
+/// `rename_all = "camelCase"`：前端 invoke 传 `systemPrompt` / `apiKey`（camelCase），
+/// 必须与 Rust snake_case 字段对齐，否则 serde 反序列化失败。
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AiStreamRequest {
     pub prompt: String,
     pub system_prompt: Option<String>,
-    pub account_id: String,
-    pub api_token: String,
+    /// 模型名（如 `qwen-plus`）；缺省用 `DEFAULT_MODEL`
+    pub model: Option<String>,
+    /// 用户在设置中填的覆盖密钥；空 / 缺省时用 env / 编译期注入
+    pub api_key: Option<String>,
 }
 
 /// AI 流式响应事件
@@ -116,17 +120,29 @@ pub async fn stream_ai_analysis(
     request: AiStreamRequest,
     on_event: Channel<AiStreamEvent>,
 ) -> Result<(), String> {
-    let url = format!(
-        "https://api.cloudflare.com/client/v4/accounts/{}/ai/run/@cf/qwen/qwen2.5-coder-14b-instruct",
-        request.account_id
-    );
+    // 解析密钥（用户覆盖 → env → 编译期注入）。失败时发 error 事件并结束（不 reject 命令）。
+    let key = match api_key(request.api_key.as_deref()) {
+        Ok(k) => k,
+        Err(e) => {
+            let _ = on_event.send(AiStreamEvent {
+                event: "error".to_string(),
+                data: Some(e),
+            });
+            return Ok(());
+        }
+    };
+    let model = request
+        .model
+        .as_deref()
+        .unwrap_or(DEFAULT_MODEL)
+        .to_string();
 
     // 构建请求头
     let mut headers = HeaderMap::new();
     headers.insert(
         AUTHORIZATION,
-        HeaderValue::from_str(&format!("Bearer {}", request.api_token))
-            .map_err(|e| format!("Invalid API token: {}", e))?,
+        HeaderValue::from_str(&format!("Bearer {}", key))
+            .map_err(|e| format!("Invalid API key: {}", e))?,
     );
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
@@ -136,15 +152,10 @@ pub async fn stream_ai_analysis(
         .unwrap_or_else(|| "你是一个LOL游戏分析师，擅长分析玩家战绩和给出游戏建议。请用简洁、专业、直接的中文回复。".to_string());
 
     let body = json!({
+        "model": model,
         "messages": [
-            {
-                "role": "system",
-                "content": system_prompt
-            },
-            {
-                "role": "user",
-                "content": request.prompt
-            }
+            { "role": "system", "content": system_prompt },
+            { "role": "user", "content": request.prompt }
         ],
         "stream": true
     });
@@ -157,7 +168,7 @@ pub async fn stream_ai_analysis(
 
     // 发送请求
     let response = client
-        .post(&url)
+        .post(DASHSCOPE_URL)
         .headers(headers)
         .json(&body)
         .send()
@@ -171,7 +182,11 @@ pub async fn stream_ai_analysis(
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_string());
-        return Err(format!("API error ({}): {}", status, error_text));
+        let _ = on_event.send(AiStreamEvent {
+            event: "error".to_string(),
+            data: Some(format!("API error ({}): {}", status, error_text)),
+        });
+        return Ok(());
     }
 
     // 获取响应流
@@ -190,50 +205,20 @@ pub async fn stream_ai_analysis(
                     let line = buffer[..line_end].trim().to_string();
                     buffer = buffer[line_end + 1..].to_string();
 
-                    if line.is_empty() || line == "data: [DONE]" {
-                        continue;
-                    }
-
-                    // 解析 SSE 数据行
-                    if let Some(data) = line.strip_prefix("data: ") {
-                        match serde_json::from_str::<serde_json::Value>(data) {
-                            Ok(json) => {
-                                // 提取响应内容
-                                let content = json
-                                    .get("response")
-                                    .and_then(|v| v.as_str())
-                                    .or_else(|| {
-                                        json.get("choices")
-                                            .and_then(|c| c.get(0))
-                                            .and_then(|c| c.get("delta"))
-                                            .and_then(|d| d.get("content"))
-                                            .and_then(|c| c.as_str())
-                                    })
-                                    .unwrap_or("")
-                                    .to_string();
-
-                                if !content.is_empty() {
-                                    // 发送 chunk 事件到前端
-                                    let _ = on_event.send(AiStreamEvent {
-                                        event: "chunk".to_string(),
-                                        data: Some(content),
-                                    });
-                                }
-                            }
-                            Err(_) => {
-                                // 忽略解析错误，继续处理
-                            }
-                        }
+                    if let Some(content) = extract_delta_content(&line) {
+                        let _ = on_event.send(AiStreamEvent {
+                            event: "chunk".to_string(),
+                            data: Some(content),
+                        });
                     }
                 }
             }
             Err(e) => {
-                // 发送错误事件
                 let _ = on_event.send(AiStreamEvent {
                     event: "error".to_string(),
                     data: Some(format!("Stream error: {}", e)),
                 });
-                return Err(format!("Stream error: {}", e));
+                return Ok(());
             }
         }
     }
@@ -267,8 +252,14 @@ mod tests {
     #[test]
     fn resolve_treats_blank_as_unset() {
         // 覆盖为空白时应跳到下一优先级，而不是用空 key
-        assert_eq!(resolve_api_key(Some("  "), Some("env"), None).unwrap(), "env");
-        assert_eq!(resolve_api_key(Some(""), None, Some("baked")).unwrap(), "baked");
+        assert_eq!(
+            resolve_api_key(Some("  "), Some("env"), None).unwrap(),
+            "env"
+        );
+        assert_eq!(
+            resolve_api_key(Some(""), None, Some("baked")).unwrap(),
+            "baked"
+        );
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
@@ -60,6 +60,28 @@ fn api_key(override_key: Option<&str>) -> Result<String, String> {
     )
 }
 
+/// 从一行 SSE 文本提取增量 token。接受带或不带 `data: ` 前缀的行；
+/// `[DONE]`、坏 JSON、缺 `choices[0].delta.content` 均返回 `None`。
+fn extract_delta_content(line: &str) -> Option<String> {
+    let data = line.trim();
+    let data = data.strip_prefix("data: ").unwrap_or(data).trim();
+    if data.is_empty() || data == "[DONE]" {
+        return None;
+    }
+    let json: serde_json::Value = serde_json::from_str(data).ok()?;
+    let content = json
+        .get("choices")?
+        .get(0)?
+        .get("delta")?
+        .get("content")?
+        .as_str()?;
+    if content.is_empty() {
+        None
+    } else {
+        Some(content.to_string())
+    }
+}
+
 /// AI 请求参数
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiStreamRequest {
@@ -253,5 +275,23 @@ mod tests {
     fn resolve_errors_when_all_unset() {
         assert!(resolve_api_key(None, None, None).is_err());
         assert!(resolve_api_key(Some(" "), Some(""), None).is_err());
+    }
+
+    #[test]
+    fn extract_pulls_delta_content() {
+        let line = r#"data: {"choices":[{"delta":{"content":"你好"}}]}"#;
+        assert_eq!(extract_delta_content(line), Some("你好".to_string()));
+    }
+
+    #[test]
+    fn extract_handles_done_and_garbage() {
+        assert_eq!(extract_delta_content("data: [DONE]"), None);
+        assert_eq!(extract_delta_content("data: {not json"), None);
+        assert_eq!(extract_delta_content(""), None);
+        // 有结构但无 content 字段（如仅 role 的首包）
+        assert_eq!(
+            extract_delta_content(r#"data: {"choices":[{"delta":{"role":"assistant"}}]}"#),
+            None
+        );
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/ai.rs
@@ -25,6 +25,41 @@ use serde_json::json;
 use std::time::Duration;
 use tauri::ipc::Channel;
 
+/// DashScope OpenAI 兼容 chat 端点。
+const DASHSCOPE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions";
+
+/// 前端未指定 model 时的兜底（发布前 benchmark 后可调，见计划 Task 7）。
+const DEFAULT_MODEL: &str = "qwen-plus";
+
+/// 按优先级解析 DashScope 密钥：用户覆盖 > 运行时环境变量 > 编译期注入。
+/// 空白串视同未配置。纯函数，便于单测。
+fn resolve_api_key(
+    override_key: Option<&str>,
+    runtime_env: Option<&str>,
+    baked: Option<&str>,
+) -> Result<String, String> {
+    for candidate in [override_key, runtime_env, baked] {
+        if let Some(k) = candidate {
+            let trimmed = k.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+    }
+    Err("未配置 DashScope 密钥（设置 DASHSCOPE_API_KEY 环境变量，或在设置中填入）".to_string())
+}
+
+/// 解析最终密钥：用户覆盖 → 运行时环境变量（测试/开发）→ `option_env!` 编译期注入（线上）。
+/// 线上由 CI 在构建时设 `DASHSCOPE_API_KEY`，明文密钥不进源码 / git。
+fn api_key(override_key: Option<&str>) -> Result<String, String> {
+    let runtime = std::env::var("DASHSCOPE_API_KEY").ok();
+    resolve_api_key(
+        override_key,
+        runtime.as_deref(),
+        option_env!("DASHSCOPE_API_KEY"),
+    )
+}
+
 /// AI 请求参数
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiStreamRequest {
@@ -188,4 +223,35 @@ pub async fn stream_ai_analysis(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_override_then_env_then_baked() {
+        assert_eq!(
+            resolve_api_key(Some("ov"), Some("env"), Some("baked")).unwrap(),
+            "ov"
+        );
+        assert_eq!(
+            resolve_api_key(None, Some("env"), Some("baked")).unwrap(),
+            "env"
+        );
+        assert_eq!(resolve_api_key(None, None, Some("baked")).unwrap(), "baked");
+    }
+
+    #[test]
+    fn resolve_treats_blank_as_unset() {
+        // 覆盖为空白时应跳到下一优先级，而不是用空 key
+        assert_eq!(resolve_api_key(Some("  "), Some("env"), None).unwrap(), "env");
+        assert_eq!(resolve_api_key(Some(""), None, Some("baked")).unwrap(), "baked");
+    }
+
+    #[test]
+    fn resolve_errors_when_all_unset() {
+        assert!(resolve_api_key(None, None, None).is_err());
+        assert!(resolve_api_key(Some(" "), Some(""), None).is_err());
+    }
 }

--- a/lol-record-analysis-tauri/src/services/ai/__tests__/stream.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/__tests__/stream.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { AiStreamEvent } from '../stream'
+import { mapStreamEvent, requestAIContentStream } from '../stream'
+import type { StreamCallbacks } from '../types'
+
+// 用可手动驱动的假 Channel 替换真实 IPC，单测 requestAIContentStream 的终态去重。
+vi.mock('@tauri-apps/api/core', () => {
+  class Channel {
+    onmessage: ((e: AiStreamEvent) => void) | null = null
+  }
+  return { Channel, invoke: vi.fn() }
+})
+vi.mock('../ipc', () => ({ getConfigByIpc: vi.fn().mockResolvedValue(undefined) }))
+
+function makeCallbacks(): StreamCallbacks & {
+  chunks: string[]
+  done: number
+  errors: string[]
+} {
+  const chunks: string[] = []
+  const errors: string[] = []
+  let done = 0
+  return {
+    chunks,
+    errors,
+    get done() {
+      return done
+    },
+    onChunk: (c: string) => chunks.push(c),
+    onDone: () => {
+      done++
+    },
+    onError: (e: string) => errors.push(e)
+  } as any
+}
+
+describe('mapStreamEvent', () => {
+  it('chunk 事件转发非空 data 到 onChunk', () => {
+    const cb = makeCallbacks()
+    mapStreamEvent({ event: 'chunk', data: '你好' }, cb)
+    expect(cb.chunks).toEqual(['你好'])
+  })
+
+  it('done 事件触发 onDone', () => {
+    const cb = makeCallbacks()
+    mapStreamEvent({ event: 'done' }, cb)
+    expect(cb.done).toBe(1)
+  })
+
+  it('error 事件把 data 传给 onError，缺省给兜底文案', () => {
+    const cb = makeCallbacks()
+    mapStreamEvent({ event: 'error', data: '炸了' }, cb)
+    mapStreamEvent({ event: 'error' }, cb)
+    expect(cb.errors).toEqual(['炸了', 'AI 请求失败'])
+  })
+})
+
+describe('requestAIContentStream 终态恰好一次', () => {
+  it('首个终态后忽略后续 done/error', async () => {
+    const { invoke } = await import('@tauri-apps/api/core')
+    let channel: { onmessage: ((e: AiStreamEvent) => void) | null } = { onmessage: null }
+    ;(invoke as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_cmd: string, args: { onEvent: typeof channel }) => {
+        channel = args.onEvent
+      }
+    )
+
+    const cb = makeCallbacks()
+    await requestAIContentStream('p', cb)
+
+    // 模拟后端先发 error，再(异常地)发 done + error：只应触发一次 onError，不触发 onDone
+    channel.onmessage?.({ event: 'error', data: '炸了' })
+    channel.onmessage?.({ event: 'done' })
+    channel.onmessage?.({ event: 'error', data: '又炸' })
+
+    expect(cb.errors).toEqual(['炸了'])
+    expect(cb.done).toBe(0)
+  })
+})

--- a/lol-record-analysis-tauri/src/services/ai/shared/twoStage.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/twoStage.ts
@@ -25,7 +25,7 @@ export interface Stage1Config<Out> {
   parse: (raw: string) => ParseOutcome<Out>
   cacheKey?: string
   retry?: number
-  /** AI model name; falls back to worker default (qwen-turbo) when omitted. */
+  /** AI model name; falls back to stream.ts DEFAULT_MODEL (qwen-plus) when omitted. */
   model?: string
 }
 
@@ -36,7 +36,7 @@ export interface Stage2Config<In, Out> {
   cacheKey?: string
   retry?: number
   streamCallback?: (chunk: string) => void
-  /** AI model name; falls back to worker default (qwen-turbo) when omitted. */
+  /** AI model name; falls back to stream.ts DEFAULT_MODEL (qwen-plus) when omitted. */
   model?: string
 }
 

--- a/lol-record-analysis-tauri/src/services/ai/stream.ts
+++ b/lol-record-analysis-tauri/src/services/ai/stream.ts
@@ -1,23 +1,41 @@
 /**
- * 通过 Cloudflare Worker 代理的流式 AI 请求
+ * 经 Rust 命令 stream_ai_analysis 直连 DashScope 的流式 AI 请求
  * 以及基于 sessionStorage 的结果缓存包装
  */
 
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { invoke, Channel } from '@tauri-apps/api/core'
+import { getConfigByIpc } from '../ipc'
+import { CONFIG_KEYS } from '../configKeys'
 import type { AIAnalysisResult, StreamCallbacks } from './types'
 
 export const DEFAULT_SYSTEM_PROMPT =
   '你是一个LOL游戏分析师，擅长分析玩家战绩和给出游戏建议。请用简洁、专业、直接的中文回复。所有结论都必须绑定数据证据，避免空泛。'
 
-const AI_WORKER_URL = 'https://ai.nuliyangguang.top'
-
 /**
- * AI Worker 默认模型（DashScope 兼容 OpenAI 协议）。
- * 各 stage 调用方按 use case 覆盖：
- * - Stage 1 attribution / Stage 1 profile: qwen-plus（JSON 严格度好）
- * - Stage 2 critique / Stage 2 naming: qwen-max（中文锐评感强）
+ * 默认模型（DashScope 兼容 OpenAI 协议）。各 stage 调用方按 use case 覆盖。
  */
-export const DEFAULT_MODEL = 'qwen-turbo'
+export const DEFAULT_MODEL = 'qwen-plus'
+
+/** Rust stream_ai_analysis 命令经 Channel 回传的事件 */
+export interface AiStreamEvent {
+  event: 'chunk' | 'done' | 'error'
+  data?: string | null
+}
+
+/** 把 Channel 事件映射到 StreamCallbacks（纯函数，便于测试） */
+export function mapStreamEvent(evt: AiStreamEvent, callbacks: StreamCallbacks): void {
+  switch (evt.event) {
+    case 'chunk':
+      if (evt.data) callbacks.onChunk(evt.data)
+      break
+    case 'done':
+      callbacks.onDone()
+      break
+    case 'error':
+      callbacks.onError(evt.data || 'AI 请求失败')
+      break
+  }
+}
 
 export async function requestAIContentStream(
   prompt: string,
@@ -25,77 +43,32 @@ export async function requestAIContentStream(
   systemPrompt: string = DEFAULT_SYSTEM_PROMPT,
   model: string = DEFAULT_MODEL
 ): Promise<void> {
-  try {
-    // 用 Tauri HTTP 插件而不是 webview fetch:
-    // - release 包 webview origin 是 http://tauri.localhost, 跟 dev 的 http://localhost:1420
-    //   不一样, Cloudflare Worker 的 CORS 白名单很可能只放行 dev origin
-    // - plugin-http 走 Rust 端 reqwest, 不经过 webview, 没有 CORS 限制
-    const response = await tauriFetch(AI_WORKER_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: prompt }
-        ],
-        stream: true
-      })
-    })
-
-    if (!response.ok) {
-      const errorText = await response.text()
-      throw new Error(`HTTP error! status: ${response.status}, ${errorText}`)
-    }
-
-    const reader = response.body?.getReader()
-    if (!reader) {
-      throw new Error('无法读取响应流')
-    }
-
-    const decoder = new TextDecoder()
-    let buffer = ''
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-
-      buffer += decoder.decode(value, { stream: true })
-      const lines = buffer.split('\n')
-      buffer = lines.pop() || ''
-
-      for (const line of lines) {
-        emitSseLine(line, callbacks)
-      }
-    }
-
-    const remaining = buffer.trim()
-    if (remaining) {
-      emitSseLine(remaining, callbacks)
-    }
-
-    callbacks.onDone()
-  } catch (error: any) {
-    callbacks.onError(error.message || '流式请求失败')
+  let settled = false
+  const settle = (fn: () => void) => {
+    if (settled) return
+    settled = true
+    fn()
   }
-}
-
-function emitSseLine(line: string, callbacks: StreamCallbacks) {
-  const trimmed = line.trim()
-  if (!trimmed || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) return
-
-  const jsonStr = trimmed.slice(6)
-  if (jsonStr === '[DONE]') return
-
   try {
-    const data = JSON.parse(jsonStr)
-    const content = data.choices?.[0]?.delta?.content || ''
-    if (content) callbacks.onChunk(content)
-  } catch {
-    // 忽略单行解析错误，继续消费流
+    // 用户覆盖 key（设置里可填）；空则后端走 env / 编译期注入
+    const override = (await getConfigByIpc<string>(CONFIG_KEYS.dashscopeApiKey)) || undefined
+
+    // 终态回调（onDone/onError）经 settle 包裹，保证恰好触发一次；分发统一走
+    // mapStreamEvent，避免 done/error 逻辑与兜底文案在两处重复。
+    const channel = new Channel<AiStreamEvent>()
+    channel.onmessage = evt =>
+      mapStreamEvent(evt, {
+        onChunk: callbacks.onChunk,
+        onDone: () => settle(callbacks.onDone),
+        onError: e => settle(() => callbacks.onError(e))
+      })
+
+    await invoke('stream_ai_analysis', {
+      request: { prompt, systemPrompt, model, apiKey: override },
+      onEvent: channel
+    })
+  } catch (error: any) {
+    settle(() => callbacks.onError(error?.message || String(error) || '流式请求失败'))
   }
 }
 

--- a/lol-record-analysis-tauri/src/services/configKeys.ts
+++ b/lol-record-analysis-tauri/src/services/configKeys.ts
@@ -16,5 +16,7 @@ export const CONFIG_KEYS = {
   /** 是否开启 Sentry 错误上报 / 日志转发（opt-in，release 默认关、debug 默认开） */
   errorReportingEnabled: 'errorReportingEnabled',
   /** 是否已就错误上报询问过用户（首次同意弹窗用，问过即不再弹） */
-  errorReportingConsentShown: 'errorReportingConsentShown'
+  errorReportingConsentShown: 'errorReportingConsentShown',
+  /** 用户自定义 DashScope API Key（留空用内置打包 key） */
+  dashscopeApiKey: 'dashscopeApiKey'
 } as const

--- a/lol-record-analysis-tauri/src/views/settings/General.vue
+++ b/lol-record-analysis-tauri/src/views/settings/General.vue
@@ -17,6 +17,20 @@
           </n-text>
         </n-space>
       </n-form-item>
+      <n-form-item label="自定义 AI Key">
+        <n-space vertical :size="4">
+          <n-input
+            v-model:value="dashscopeKey"
+            type="password"
+            show-password-on="click"
+            placeholder="留空使用内置 Key"
+            @blur="handleDashscopeKeyUpdate"
+          />
+          <n-text :depth="3" style="font-size: 12px">
+            填入你自己的 DashScope (通义千问) API Key 则走你的额度；留空使用内置 Key。
+          </n-text>
+        </n-space>
+      </n-form-item>
     </n-form>
   </n-card>
 </template>
@@ -29,6 +43,7 @@ import { useMessage } from 'naive-ui'
 
 const matchCount = ref(4)
 const errorReporting = ref(false)
+const dashscopeKey = ref('')
 const message = useMessage()
 
 onMounted(async () => {
@@ -44,6 +59,14 @@ onMounted(async () => {
     const enabled = await getConfigByIpc<boolean>(CONFIG_KEYS.errorReportingEnabled)
     if (typeof enabled === 'boolean') {
       errorReporting.value = enabled
+    }
+  } catch (e) {
+    console.error(e)
+  }
+  try {
+    const key = await getConfigByIpc<string>(CONFIG_KEYS.dashscopeApiKey)
+    if (typeof key === 'string') {
+      dashscopeKey.value = key
     }
   } catch (e) {
     console.error(e)
@@ -64,6 +87,15 @@ const handleReportingUpdate = async (value: boolean) => {
   try {
     await putConfigByIpc(CONFIG_KEYS.errorReportingEnabled, value)
     message.success('设置已保存，重启后生效')
+  } catch (e) {
+    message.error('保存失败')
+  }
+}
+
+const handleDashscopeKeyUpdate = async () => {
+  try {
+    await putConfigByIpc(CONFIG_KEYS.dashscopeApiKey, dashscopeKey.value.trim())
+    message.success('设置已保存')
   } catch (e) {
     message.error('保存失败')
   }


### PR DESCRIPTION
## Summary
- 前端 `stream.ts` 改走 `invoke('stream_ai_analysis') + Channel`，由 Rust 直连 DashScope OpenAI 兼容端点，删除经 Cloudflare Worker 的 `tauriFetch` 路径与手写 SSE 解析
- Rust 侧 `command/ai.rs`：密钥按 `用户覆盖 > 运行时 env > 编译期 option_env!` 优先级解析（`resolve_api_key` 纯函数），SSE 增量提取抽成 `extract_delta_content` 纯函数，均带单测
- 设置页支持填自定义 DashScope Key 覆盖内置（`configKeys.ts` + `General.vue`）
- 终态去重：`onDone/onError` 经 `settle` 保证恰好触发一次，分发统一走 `mapStreamEvent`
- CI 发布构建注入 `DASHSCOPE_API_KEY` 编译期密钥（`release.yml`），明文密钥不进源码/git
- 默认模型 `qwen-turbo` → `qwen-plus`

## Test plan
- [x] `npm run check` 通过（0 error）
- [x] `npm run test`（含新增 `stream.spec.ts`：mapStreamEvent + 终态恰好一次）
- [x] `cargo test`（resolve_api_key / extract_delta_content 覆盖优先级、[DONE]、坏 JSON、缺字段）
- [ ] 发布前用轮换后的新 key 跑一轮真实流式验证