### PR TITLE
fix(lcu): 允许战绩区间 beg_index == end_index，修复 matchHistoryCount=1 时战绩静默为空

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
@@ -125,8 +125,9 @@ impl MatchHistory {
             return Err("索引不能为负数".to_string());
         }
 
-        if beg_index >= end_index {
-            return Err("开始索引必须小于结束索引".to_string());
+        // 允许 beg_index == end_index：matchHistoryCount=1 时请求区间为 (0, 0)，表示单场
+        if beg_index > end_index {
+            return Err("开始索引不能大于结束索引".to_string());
         }
 
         // 如果没有用户缓存，且在缓存范围内，则获取缓存


### PR DESCRIPTION
## Summary
- `get_match_history_by_puuid` 的参数校验要求 `beg_index < end_index`，导致设置页把「默认战绩场数」调到 1 时，session 流程请求区间 `(0, 0)` 被误判为非法，报错后走 `MatchHistory::default()` 兜底，玩家战绩静默变空
- 放宽为 `beg_index > end_index` 才报错；下游切片逻辑本身兼容 `beg == end`（`actual_end = min(end + 1, total)`），无需其他改动

## Test plan
- [x] prettier / eslint / cargo fmt 本地通过（clippy 与 cargo test 依赖 Windows CI，mac 上 token.rs 无法编译）
- [ ] Windows CI 通过
- [ ] Manual: 设置「默认战绩场数」为 1，对局中玩家卡战绩正常显示 1 场