### PR TITLE
feat(lcu): 权限不足引导以管理员身份重启，并修复启动期连接/资源健壮性

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/.gitignore
+++ b/lol-record-analysis-tauri/src-tauri/.gitignore
@@ -6,4 +6,7 @@
 # will have schema files for capabilities auto-completion
 /gen/schemas
 
+# 运行时生成的匿名设备 ID（Sentry 上报用），每台机器各异，不入库
+/device_id
+
 *claude*

--- a/lol-record-analysis-tauri/src-tauri/Cargo.lock
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "tokio-tungstenite 0.20.1",
  "url",
  "urlencoding",
+ "uuid",
  "winapi",
 ]
 

--- a/lol-record-analysis-tauri/src-tauri/Cargo.toml
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.toml
@@ -40,6 +40,8 @@ winapi = { version = "0.3.9", features = [
     "libloaderapi",
     "memoryapi",
     "winnt",
+    "shellapi",
+    "winuser",
 ] } # 用于 Windows api，用于获取lol进程信息
 log = "0.4.0"
 env_logger = "0.11"

--- a/lol-record-analysis-tauri/src-tauri/src/command.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command.rs
@@ -46,6 +46,7 @@ pub mod match_history;
 pub mod rank;
 pub mod rule_config;
 pub mod session;
+pub mod system;
 pub mod user_tag;
 pub mod user_tag_config;
 

--- a/lol-record-analysis-tauri/src-tauri/src/command/system.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/system.rs
@@ -1,0 +1,69 @@
+//! # 系统命令模块
+//!
+//! 与操作系统交互的辅助命令。目前提供"以管理员身份重启"——当检测到游戏客户端
+//! 以更高完整性级别（管理员）运行、本工具无权读取其进程信息（`ACCESS_DENIED`）时，
+//! 前端据此引导用户提权重启本工具。
+//!
+//! 采用**按需提权**而非在清单里强制 `requireAdministrator`：后者会让每次启动都弹
+//! UAC，并与 `currentUser` 安装模式、自动更新静默重启相冲突。只在真正需要时提权，
+//! 普通使用路径不受影响。
+
+/// 以管理员身份重新启动本程序。
+///
+/// 通过 `ShellExecuteW` 的 `runas` 动词拉起一个提权实例（触发 UAC），成功后退出
+/// 当前普通权限实例。用户在 UAC 取消则返回错误，当前实例不退出。
+///
+/// # 返回值
+///
+/// - `Ok(())`: 已拉起提权实例（随后当前进程退出）
+/// - `Err(String)`: 拉起失败（如用户取消 UAC）
+#[tauri::command]
+pub fn relaunch_as_admin(app: tauri::AppHandle) -> Result<(), String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use winapi::um::shellapi::ShellExecuteW;
+    use winapi::um::winuser::SW_SHOWNORMAL;
+
+    log::info!("用户请求以管理员身份重启");
+
+    // 失败文本里不带路径：路径含 `C:\Users\<用户名>\`，开启上报时会随日志外传，
+    // 而 redact_pii 不覆盖自由文本里的 Windows 路径。
+    let exe = std::env::current_exe().map_err(|e| {
+        log::error!("以管理员身份重启失败：获取当前程序路径失败: {}", e);
+        format!("获取当前程序路径失败: {}", e)
+    })?;
+
+    // ShellExecuteW 需要以 null 结尾的宽字符串。
+    let to_wide = |s: &OsStr| -> Vec<u16> { s.encode_wide().chain(std::iter::once(0)).collect() };
+    let verb = to_wide(OsStr::new("runas"));
+    let file = to_wide(exe.as_os_str());
+
+    let result = unsafe {
+        ShellExecuteW(
+            std::ptr::null_mut(),
+            verb.as_ptr(),
+            file.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            SW_SHOWNORMAL,
+        )
+    };
+
+    // ShellExecuteW 返回值 > 32 表示成功；<= 32 为错误码（用户取消 UAC 时为
+    // SE_ERR_ACCESSDENIED 等）。
+    if (result as isize) <= 32 {
+        log::warn!(
+            "以管理员身份重启失败（ShellExecuteW 错误码 {}），用户可能取消了 UAC 提示",
+            result as isize
+        );
+        return Err(format!(
+            "以管理员身份重启失败（错误码 {}），用户可能取消了 UAC 提示",
+            result as isize
+        ));
+    }
+
+    // 提权实例已拉起，退出当前普通权限实例，避免两份同时运行。
+    log::info!("已拉起提权实例，退出当前普通权限实例");
+    app.exit(0);
+    Ok(())
+}

--- a/lol-record-analysis-tauri/src-tauri/src/game_state_monitor.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/game_state_monitor.rs
@@ -65,6 +65,7 @@ use crate::lcu::api::summoner::Summoner;
 /// - `phase`: 当前游戏阶段（如 "Lobby", "ChampSelect", "InProgress" 等），未连接时为 None
 /// - `summoner`: 当前登录的召唤师信息，未连接时为 None
 #[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GameStateEvent {
     /// LCU 客户端连接状态
     pub connected: bool,
@@ -72,6 +73,13 @@ pub struct GameStateEvent {
     pub phase: Option<String>,
     /// 当前登录的召唤师信息
     pub summoner: Option<Summoner>,
+    /// 未连接时的失败归类码（`NOT_RUNNING` / `ACCESS_DENIED` / `OTHER`）。
+    ///
+    /// 已连接或仅是 API 短暂抖动时为 `None`。前端据此决定是否展示"以管理员
+    /// 身份重启"等引导。
+    pub reason_code: Option<String>,
+    /// 未连接时面向用户的失败说明（与 `reason_code` 同源）。
+    pub reason_message: Option<String>,
 }
 
 /// 全局游戏状态监听器实例。
@@ -116,6 +124,8 @@ impl GameStateMonitor {
                 connected: false,
                 phase: None,
                 summoner: None,
+                reason_code: None,
+                reason_message: None,
             },
             last_push_time: SystemTime::now(),
         }
@@ -139,16 +149,32 @@ impl GameStateMonitor {
         // 尝试获取 summoner 信息
         let summoner_result = Summoner::get_my_summoner().await;
         let phase_result = get_phase().await;
+        let connected = summoner_result.is_ok();
 
-        let new_state = GameStateEvent {
-            connected: summoner_result.is_ok(),
-            phase: phase_result.ok(),
-            summoner: summoner_result.ok(),
+        // 未连接时进一步归类原因：区分"游戏没开"（正常等待）与"权限不足"
+        // （需引导用户提权）。已连接，或仅是 API 短暂抖动（进程在但请求失败）时
+        // 不展示任何告警，避免误导。
+        let (reason_code, reason_message) = if connected {
+            (None, None)
+        } else {
+            match crate::lcu::util::token::get_auth_detailed() {
+                Ok(_) => (None, None),
+                Err(e) => (Some(e.code().to_string()), Some(e.to_string())),
+            }
         };
 
-        // 检查状态是否改变
+        let new_state = GameStateEvent {
+            connected,
+            phase: phase_result.ok(),
+            summoner: summoner_result.ok(),
+            reason_code,
+            reason_message,
+        };
+
+        // 检查状态是否改变（含 reason_code，使提权引导能及时出现/消失）
         let state_changed = new_state.connected != self.last_state.connected
-            || new_state.phase != self.last_state.phase;
+            || new_state.phase != self.last_state.phase
+            || new_state.reason_code != self.last_state.reason_code;
         let now = SystemTime::now();
         let diff_time = now
             .duration_since(self.last_push_time)

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
@@ -506,12 +506,47 @@ pub async fn init() {
     log::info!("Asset API caches initialized successfully");
 }
 
+/// 自愈用单飞器：仅当 `is_empty()` 为真时，拿锁后再次确认仍为空，才跑一次 `run_init`。
+/// 并发调用只触发一次 init，其余等锁后复查即返回。抽出来便于单测（不依赖 LCU）。
+async fn run_once_if_empty<E, I, F>(is_empty: E, lock: &tokio::sync::Mutex<()>, run_init: I)
+where
+    E: Fn() -> bool,
+    I: Fn() -> F,
+    F: std::future::Future<Output = ()>,
+{
+    if !is_empty() {
+        return;
+    }
+    let _guard = lock.lock().await;
+    // 双检：等锁期间可能已有别的请求填好缓存。
+    if !is_empty() {
+        return;
+    }
+    run_init().await;
+}
+
+/// 资源缓存自愈：启动竞态下缓存还空时，确保 [`init`] 至少跑过一次再继续，
+/// 避免协议处理器在缓存就绪前对 champion/item/perk 图标直接返回 404（首屏图裂、
+/// 且因 no-store 不缓存失败、又无前端重试，会一直裂到手动刷新）。
+///
+/// **只能在异步协议处理器里 await**（见 main.rs 的 `register_asynchronous_uri_scheme_protocol`）：
+/// init 会发多次 LCU 请求、耗时较长，绝不可在同步处理器里 `block_on`，否则会占满
+/// webview 资源加载线程导致 UI 卡死。
+async fn ensure_caches_ready() {
+    static ASSET_INIT_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+        LazyLock::new(|| tokio::sync::Mutex::new(()));
+    run_once_if_empty(champion_cache_is_empty, &ASSET_INIT_LOCK, init).await;
+}
+
 // 新增：返回二进制与 content-type，便于通过 HTTP 下发
 pub async fn get_asset_binary(type_string: String, id: i64) -> Result<(Vec<u8>, String), String> {
     let cache_key = build_asset_key(&type_string, id);
     if let Some(hit) = BINARY_CACHE.get(&cache_key).await {
         return Ok(hit);
     }
+
+    // 自愈：缓存未就绪（启动竞态）时先确保 init 跑过一次，避免直接 404。
+    ensure_caches_ready().await;
 
     let result = match type_string.as_str() {
         "champion" => get_champion_binary(id).await,
@@ -726,9 +761,42 @@ fn normalize_asset_text(raw: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn parse(raw: &str) -> CherryAugment {
         serde_json::from_str(raw).expect("valid CherryAugment JSON")
+    }
+
+    #[tokio::test]
+    async fn run_once_if_empty_skips_when_already_ready() {
+        // 缓存已就绪（is_empty=false）时不应触发 init。
+        let init_count = AtomicUsize::new(0);
+        let lock = tokio::sync::Mutex::new(());
+        run_once_if_empty(
+            || false,
+            &lock,
+            || async {
+                init_count.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await;
+        assert_eq!(init_count.load(Ordering::SeqCst), 0, "就绪时不应跑 init");
+    }
+
+    #[tokio::test]
+    async fn run_once_if_empty_dedups_concurrent_callers() {
+        // 启动竞态下，多个并发图片请求只应触发一次 init，其余等锁后复查即返回。
+        let init_count = AtomicUsize::new(0);
+        let lock = tokio::sync::Mutex::new(());
+        let is_empty = || init_count.load(Ordering::SeqCst) == 0;
+        let run_init = || async {
+            tokio::task::yield_now().await; // 制造交错窗口
+            init_count.fetch_add(1, Ordering::SeqCst);
+        };
+        let call = || run_once_if_empty(is_empty, &lock, run_init);
+        tokio::join!(call(), call(), call(), call(), call(), call());
+        assert_eq!(init_count.load(Ordering::SeqCst), 1, "init 应只跑一次");
+        assert!(!is_empty(), "init 后缓存应视为就绪");
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/util/http.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/util/http.rs
@@ -101,6 +101,19 @@ async fn lcu_get_raw(uri: &str) -> Result<String, String> {
     Err("请求失败或认证失效".to_string())
 }
 
+/// 将 LCU 响应体反序列化为 `T`，**把空 body 当作 JSON `null`**。
+///
+/// LCU 的动作类接口（接受对局 `ready-check/accept`、选英雄 `patch_session_action`
+/// 等）成功时返回 `204 No Content` 空 body。直接拿空字符串喂 `serde_json` 会得到
+/// “EOF while parsing a value at line 1 column 0”，导致**已成功**的操作被误报为
+/// 反序列化失败并上报。把空/纯空白 body 归一成 `null`，使 `T = ()` / `Option<_>`
+/// 等正常反序列化；非空 body 照常解析、坏数据照常报错。
+fn deserialize_lcu_body<T: DeserializeOwned>(body: &str) -> Result<T, String> {
+    let trimmed = body.trim();
+    let json = if trimmed.is_empty() { "null" } else { trimmed };
+    serde_json::from_str::<T>(json).map_err(|e| format!("反序列化失败: {}", e))
+}
+
 /// 向 LCU 发起 GET 请求，将响应 JSON 反序列化为 `T`。
 /// 内置 singleflight（相同 URI 并发请求合并）和并发限制（最多 10 个同时请求）。
 pub async fn lcu_get<T: DeserializeOwned + 'static>(uri: &str) -> Result<T, String> {
@@ -120,8 +133,8 @@ pub async fn lcu_get<T: DeserializeOwned + 'static>(uri: &str) -> Result<T, Stri
         .await
         .map_err(|e| format!("{}", e))?;
 
-    // 从 JSON 字符串反序列化为目标类型
-    serde_json::from_str::<T>(&raw_json).map_err(|e| format!("反序列化失败: {}", e))
+    // 从 JSON 字符串反序列化为目标类型（空 body 归一成 null，见 deserialize_lcu_body）
+    deserialize_lcu_body::<T>(&raw_json)
 }
 
 /// 向 LCU 发起 POST 请求，请求体为 JSON。失败时刷新认证并重试一次。
@@ -132,11 +145,9 @@ pub async fn lcu_post<T: DeserializeOwned, D: Serialize>(uri: &str, data: &D) ->
         let resp = get_client().post(&url).json(data).send().await;
         match resp {
             Ok(r) if r.status().is_success() => {
-                let data = r
-                    .json::<T>()
-                    .await
-                    .map_err(|e| format!("反序列化失败: {}", e))?;
-                return Ok(data);
+                // 动作类接口常返回 204 空 body：先取文本，空 body 归一成 null。
+                let body = r.text().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                return deserialize_lcu_body::<T>(&body);
             }
             _ => {
                 if let Err(e) = refresh_auth() {
@@ -159,11 +170,9 @@ pub async fn lcu_patch<T: DeserializeOwned, D: Serialize>(
         let resp = get_client().patch(&url).json(data).send().await;
         match resp {
             Ok(r) if r.status().is_success() => {
-                let data = r
-                    .json::<T>()
-                    .await
-                    .map_err(|e| format!("反序列化失败: {}", e))?;
-                return Ok(data);
+                // 动作类接口常返回 204 空 body：先取文本，空 body 归一成 null。
+                let body = r.text().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                return deserialize_lcu_body::<T>(&body);
             }
             _ => {
                 if let Err(e) = refresh_auth() {
@@ -251,4 +260,46 @@ pub async fn external_get_json<T: DeserializeOwned>(url: &str) -> Result<T, Stri
     resp.json::<T>()
         .await
         .map_err(|e| format!("external JSON 反序列化失败: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 复现根因：LCU 的动作类接口（接受对局 / 选英雄等）成功时返回 204 空 body，
+    /// 直接拿空字符串喂 serde_json 会得到 “EOF while parsing a value”。
+    #[test]
+    fn empty_body_breaks_raw_serde_json() {
+        let err = serde_json::from_str::<()>("").unwrap_err();
+        assert!(err.to_string().contains("EOF"), "实际错误: {err}");
+    }
+
+    #[test]
+    fn deserialize_body_treats_empty_as_unit() {
+        // 接受对局成功（204 空 body），T = ()，应当成功而非报反序列化失败。
+        deserialize_lcu_body::<()>("").expect("空 body 应反序列化为 ()");
+    }
+
+    #[test]
+    fn deserialize_body_treats_whitespace_as_unit() {
+        deserialize_lcu_body::<()>("  \n ").expect("纯空白 body 应反序列化为 ()");
+    }
+
+    #[test]
+    fn deserialize_body_empty_option_is_none() {
+        let v: Option<i32> = deserialize_lcu_body("").expect("空 body 应反序列化为 None");
+        assert_eq!(v, None);
+    }
+
+    #[test]
+    fn deserialize_body_still_parses_non_empty_json() {
+        let v: Vec<i32> = deserialize_lcu_body("[1,2,3]").expect("非空 JSON 应正常解析");
+        assert_eq!(v, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn deserialize_body_reports_malformed_json() {
+        // 非空但不是合法 JSON 时仍应报错（不要把坏数据吞成默认值）。
+        assert!(deserialize_lcu_body::<Vec<i32>>("{not json").is_err());
+    }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
@@ -17,7 +17,23 @@ use winapi::um::processthreadsapi::OpenProcess;
 use winapi::um::tlhelp32::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
+use winapi::um::winbase::QueryFullProcessImageNameW;
 use winapi::um::winnt::{HANDLE, PROCESS_QUERY_LIMITED_INFORMATION};
+
+/// `Windows` `ERROR_ACCESS_DENIED`：`OpenProcess` 对更高完整性级别（如以管理员
+/// 身份运行的客户端）的进程会返回此错误。
+const ERROR_ACCESS_DENIED: i32 = 5;
+
+/// 读取单个进程命令行的失败归类。
+///
+/// 区分"无权访问"（句柄都打不开，通常是游戏以管理员身份运行而本工具没有）与
+/// 其他失败，便于上层 [`get_auth_detailed`] 给前端精确的处置建议。
+enum CmdError {
+    /// `OpenProcess` 被拒绝（`ERROR_ACCESS_DENIED`）。
+    AccessDenied,
+    /// 其他失败（句柄已打开但读取命令行失败等）。
+    Failed(String),
+}
 
 mod ntapi {
     pub mod ntpsapi {
@@ -96,16 +112,17 @@ fn get_process_pid_by_name(name: &str) -> Result<Vec<DWORD>, String> {
     Ok(pids)
 }
 
-fn get_process_command_line(pid: DWORD) -> Result<String, String> {
+fn get_process_command_line(pid: DWORD) -> Result<String, CmdError> {
     log::info!("尝试获取进程 {} 的命令行", pid);
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
         if handle.is_null() {
-            return Err(format!(
-                "无法打开进程 {}: {}",
-                pid,
-                std::io::Error::last_os_error()
-            ));
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(ERROR_ACCESS_DENIED) {
+                log::warn!("无权打开进程 {}（ACCESS_DENIED）: {}", pid, err);
+                return Err(CmdError::AccessDenied);
+            }
+            return Err(CmdError::Failed(format!("无法打开进程 {}: {}", pid, err)));
         }
         log::info!("成功打开进程句柄");
         let _process_handle = ProcessHandle(handle);
@@ -133,31 +150,31 @@ fn get_process_command_line(pid: DWORD) -> Result<String, String> {
                     &mut return_size,
                 );
                 if status != 0 {
-                    return Err(format!(
+                    return Err(CmdError::Failed(format!(
                         "NtQueryInformationProcess 失败，状态码: {:#x}",
                         status
-                    ));
+                    )));
                 }
             } else {
-                return Err(format!(
+                return Err(CmdError::Failed(format!(
                     "NtQueryInformationProcess 失败，状态码: {:#x}",
                     status
-                ));
+                )));
             }
         }
 
         if return_size == 0 {
-            return Err("返回的缓冲区大小为0".to_string());
+            return Err(CmdError::Failed("返回的缓冲区大小为0".to_string()));
         }
 
         buffer.truncate(return_size as usize);
 
         let ucs = &*(buffer.as_ptr() as *const UNICODE_STRING);
         if ucs.Buffer.is_null() || ucs.Length == 0 {
-            return Err(format!(
+            return Err(CmdError::Failed(format!(
                 "无效的命令行数据，Buffer: {:?}, Length: {}",
                 ucs.Buffer, ucs.Length
-            ));
+            )));
         }
 
         let slice = std::slice::from_raw_parts(ucs.Buffer, (ucs.Length / 2) as usize);
@@ -206,52 +223,227 @@ fn auth_resolver(command_line: &str) -> Result<(String, String), String> {
 /// 的数据竞争（Rust UB）。
 static CUR_PID: AtomicU32 = AtomicU32::new(0);
 
-/// 获取当前 LCU 认证信息。
+/// 客户端检测失败的归类。
 ///
-/// 查找 LeagueClientUx.exe 进程，读取命令行中的 `remoting-auth-token` 与 `app-port`，
-/// 返回 `(token, port)`。未找到或解析失败则返回错误。
-pub fn get_auth() -> Result<(String, String), String> {
+/// 上层据此给前端**精确**的处置建议——尤其要把"权限不足"和"游戏没开"分开：
+/// 前者需要引导用户以管理员身份运行，后者只是正常等待态，不应弹任何警告。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthError {
+    /// 未找到客户端进程——游戏多半没启动，属正常等待态。
+    NotRunning,
+    /// 找到了客户端进程，但无权读取它的信息。
+    ///
+    /// 典型成因：游戏（或 WeGame）以管理员身份运行，而本工具是普通权限，
+    /// `OpenProcess` 被 `ERROR_ACCESS_DENIED` 拒绝。解法是让本工具也提权运行。
+    AccessDenied,
+    /// 其他失败（命令行读取/解析、lockfile 读取等）。
+    Other(String),
+}
+
+impl AuthError {
+    /// 稳定的机器可读错误码，供前端按码分支与遥测聚合。
+    pub fn code(&self) -> &'static str {
+        match self {
+            AuthError::NotRunning => "NOT_RUNNING",
+            AuthError::AccessDenied => "ACCESS_DENIED",
+            AuthError::Other(_) => "OTHER",
+        }
+    }
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::NotRunning => write!(f, "未找到英雄联盟客户端进程"),
+            AuthError::AccessDenied => write!(
+                f,
+                "检测到游戏客户端，但无权读取其信息。请以管理员身份运行本工具（或不要以管理员身份运行游戏）。"
+            ),
+            AuthError::Other(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+/// 通过已打开的进程句柄获取其可执行文件完整路径（用于定位同目录下的 lockfile）。
+fn get_process_image_path(handle: HANDLE) -> Result<String, String> {
+    unsafe {
+        // 客户端安装路径可能很长（含中文/嵌套目录），给足缓冲避免截断。
+        let mut buf: Vec<u16> = vec![0; 1024];
+        let mut size = buf.len() as u32;
+        let ok = QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut size);
+        if ok == FALSE {
+            return Err(format!(
+                "QueryFullProcessImageNameW 失败: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(String::from_utf16_lossy(&buf[..size as usize]))
+    }
+}
+
+/// 解析 lockfile 内容，返回 `(remoting-auth-token, app-port)`。
+///
+/// lockfile 由客户端写入，格式固定为 `LeagueClient:<pid>:<port>:<token>:<protocol>`，
+/// 冒号分隔。token 即 `remoting-auth-token`，与命令行解析出的一致。
+fn parse_lockfile(content: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = content.trim().split(':').collect();
+    if parts.len() < 5 {
+        return Err(format!("lockfile 格式异常（{} 段）", parts.len()));
+    }
+    let port = parts[2].to_string();
+    let token = parts[3].to_string();
+    if port.is_empty() || token.is_empty() {
+        return Err("lockfile 缺少 port 或 token".to_string());
+    }
+    Ok((token, port))
+}
+
+/// 命令行读取失败时的兜底：通过进程可执行文件路径定位同目录 lockfile 并解析。
+///
+/// 仅当 `OpenProcess` 能成功（即非 [`AuthError::AccessDenied`]）时有意义；
+/// 权限不足时连句柄都打不开，自然也拿不到镜像路径。
+fn lockfile_auth_for_pid(pid: DWORD) -> Result<(String, String), String> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid) };
+    if handle.is_null() {
+        return Err(format!(
+            "为读取 lockfile 打开进程 {} 失败: {}",
+            pid,
+            std::io::Error::last_os_error()
+        ));
+    }
+    let _guard = ProcessHandle(handle);
+    let exe_path = get_process_image_path(handle)?;
+    let dir = std::path::Path::new(&exe_path)
+        .parent()
+        .ok_or("无法从客户端路径推导安装目录")?;
+    let lockfile = dir.join("lockfile");
+    let content = std::fs::read_to_string(&lockfile)
+        .map_err(|e| format!("读取 lockfile {} 失败: {}", lockfile.display(), e))?;
+    let auth = parse_lockfile(&content)?;
+    // 标记走了兜底路径，便于在日志/遥测里看出命令行失效、是 lockfile 救回来的。
+    // 不打印 token / 端口，避免凭据外传。
+    log::info!("通过 lockfile 兜底获取认证成功 (pid {})", pid);
+    Ok(auth)
+}
+
+/// 尝试从单个进程获取认证：优先命令行，失败再回退 lockfile。
+fn try_auth_from_pid(pid: DWORD) -> Result<(String, String), AuthError> {
+    match get_process_command_line(pid) {
+        Ok(cmd) if !cmd.is_empty() => auth_resolver(&cmd).or_else(|cmd_err| {
+            // 命令行拿到了却没解析出 token，再试一次 lockfile。
+            lockfile_auth_for_pid(pid).map_err(|lf| {
+                AuthError::Other(format!("命令行解析失败({cmd_err}); lockfile: {lf}"))
+            })
+        }),
+        // 句柄能开但命令行为空/读取失败：lockfile 兜底。
+        Ok(_) => lockfile_auth_for_pid(pid).map_err(AuthError::Other),
+        Err(CmdError::Failed(e)) => lockfile_auth_for_pid(pid)
+            .map_err(|lf| AuthError::Other(format!("命令行读取失败({e}); lockfile: {lf}"))),
+        // 权限不足：lockfile 路径同样拿不到，直接归类，交由上层引导提权。
+        Err(CmdError::AccessDenied) => Err(AuthError::AccessDenied),
+    }
+}
+
+/// 获取当前 LCU 认证信息，带失败归类。
+///
+/// 查找 `LeagueClientUx.exe` 进程，优先从命令行解析 `remoting-auth-token` 与
+/// `app-port`，失败时回退读取 lockfile。无法获取时返回 [`AuthError`]，区分
+/// "游戏没开 / 权限不足 / 其他失败"。
+pub fn get_auth_detailed() -> Result<(String, String), AuthError> {
     log::info!("开始查找英雄联盟客户端进程...");
-    let pids = get_process_pid_by_name("LeagueClientUx.exe")?;
+    let pids = get_process_pid_by_name("LeagueClientUx.exe").map_err(AuthError::Other)?;
 
     log::info!("找到 {} 个进程", pids.len());
     if pids.is_empty() {
-        return Err("未找到英雄联盟客户端进程".to_string());
+        return Err(AuthError::NotRunning);
     }
 
-    let mut cmd_line = String::new();
-    let mut found_valid_process = false;
     let cached_pid = CUR_PID.load(Ordering::Relaxed);
+    let mut saw_access_denied = false;
+    let mut last_other: Option<String> = None;
 
-    for &pid in &pids {
-        if pid == cached_pid {
-            log::info!("跳过当前PID: {}", pid);
-            continue;
-        }
-
+    // 先尝试非缓存的进程（缓存进程留作最后兜底，沿用历史行为）。
+    for &pid in pids.iter().filter(|&&p| p != cached_pid) {
         log::info!("正在检查PID: {}", pid);
-        match get_process_command_line(pid) {
-            Ok(temp_cmd_line) if !temp_cmd_line.is_empty() => {
-                cmd_line = temp_cmd_line;
+        match try_auth_from_pid(pid) {
+            Ok(auth) => {
                 CUR_PID.store(pid, Ordering::Relaxed);
-                found_valid_process = true;
                 log::info!("找到有效进程，PID: {}", pid);
-                break;
+                return Ok(auth);
             }
-            Err(e) => log::info!("获取进程 {} 的命令行失败: {}", pid, e),
-            _ => log::info!("进程 {} 的命令行为空", pid),
+            Err(AuthError::AccessDenied) => saw_access_denied = true,
+            Err(AuthError::Other(e)) => {
+                log::info!("获取进程 {} 的认证失败: {}", pid, e);
+                last_other = Some(e);
+            }
+            Err(AuthError::NotRunning) => {}
         }
     }
 
-    if !found_valid_process {
-        let cached = CUR_PID.load(Ordering::Relaxed);
-        log::info!("未找到有效的命令行，尝试使用当前PID: {}", cached);
-        if cached > 0 {
-            cmd_line = get_process_command_line(cached)?;
-        } else {
-            return Err("未找到有效的英雄联盟客户端进程".to_string());
+    // 兜底：缓存 pid 仍在存活进程里时再试一次。
+    if cached_pid > 0 && pids.contains(&cached_pid) {
+        if let Ok(auth) = try_auth_from_pid(cached_pid) {
+            log::info!("使用缓存 PID {} 命中", cached_pid);
+            return Ok(auth);
         }
     }
 
-    auth_resolver(&cmd_line)
+    if saw_access_denied {
+        log::warn!("检测到客户端进程但无权读取（疑似游戏以管理员身份运行）");
+        Err(AuthError::AccessDenied)
+    } else if let Some(e) = last_other {
+        Err(AuthError::Other(e))
+    } else {
+        Err(AuthError::NotRunning)
+    }
+}
+
+/// 获取当前 LCU 认证信息（字符串错误版，供既有 HTTP / WebSocket 调用方使用）。
+///
+/// 等价于 [`get_auth_detailed`]，仅把 [`AuthError`] 拍平为人类可读字符串。
+pub fn get_auth() -> Result<(String, String), String> {
+    get_auth_detailed().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_lockfile_extracts_port_and_token() {
+        let (token, port) = parse_lockfile("LeagueClient:12345:53970:abcdToken:https").unwrap();
+        assert_eq!(port, "53970");
+        assert_eq!(token, "abcdToken");
+    }
+
+    #[test]
+    fn parse_lockfile_tolerates_trailing_newline() {
+        let (token, port) = parse_lockfile("LeagueClient:1:2:tok:https\n").unwrap();
+        assert_eq!(port, "2");
+        assert_eq!(token, "tok");
+    }
+
+    #[test]
+    fn parse_lockfile_rejects_malformed() {
+        assert!(parse_lockfile("LeagueClient:1:2").is_err());
+        assert!(parse_lockfile("").is_err());
+    }
+
+    #[test]
+    fn parse_lockfile_rejects_empty_fields() {
+        assert!(parse_lockfile("LeagueClient:1::tok:https").is_err());
+        assert!(parse_lockfile("LeagueClient:1:2::https").is_err());
+    }
+
+    #[test]
+    fn auth_error_codes_are_stable() {
+        assert_eq!(AuthError::NotRunning.code(), "NOT_RUNNING");
+        assert_eq!(AuthError::AccessDenied.code(), "ACCESS_DENIED");
+        assert_eq!(AuthError::Other("x".into()).code(), "OTHER");
+    }
+
+    #[test]
+    fn access_denied_message_mentions_admin() {
+        assert!(AuthError::AccessDenied.to_string().contains("管理员"));
+    }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -68,53 +68,56 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_process::init())
-        .register_uri_scheme_protocol("asset", move |_app, request| {
+        .register_asynchronous_uri_scheme_protocol("asset", move |_ctx, request, responder| {
             let path = request.uri().path();
             // path is like /champion/123
             let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
 
             if parts.len() < 2 {
-                return tauri::http::Response::builder()
-                    .status(404)
-                    .body(Vec::new())
-                    .unwrap();
+                responder.respond(
+                    tauri::http::Response::builder()
+                        .status(404)
+                        .body(Vec::new())
+                        .unwrap(),
+                );
+                return;
             }
 
             let kind = parts[0].to_string();
-            let id_str = parts[1];
-            let id = match id_str.parse::<i64>() {
+            let id = match parts[1].parse::<i64>() {
                 Ok(i) => i,
                 Err(_) => {
-                    return tauri::http::Response::builder()
-                        .status(400)
-                        .body(Vec::new())
-                        .unwrap()
+                    responder.respond(
+                        tauri::http::Response::builder()
+                            .status(400)
+                            .body(Vec::new())
+                            .unwrap(),
+                    );
+                    return;
                 }
             };
 
-            let result = tauri::async_runtime::block_on(async move {
-                asset_api::get_asset_binary(kind, id).await
+            // 异步处理：绝不阻塞 webview 资源加载线程。缓存未就绪（启动竞态）时，
+            // get_asset_binary 内部会后台自愈一次 init（见 asset::ensure_caches_ready），
+            // 就绪后再通过 responder 回包——首屏冷启动也能自动补上图标，无需手动刷新。
+            //
+            // Cache-Control: no-store —— 成功响应命中 Rust 端 BINARY_CACHE 是 O(1)，
+            // 重新请求成本可忽略；失败响应不被浏览器负缓存，cache 就绪后下次请求即恢复。
+            tauri::async_runtime::spawn(async move {
+                let response = match asset_api::get_asset_binary(kind, id).await {
+                    Ok((bytes, mime)) => tauri::http::Response::builder()
+                        .header("Content-Type", mime)
+                        .header("Cache-Control", "no-store")
+                        .body(bytes)
+                        .unwrap(),
+                    Err(e) => tauri::http::Response::builder()
+                        .status(404)
+                        .header("Cache-Control", "no-store")
+                        .body(e.into_bytes())
+                        .unwrap(),
+                };
+                responder.respond(response);
             });
-
-            // 不让浏览器缓存任何响应：
-            //   - 成功响应：Rust 端 BINARY_CACHE 命中是 O(1) 内存查找，IPC 走 asset.localhost
-            //     回到 webview 也是本地直传，每次重新请求成本可忽略
-            //   - 失败响应（asset cache 未就绪、Fandom 数据缺失等）：之前 24h max-age
-            //     会让浏览器 negative-cache 失败状态，cache 就绪后不会重试，导致
-            //     启动后 augment / champion / perk 图标长时间不出。
-            //     用 no-store 让浏览器每次都走 Rust，cache 就绪后第一次刷新就显示
-            match result {
-                Ok((bytes, mime)) => tauri::http::Response::builder()
-                    .header("Content-Type", mime)
-                    .header("Cache-Control", "no-store")
-                    .body(bytes)
-                    .unwrap(),
-                Err(e) => tauri::http::Response::builder()
-                    .status(404)
-                    .header("Cache-Control", "no-store")
-                    .body(e.into_bytes())
-                    .unwrap(),
-            }
         })
         .manage(AppState::default())
         .invoke_handler(tauri::generate_handler![
@@ -143,6 +146,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::session::get_session_data,
             command::fandom::update_fandom_data,
             command::fandom::get_aram_balance,
+            command::system::relaunch_as_admin,
         ]);
 
     #[cfg(debug_assertions)]

--- a/lol-record-analysis-tauri/src/components/LoadingComponent.vue
+++ b/lol-record-analysis-tauri/src/components/LoadingComponent.vue
@@ -8,13 +8,22 @@
       </div>
       <div class="loading-text-block">
         <p class="loading-text"><slot /></p>
-        <p class="loading-hint">请确保英雄联盟客户端已启动</p>
+        <p class="loading-hint">{{ hint ?? '请确保英雄联盟客户端已启动' }}</p>
+        <slot name="action" />
       </div>
       <div class="loading-shimmer-bar" />
     </div>
   </div>
 </template>
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+/**
+ * 加载/等待态展示组件
+ * @property hint - 覆盖默认副提示文案（如权限不足时的具体说明）
+ * @slot default - 主提示文案
+ * @slot action - 副提示下方的操作区（如"以管理员身份重启"按钮）
+ */
+defineProps<{ hint?: string }>()
+</script>
 
 <style lang="css" scoped>
 .loading-wrap {

--- a/lol-record-analysis-tauri/src/composables/useGameState.ts
+++ b/lol-record-analysis-tauri/src/composables/useGameState.ts
@@ -6,6 +6,10 @@ import router from '../router'
 export interface GameStateEvent {
   connected: boolean
   phase: string | null
+  /** 未连接时的失败归类码：'NOT_RUNNING' | 'ACCESS_DENIED' | 'OTHER'，已连接为 null */
+  reasonCode: string | null
+  /** 未连接时面向用户的失败说明 */
+  reasonMessage: string | null
   summoner: {
     gameName: string
     tagLine: string
@@ -46,6 +50,8 @@ interface SessionData {
 const isConnected = ref(false)
 const currentPhase = ref<string | null>(null)
 const summoner = ref<GameStateEvent['summoner'] | null>(null)
+const reasonCode = ref<string | null>(null)
+const reasonMessage = ref<string | null>(null)
 
 let unlistenState: UnlistenFn | null = null
 let unlistenSession: UnlistenFn | null = null
@@ -100,6 +106,8 @@ async function setupListeners() {
     isConnected.value = state.connected
     currentPhase.value = state.phase
     summoner.value = state.summoner
+    reasonCode.value = state.reasonCode ?? null
+    reasonMessage.value = state.reasonMessage ?? null
 
     handleConnectionRoute(state)
   })
@@ -162,6 +170,8 @@ export function useGameState() {
   return {
     isConnected,
     currentPhase,
-    summoner
+    summoner,
+    reasonCode,
+    reasonMessage
   }
 }

--- a/lol-record-analysis-tauri/src/services/ai/matchDetail/__tests__/validator.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/matchDetail/__tests__/validator.spec.ts
@@ -174,7 +174,7 @@ describe('validateAttribution', () => {
   })
 
   describe('data-grounding: off-role', () => {
-    it('rejects off-role mitigation when player.isOffRole=false', () => {
+    it('strips ungrounded off-role factor (player.isOffRole=false)', () => {
       const snap = snapshotWithPlayer({
         participantId: 1,
         teamId: 100,
@@ -192,8 +192,8 @@ describe('validateAttribution', () => {
         validVerdict(4)
       ])
       const out = validateAttribution(JSON.stringify(result), snap)
-      expect(out.ok).toBe(false)
-      if (!out.ok) expect(out.error).toMatch(/off-role/)
+      expect(out.ok).toBe(true)
+      if (out.ok) expect(out.value.verdicts[0].mitigatingFactors).toHaveLength(0)
     })
 
     it('accepts off-role mitigation when player.isOffRole=true', () => {
@@ -219,7 +219,7 @@ describe('validateAttribution', () => {
   })
 
   describe('data-grounding: first-time-champion', () => {
-    it('rejects when player.currentChampionMastery.isFirstTimeInRecent=false', () => {
+    it('strips ungrounded first-time-champion factor (isFirstTimeInRecent=false)', () => {
       const snap = snapshotWithPlayer({
         participantId: 1,
         teamId: 100,
@@ -237,7 +237,8 @@ describe('validateAttribution', () => {
         validVerdict(4)
       ])
       const out = validateAttribution(JSON.stringify(result), snap)
-      expect(out.ok).toBe(false)
+      expect(out.ok).toBe(true)
+      if (out.ok) expect(out.value.verdicts[0].mitigatingFactors).toHaveLength(0)
     })
 
     it('accepts when isFirstTimeInRecent=true', () => {
@@ -263,7 +264,7 @@ describe('validateAttribution', () => {
   })
 
   describe('data-grounding: team-collapse', () => {
-    it('rejects when fewer than 2 同队 verdict.label="犯罪"', () => {
+    it('strips team-collapse factor when <2 同队 犯罪', () => {
       const snap = snapshotWithPlayer({
         participantId: 1,
         teamId: 100,
@@ -280,8 +281,8 @@ describe('validateAttribution', () => {
         validVerdict(4, '尽力')
       ])
       const out = validateAttribution(JSON.stringify(result), snap)
-      expect(out.ok).toBe(false)
-      if (!out.ok) expect(out.error).toMatch(/team-collapse/)
+      expect(out.ok).toBe(true)
+      if (out.ok) expect(out.value.verdicts[0].mitigatingFactors).toHaveLength(0)
     })
 
     it('accepts when ≥2 同队 verdict.label="犯罪" (excluding self)', () => {
@@ -306,7 +307,7 @@ describe('validateAttribution', () => {
   })
 
   describe('data-grounding: targeted', () => {
-    it('always rejects targeted (no timeline data in current snapshot)', () => {
+    it('always strips targeted (no timeline data in current snapshot)', () => {
       const snap = snapshotWithPlayer({
         participantId: 1,
         teamId: 100,
@@ -323,7 +324,8 @@ describe('validateAttribution', () => {
         validVerdict(4)
       ])
       const out = validateAttribution(JSON.stringify(result), snap)
-      expect(out.ok).toBe(false)
+      expect(out.ok).toBe(true)
+      if (out.ok) expect(out.value.verdicts[0].mitigatingFactors).toHaveLength(0)
     })
   })
 })

--- a/lol-record-analysis-tauri/src/services/ai/matchDetail/validator.ts
+++ b/lol-record-analysis-tauri/src/services/ai/matchDetail/validator.ts
@@ -106,87 +106,68 @@ export function validateAttribution(rawJson: string, snapshot: MatchSnapshot): V
     }
   }
 
-  // ─── Layer 3: data-grounding ───
+  // ─── Layer 3: data-grounding（清洗，不再硬毙） ───
+  // 缓解因子只是负面 verdict 上的解释性标注。模型若给出与 snapshot 对不上的因子，
+  // 摘掉该因子即可：既不把未证实的说法放给用户，也不因一个小标注就废掉整份多 verdict
+  // 分析（历史上 stage1 最常见的失败正是这层硬毙）。JSON / 结构仍严格校验。
   const result = candidate as AttributionResult
-  for (let i = 0; i < result.verdicts.length; i++) {
-    const v = result.verdicts[i]
+  for (const v of result.verdicts) {
     if (v.mitigatingFactors.length === 0) continue
 
-    // Mitigating factors only allowed on negative labels
+    // 因子只在负面 label 上有意义；非负面一律摘除。
     if (!NEGATIVE_LABELS.has(v.label)) {
-      return {
-        ok: false,
-        error: `verdict[${i}] has mitigatingFactors but label='${v.label}' is not negative`
-      }
+      v.mitigatingFactors = []
+      continue
     }
 
     const playerSnap = snapshot.players.find((p: any) => p.participantId === v.participantId)
     if (!playerSnap) {
-      return {
-        ok: false,
-        error: `verdict[${i}].participantId=${v.participantId} not found in snapshot`
-      }
+      // 找不到对应玩家，无从 grounding，摘除全部因子但保留 verdict。
+      v.mitigatingFactors = []
+      continue
     }
 
-    for (let j = 0; j < v.mitigatingFactors.length; j++) {
-      const m = v.mitigatingFactors[j]
-      if (!ALLOWED_MITIGATING.has(m.factor)) {
-        return {
-          ok: false,
-          error: `verdict[${i}].mitigatingFactors[${j}].factor invalid: ${m.factor}`
-        }
-      }
-
-      switch (m.factor) {
-        case 'off-role': {
-          const rp = (playerSnap as any).recentProfile
-          if (!rp || rp.isOffRole !== true) {
-            return {
-              ok: false,
-              error: `verdict[${i}] claims 'off-role' but snapshot recentProfile.isOffRole !== true`
-            }
-          }
-          break
-        }
-        case 'first-time-champion': {
-          const rp = (playerSnap as any).recentProfile
-          const mastery = rp?.currentChampionMastery
-          if (!mastery || mastery.isFirstTimeInRecent !== true) {
-            return {
-              ok: false,
-              error: `verdict[${i}] claims 'first-time-champion' but isFirstTimeInRecent !== true`
-            }
-          }
-          break
-        }
-        case 'team-collapse': {
-          const sameTeamCriminals = result.verdicts.filter(
-            other =>
-              other.participantId !== v.participantId &&
-              snapshot.players.find((p: any) => p.participantId === other.participantId)?.teamId ===
-                (playerSnap as any).teamId &&
-              other.label === '犯罪'
-          )
-          if (sameTeamCriminals.length < 2) {
-            return {
-              ok: false,
-              error: `verdict[${i}] claims 'team-collapse' but only ${sameTeamCriminals.length} same-team criminals (need ≥2)`
-            }
-          }
-          break
-        }
-        case 'targeted': {
-          // Snapshot has no timeline data yet — this factor is always disallowed.
-          return {
-            ok: false,
-            error: `verdict[${i}] uses 'targeted' factor which requires timeline data not in snapshot`
-          }
-        }
-      }
-    }
+    v.mitigatingFactors = v.mitigatingFactors.filter(m =>
+      isFactorGrounded(m.factor, v, playerSnap, result, snapshot)
+    )
   }
 
   return { ok: true, value: result }
+}
+
+/**
+ * 判断单个缓解因子是否被 snapshot 数据支撑。未在白名单、或证据对不上的一律返回
+ * false（调用方据此摘除）。`targeted` 因 snapshot 暂无 timeline，恒不成立。
+ */
+function isFactorGrounded(
+  factor: MitigatingFactorKind,
+  v: Verdict,
+  playerSnap: any,
+  result: AttributionResult,
+  snapshot: MatchSnapshot
+): boolean {
+  if (!ALLOWED_MITIGATING.has(factor)) return false
+  switch (factor) {
+    case 'off-role':
+      return playerSnap.recentProfile?.isOffRole === true
+    case 'first-time-champion':
+      return playerSnap.recentProfile?.currentChampionMastery?.isFirstTimeInRecent === true
+    case 'team-collapse': {
+      const sameTeamCriminals = result.verdicts.filter(
+        other =>
+          other.participantId !== v.participantId &&
+          snapshot.players.find((p: any) => p.participantId === other.participantId)?.teamId ===
+            playerSnap.teamId &&
+          other.label === '犯罪'
+      )
+      return sameTeamCriminals.length >= 2
+    }
+    case 'targeted':
+      // snapshot 暂无 timeline 数据，无法证实 → 摘除。
+      return false
+    default:
+      return false
+  }
 }
 
 function stripFencedCodeBlock(raw: string): string {

--- a/lol-record-analysis-tauri/src/views/Loading.vue
+++ b/lol-record-analysis-tauri/src/views/Loading.vue
@@ -1,7 +1,66 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
 import LoadingComponent from '../components/LoadingComponent.vue'
+import { useGameState } from '../composables/useGameState'
+
+const { reasonCode, reasonMessage } = useGameState()
+
+/** 检测到客户端但无权读取（典型：游戏以管理员身份运行，本工具没有）。 */
+const isAccessDenied = computed(() => reasonCode.value === 'ACCESS_DENIED')
+
+const mainText = computed(() => (isAccessDenied.value ? '需要管理员权限' : '等待连接客户端...'))
+const hint = computed(() =>
+  isAccessDenied.value ? (reasonMessage.value ?? '请以管理员身份运行本工具') : undefined
+)
+
+const relaunching = ref(false)
+
+async function relaunchAsAdmin() {
+  if (relaunching.value) return
+  relaunching.value = true
+  try {
+    await invoke('relaunch_as_admin')
+  } catch (e) {
+    console.error('以管理员身份重启失败:', e)
+    relaunching.value = false
+  }
+}
 </script>
 
 <template>
-  <LoadingComponent>等待连接客户端...</LoadingComponent>
+  <LoadingComponent :hint="hint">
+    {{ mainText }}
+    <template v-if="isAccessDenied" #action>
+      <button class="admin-btn" :disabled="relaunching" @click="relaunchAsAdmin">
+        {{ relaunching ? '正在重启...' : '以管理员身份重启' }}
+      </button>
+    </template>
+  </LoadingComponent>
 </template>
+
+<style scoped>
+.admin-btn {
+  margin-top: var(--space-12, 12px);
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--semantic-win, #3d9b7a);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    filter 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.admin-btn:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.admin-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+</style>


### PR DESCRIPTION
> 注：本批改动与 #76 (DashScope 直连) 无关，已拆到独立分支单独 PR。

## Summary
- **权限不足引导提权**：游戏以管理员身份运行、本工具普通权限时 `OpenProcess` 被 `ERROR_ACCESS_DENIED` 拒绝，原来只笼统报"未找到客户端"。现在 `token.rs` 把认证失败归类为 `NotRunning / AccessDenied / Other`（`AuthError` + 稳定 `code()`），命令行读取失败时回退读 lockfile 兜底；新增 `command/system.rs::relaunch_as_admin`（`ShellExecuteW "runas"` 按需提权，不在清单里强制 `requireAdministrator`）；Loading 页在 `ACCESS_DENIED` 时展示"以管理员身份重启"按钮。
- **启动期资源自愈**：资源协议处理器改异步（`register_asynchronous_uri_scheme_protocol`），不再 `block_on` 卡 webview；启动竞态下缓存还空时自愈跑一次 `init`，避免首屏图标 404 裂图。
- **fix(lcu) 204 空 body**：动作类接口（接受对局 / 选英雄等）成功返回 204 空 body，原来喂 `serde_json` 报 "EOF while parsing"，把已成功操作误报为失败上报。新增 `deserialize_lcu_body` 把空 body 归一成 `null`。
- **refactor(ai) attribution**：缓解因子改为按 snapshot 数据清洗（摘除未证实因子）而非整份硬毙。
- **chore**：gitignore 运行时生成的 `device_id`。

## Test plan
- [x] `npm run check` 通过（0 error）
- [x] `npm run test`：38 文件 / 427 用例全过
- [x] `cargo test`：125 用例全过（含 `parse_lockfile`、`AuthError::code`、`deserialize_lcu_body` 204/空白/坏 JSON、asset `run_once_if_empty` 并发去重）
- [ ] 手动：游戏以管理员身份运行时，Loading 页出现提权按钮、点击后 UAC 提权重启
- [ ] 手动：冷启动首屏 champion/item/perk 图标不裂