### PR TITLE
feat(user-tag): 语义默认标签 + 老用户自动补齐 + 条件编辑器支持

### DIFF
--- a/docs/superpowers/specs/2026-07-02-tag-iteration-design.md
+++ b/docs/superpowers/specs/2026-07-02-tag-iteration-design.md
@@ -76,13 +76,16 @@ Recent { count: i32 },
 | id | 名称 | 极性 | 规则 |
 |----|------|------|------|
 | `default_smurf` | 炸鱼嫌疑 | bad | And[History(排位 + Recent 20, Count ≥ 10), History(排位 + Recent 20, Average win ≥ 0.75), History(排位 + Recent 20, Average kda ≥ 5)] |
-| `default_champion_pool_wide` | 英雄海 | good | History(Recent 20, DistinctChampions ≥ 12) |
 | `default_champion_pool_narrow` | 专精 | good | And[History(Recent 20, DistinctChampions ≤ 3), History(Recent 20, Count ≥ 10)] |
 | `default_hot_streak_form` | 手热 | good | And[History(排位 + Recent 10, Average win ≥ 0.7), History(排位 + Recent 20, Average win ≤ 0.55), History(排位 + Recent 20, Count ≥ 15)] |
 | `default_cold_form` | 低谷 | bad | And[History(排位 + Recent 10, Average win ≤ 0.3), History(排位 + Recent 20, Average win ≥ 0.45), History(排位 + Recent 20, Count ≥ 15)] |
-| `default_int_risk` | 挂机送头风险 | bad | History(Recent 20, Ratio: damageShare < 0.08 的场次占比 ≥ 0.2) |
+| `default_int_risk` | 伤害贡献低 | bad | History(Recent 20, Ratio: damageShare < 0.05 的场次占比 ≥ 0.3) |
 
 > 注：手热/低谷需近 20 场内有足够场次（Count ≥ 15）避免小样本误报；「专精」与子项 1 的 CurrentChampion 组合后可衍生「本命英雄」玩法，本期不内置该衍生标签。
+>
+> 「英雄海」（`default_champion_pool_wide`）经维护者评审撤下——按「玩过的不同英雄数」算池宽会被随机英雄模式与浅尝行为污染，需要「每个英雄有足够场次」的更严定义，待引擎支持 per-champion 统计后再迭代。
+>
+> `default_int_risk` 由「挂机送头风险」改名为「伤害贡献低」：改为事实描述、避免动机指控式命名误伤软辅等低伤害正常定位，同时收紧阈值（单场 damageShare < 0.05、占比 ≥ 0.3）。
 
 ## 子项 4：默认标签合并（老用户可见性）
 

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -987,21 +987,6 @@ pub fn get_default_tags() -> Vec<TagConfig> {
             },
         },
         TagConfig {
-            id: "default_champion_pool_wide".to_string(),
-            name: "英雄海".to_string(),
-            desc: "近 20 场使用了 12 个以上英雄".to_string(),
-            good: true,
-            enabled: true,
-            is_default: true,
-            condition: TagCondition::History {
-                filters: vec![MatchFilter::Recent { count: 20 }],
-                refresh: MatchRefresh::DistinctChampions {
-                    op: Operator::Gte,
-                    value: 12.0,
-                },
-            },
-        },
-        TagConfig {
             id: "default_champion_pool_narrow".to_string(),
             name: "专精".to_string(),
             desc: "近 20 场只玩 3 个以内英雄".to_string(),
@@ -1099,7 +1084,7 @@ pub fn get_default_tags() -> Vec<TagConfig> {
         },
         TagConfig {
             id: "default_int_risk".to_string(),
-            name: "挂机送头风险".to_string(),
+            name: "伤害贡献低".to_string(),
             desc: "近 20 场中伤害占比极低的场次偏多，仅供参考".to_string(),
             good: false,
             enabled: true,
@@ -1109,9 +1094,9 @@ pub fn get_default_tags() -> Vec<TagConfig> {
                 refresh: MatchRefresh::Ratio {
                     metric: "damageShare".to_string(),
                     game_op: Operator::Lt,
-                    game_value: 0.08,
+                    game_value: 0.05,
                     op: Operator::Gte,
-                    value: 0.2,
+                    value: 0.3,
                 },
             },
         },
@@ -1598,25 +1583,6 @@ mod tests {
     }
 
     #[test]
-    fn default_champion_pool_wide_fires_on_many_distinct_champions() {
-        let tag = default_tag("default_champion_pool_wide");
-        // 20 场 20 个不同英雄 → DistinctChampions 20 ≥ 12 命中
-        let wide = make_history(
-            (0..20)
-                .map(|i| make_game(i, true, QUEUE_SOLO_5X5))
-                .collect(),
-        );
-        assert!(tag.evaluate(&wide, 420, None).is_some());
-        // 20 场全同一英雄 → Distinct 1 < 12 不命中
-        let narrow = make_history(
-            (0..20)
-                .map(|_| make_game(1, true, QUEUE_SOLO_5X5))
-                .collect(),
-        );
-        assert!(tag.evaluate(&narrow, 420, None).is_none());
-    }
-
-    #[test]
     fn default_champion_pool_narrow_fires_on_few_champions_enough_games() {
         let tag = default_tag("default_champion_pool_narrow");
         // 20 场全英雄 1 → Distinct 1 ≤ 3 且 Count 20 ≥ 10 命中
@@ -1670,13 +1636,14 @@ mod tests {
     fn default_int_risk_fires_on_frequent_low_damage_share() {
         let tag = default_tag("default_int_risk");
         // 20 场全部带 game_detail（避免 NAN 稀释分子）：
-        // 5 场 rate 5（0.05 < 0.08）+ 15 场 rate 25 → 占比 5/20 = 0.25 ≥ 0.2 命中
-        let mut games: Vec<Game> = (0..5)
-            .map(|_| make_game_with_damage_rate(false, 5))
+        // 6 场 rate 3（0.03 < 0.05）+ 14 场 rate 25 → 占比 6/20 = 0.3 ≥ 0.3 命中
+        // （rate 5 → 0.05 不满足 Lt 0.05，故正例用 rate 3）
+        let mut games: Vec<Game> = (0..6)
+            .map(|_| make_game_with_damage_rate(false, 3))
             .collect();
-        games.extend((0..15).map(|_| make_game_with_damage_rate(true, 25)));
+        games.extend((0..14).map(|_| make_game_with_damage_rate(true, 25)));
         assert!(tag.evaluate(&make_history(games), 420, None).is_some());
-        // 20 场伤害占比全部正常（0.25）→ 占比 0 < 0.2 不命中
+        // 20 场伤害占比全部正常（0.25）→ 占比 0 < 0.3 不命中
         let normal = make_history(
             (0..20)
                 .map(|_| make_game_with_damage_rate(true, 25))

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -950,6 +950,171 @@ pub fn get_default_tags() -> Vec<TagConfig> {
                 },
             },
         },
+        // --- 语义类默认标签（2026-07 迭代新增）---
+        TagConfig {
+            id: "default_smurf".to_string(),
+            name: "炸鱼嫌疑".to_string(),
+            desc: "近期排位胜率与 KDA 异常偏高，仅供参考".to_string(),
+            good: false,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::And {
+                conditions: vec![
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Count {
+                            op: Operator::Gte,
+                            value: 10.0,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Average {
+                            metric: "win".to_string(),
+                            op: Operator::Gte,
+                            value: 0.75,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Average {
+                            metric: "kda".to_string(),
+                            op: Operator::Gte,
+                            value: 5.0,
+                        },
+                    },
+                ],
+            },
+        },
+        TagConfig {
+            id: "default_champion_pool_wide".to_string(),
+            name: "英雄海".to_string(),
+            desc: "近 20 场使用了 12 个以上英雄".to_string(),
+            good: true,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::History {
+                filters: vec![MatchFilter::Recent { count: 20 }],
+                refresh: MatchRefresh::DistinctChampions {
+                    op: Operator::Gte,
+                    value: 12.0,
+                },
+            },
+        },
+        TagConfig {
+            id: "default_champion_pool_narrow".to_string(),
+            name: "专精".to_string(),
+            desc: "近 20 场只玩 3 个以内英雄".to_string(),
+            good: true,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::And {
+                conditions: vec![
+                    TagCondition::History {
+                        filters: vec![MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::DistinctChampions {
+                            op: Operator::Lte,
+                            value: 3.0,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Count {
+                            op: Operator::Gte,
+                            value: 10.0,
+                        },
+                    },
+                ],
+            },
+        },
+        TagConfig {
+            id: "default_hot_streak_form".to_string(),
+            name: "手热".to_string(),
+            desc: "近 10 场排位胜率显著高于近 20 场，状态上升".to_string(),
+            good: true,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::And {
+                conditions: vec![
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 10 }],
+                        refresh: MatchRefresh::Average {
+                            metric: "win".to_string(),
+                            op: Operator::Gte,
+                            value: 0.7,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Average {
+                            metric: "win".to_string(),
+                            op: Operator::Lte,
+                            value: 0.55,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Count {
+                            op: Operator::Gte,
+                            value: 15.0,
+                        },
+                    },
+                ],
+            },
+        },
+        TagConfig {
+            id: "default_cold_form".to_string(),
+            name: "低谷".to_string(),
+            desc: "近 10 场排位胜率显著低于近 20 场，仅供参考".to_string(),
+            good: false,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::And {
+                conditions: vec![
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 10 }],
+                        refresh: MatchRefresh::Average {
+                            metric: "win".to_string(),
+                            op: Operator::Lte,
+                            value: 0.3,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Average {
+                            metric: "win".to_string(),
+                            op: Operator::Gte,
+                            value: 0.45,
+                        },
+                    },
+                    TagCondition::History {
+                        filters: vec![ranked_filter.clone(), MatchFilter::Recent { count: 20 }],
+                        refresh: MatchRefresh::Count {
+                            op: Operator::Gte,
+                            value: 15.0,
+                        },
+                    },
+                ],
+            },
+        },
+        TagConfig {
+            id: "default_int_risk".to_string(),
+            name: "挂机送头风险".to_string(),
+            desc: "近 20 场中伤害占比极低的场次偏多，仅供参考".to_string(),
+            good: false,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::History {
+                filters: vec![MatchFilter::Recent { count: 20 }],
+                refresh: MatchRefresh::Ratio {
+                    metric: "damageShare".to_string(),
+                    game_op: Operator::Lt,
+                    game_value: 0.08,
+                    op: Operator::Gte,
+                    value: 0.2,
+                },
+            },
+        },
     ]
 }
 
@@ -1064,6 +1229,39 @@ mod tests {
             games: GamesWrapper { games },
             ..Default::default()
         }
+    }
+
+    /// 构造一场带 K/D/A 数据的对局（其余同 `make_game`）。
+    fn make_game_kda(
+        champion_id: i32,
+        win: bool,
+        queue_id: i32,
+        kills: i32,
+        deaths: i32,
+        assists: i32,
+    ) -> Game {
+        let mut g = make_game(champion_id, win, queue_id);
+        g.participants[0].stats.kills = kills;
+        g.participants[0].stats.deaths = deaths;
+        g.participants[0].stats.assists = assists;
+        g
+    }
+
+    /// 构造一场带伤害占比（rate 为 calculate() 预计算的 0-100 整数）
+    /// 且 game_detail 非空的排位对局——detail 缺失时 damageShare 为 NAN，不计入 Ratio 分子。
+    fn make_game_with_damage_rate(win: bool, rate: i32) -> Game {
+        let mut g = make_game(1, win, QUEUE_SOLO_5X5);
+        g.participants[0].stats.damage_dealt_to_champions_rate = rate;
+        g.game_detail.participants = vec![Default::default()];
+        g
+    }
+
+    /// 按 id 从默认标签列表中取出一个 TagConfig。
+    fn default_tag(id: &str) -> TagConfig {
+        get_default_tags()
+            .into_iter()
+            .find(|t| t.id == id)
+            .unwrap_or_else(|| panic!("默认标签不存在: {}", id))
     }
 
     #[test]
@@ -1353,5 +1551,114 @@ mod tests {
                 value: 3.0
             },
         ));
+    }
+
+    // --- 语义类默认标签（规则语义级测试）---
+
+    #[test]
+    fn default_smurf_fires_on_high_winrate_high_kda() {
+        // 12 场排位全胜、KDA (10+5)/2 = 7.5 ≥ 5：
+        // Count 12 ≥ 10、胜率 1.0 ≥ 0.75、KDA 7.5 ≥ 5 → 命中「炸鱼嫌疑」
+        let games: Vec<Game> = (0..12)
+            .map(|_| make_game_kda(1, true, QUEUE_SOLO_5X5, 10, 2, 5))
+            .collect();
+        let history = make_history(games);
+        let smurf = default_tag("default_smurf");
+        assert!(smurf.evaluate(&history, 420, None).is_some());
+        // 6 场样本不足（Count 6 < 10）→ 不命中
+        let few = make_history(
+            (0..6)
+                .map(|_| make_game_kda(1, true, QUEUE_SOLO_5X5, 10, 2, 5))
+                .collect(),
+        );
+        assert!(smurf.evaluate(&few, 420, None).is_none());
+    }
+
+    #[test]
+    fn default_champion_pool_wide_fires_on_many_distinct_champions() {
+        let tag = default_tag("default_champion_pool_wide");
+        // 20 场 20 个不同英雄 → DistinctChampions 20 ≥ 12 命中
+        let wide = make_history(
+            (0..20)
+                .map(|i| make_game(i, true, QUEUE_SOLO_5X5))
+                .collect(),
+        );
+        assert!(tag.evaluate(&wide, 420, None).is_some());
+        // 20 场全同一英雄 → Distinct 1 < 12 不命中
+        let narrow = make_history(
+            (0..20)
+                .map(|_| make_game(1, true, QUEUE_SOLO_5X5))
+                .collect(),
+        );
+        assert!(tag.evaluate(&narrow, 420, None).is_none());
+    }
+
+    #[test]
+    fn default_champion_pool_narrow_fires_on_few_champions_enough_games() {
+        let tag = default_tag("default_champion_pool_narrow");
+        // 20 场全英雄 1 → Distinct 1 ≤ 3 且 Count 20 ≥ 10 命中
+        let narrow = make_history(
+            (0..20)
+                .map(|_| make_game(1, true, QUEUE_SOLO_5X5))
+                .collect(),
+        );
+        assert!(tag.evaluate(&narrow, 420, None).is_some());
+        // 英雄海玩家（20 个英雄）→ Distinct 20 > 3 不命中「专精」
+        let wide = make_history(
+            (0..20)
+                .map(|i| make_game(i, true, QUEUE_SOLO_5X5))
+                .collect(),
+        );
+        assert!(tag.evaluate(&wide, 420, None).is_none());
+    }
+
+    #[test]
+    fn default_hot_streak_form_fires_on_recent_surge_only() {
+        let tag = default_tag("default_hot_streak_form");
+        // 列表最新在前：近 10 场 8 胜（0.8 ≥ 0.7），更早 10 场 2 胜，
+        // 整体 20 场胜率 0.5 ≤ 0.55 且 Count 20 ≥ 15 → 命中「手热」
+        let mut games: Vec<Game> = (0..10)
+            .map(|i| make_game(1, i < 8, QUEUE_SOLO_5X5))
+            .collect();
+        games.extend((0..10).map(|i| make_game(1, i < 2, QUEUE_SOLO_5X5)));
+        assert!(tag.evaluate(&make_history(games), 420, None).is_some());
+        // 20 场全胜：近 10 胜率高但整体 1.0 > 0.55，「一直很强」不算「手热」
+        let all_win = make_history(
+            (0..20)
+                .map(|_| make_game(1, true, QUEUE_SOLO_5X5))
+                .collect(),
+        );
+        assert!(tag.evaluate(&all_win, 420, None).is_none());
+    }
+
+    #[test]
+    fn default_cold_form_fires_on_recent_slump() {
+        let tag = default_tag("default_cold_form");
+        // 近 10 场 2 胜（0.2 ≤ 0.3），更早 10 场 8 胜，
+        // 整体 20 场胜率 0.5 ≥ 0.45 且 Count 20 ≥ 15 → 命中「低谷」
+        let mut games: Vec<Game> = (0..10)
+            .map(|i| make_game(1, i < 2, QUEUE_SOLO_5X5))
+            .collect();
+        games.extend((0..10).map(|i| make_game(1, i < 8, QUEUE_SOLO_5X5)));
+        assert!(tag.evaluate(&make_history(games), 420, None).is_some());
+    }
+
+    #[test]
+    fn default_int_risk_fires_on_frequent_low_damage_share() {
+        let tag = default_tag("default_int_risk");
+        // 20 场全部带 game_detail（避免 NAN 稀释分子）：
+        // 5 场 rate 5（0.05 < 0.08）+ 15 场 rate 25 → 占比 5/20 = 0.25 ≥ 0.2 命中
+        let mut games: Vec<Game> = (0..5)
+            .map(|_| make_game_with_damage_rate(false, 5))
+            .collect();
+        games.extend((0..15).map(|_| make_game_with_damage_rate(true, 25)));
+        assert!(tag.evaluate(&make_history(games), 420, None).is_some());
+        // 20 场伤害占比全部正常（0.25）→ 占比 0 < 0.2 不命中
+        let normal = make_history(
+            (0..20)
+                .map(|_| make_game_with_damage_rate(true, 25))
+                .collect(),
+        );
+        assert!(tag.evaluate(&normal, 420, None).is_none());
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -1118,16 +1118,39 @@ pub fn get_default_tags() -> Vec<TagConfig> {
     ]
 }
 
+/// 将 get_default_tags 中用户配置里缺失的默认标签追加进来。
+///
+/// 只补"id 不存在"的项；用户对已有标签的任何修改（禁用/改名/调阈值）不被覆盖。
+/// is_default 标签 UI 上不可删除，因此无需删除墓碑机制。
+fn merge_missing_defaults(mut tags: Vec<TagConfig>) -> Vec<TagConfig> {
+    let existing: std::collections::HashSet<String> = tags.iter().map(|t| t.id.clone()).collect();
+    tags.extend(
+        get_default_tags()
+            .into_iter()
+            .filter(|d| !existing.contains(&d.id)),
+    );
+    tags
+}
+
 /// 加载标签配置。
 ///
-/// 如果配置文件不存在，会自动创建默认配置。
+/// 如果配置文件不存在，会自动创建默认配置；
+/// 已有配置会自动补齐版本更新后新增的默认标签（不覆盖用户对已有标签的修改）。
 ///
 /// # 返回值
 ///
 /// 标签配置列表
 pub async fn load_config() -> Vec<TagConfig> {
     match config::get_config("userTags").await {
-        Ok(val) => config_value_to_tags(val),
+        Ok(val) => {
+            let tags = config_value_to_tags(val);
+            let before = tags.len();
+            let merged = merge_missing_defaults(tags);
+            if merged.len() != before {
+                let _ = save_tag_configs(merged.clone()).await;
+            }
+            merged
+        }
         Err(_) => {
             let defaults = get_default_tags();
             let _ = save_tag_configs(defaults.clone()).await;
@@ -1660,5 +1683,26 @@ mod tests {
                 .collect(),
         );
         assert!(tag.evaluate(&normal, 420, None).is_none());
+    }
+
+    #[test]
+    fn merge_appends_missing_defaults_without_touching_user_edits() {
+        let mut mine = get_default_tags();
+        mine.truncate(2); // 模拟老用户只有旧的两个默认标签
+        mine[0].enabled = false; // 用户禁用过
+        mine[0].name = "我改过名".to_string();
+        let merged = merge_missing_defaults(mine);
+        // 新默认标签补齐
+        assert!(merged.iter().any(|t| t.id == "default_smurf"));
+        // 用户的修改原样保留
+        let first = merged
+            .iter()
+            .find(|t| t.id == get_default_tags()[0].id)
+            .unwrap();
+        assert!(!first.enabled);
+        assert_eq!(first.name, "我改过名");
+        // 幂等：再 merge 不再增长
+        let len = merged.len();
+        assert_eq!(merge_missing_defaults(merged).len(), len);
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -1082,6 +1082,7 @@ pub fn get_default_tags() -> Vec<TagConfig> {
                 ],
             },
         },
+        // 阈值 0.05 / 0.3 与前端 TagConditionNode.vue 的 ratio 编辑器默认值保持一致，调参需同步
         TagConfig {
             id: "default_int_risk".to_string(),
             name: "伤害贡献低".to_string(),
@@ -1630,6 +1631,13 @@ mod tests {
             .collect();
         games.extend((0..10).map(|i| make_game(1, i < 8, QUEUE_SOLO_5X5)));
         assert!(tag.evaluate(&make_history(games), 420, None).is_some());
+        // 20 场全败：近 10 胜率 0 ≤ 0.3，但整体 0 < 0.45，「一直低迷」不算「低谷」
+        let all_loss = make_history(
+            (0..20)
+                .map(|_| make_game(1, false, QUEUE_SOLO_5X5))
+                .collect(),
+        );
+        assert!(tag.evaluate(&all_loss, 420, None).is_none());
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src/types/__tests__/tagSuggest.spec.ts
+++ b/lol-record-analysis-tauri/src/types/__tests__/tagSuggest.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import type { MatchFilter, MatchRefresh } from '../tagSuggest'
+
+describe('tagSuggest 类型与 Rust serde 序列化一致', () => {
+  it('recent filter 使用 count 字段', () => {
+    const f: MatchFilter = { type: 'recent', count: 20 }
+    expect(JSON.parse(JSON.stringify(f))).toEqual({ type: 'recent', count: 20 })
+  })
+  it('ratio refresh 使用 gameOp/gameValue 命名（对应 Rust serde rename）', () => {
+    const r: MatchRefresh = {
+      type: 'ratio',
+      metric: 'damageShare',
+      gameOp: '<',
+      gameValue: 0.05,
+      op: '>=',
+      value: 0.3
+    }
+    expect(Object.keys(r).sort()).toEqual(
+      ['gameOp', 'gameValue', 'metric', 'op', 'type', 'value'].sort()
+    )
+  })
+  it('distinctChampions refresh 结构', () => {
+    const r: MatchRefresh = { type: 'distinctChampions', op: '<=', value: 3 }
+    expect(JSON.parse(JSON.stringify(r))).toEqual({ type: 'distinctChampions', op: '<=', value: 3 })
+  })
+})

--- a/lol-record-analysis-tauri/src/types/tagSuggest.ts
+++ b/lol-record-analysis-tauri/src/types/tagSuggest.ts
@@ -12,6 +12,8 @@ export type MatchFilter =
   | { type: 'queue'; ids: number[] }
   | { type: 'champion'; ids: number[] }
   | { type: 'stat'; metric: string; op: Operator; value: number }
+  // 只取最近 N 场（按时间倒序截断）
+  | { type: 'recent'; count: number }
 
 export type MatchRefresh =
   | { type: 'count'; op: Operator; value: number }
@@ -20,6 +22,18 @@ export type MatchRefresh =
   | { type: 'max'; metric: string; op: Operator; value: number }
   | { type: 'min'; metric: string; op: Operator; value: number }
   | { type: 'streak'; min: number; kind: StreakType }
+  // 去重英雄数量与阈值比较
+  | { type: 'distinctChampions'; op: Operator; value: number }
+  // 单场指标满足 (gameOp, gameValue) 的场次占比与 (op, value) 比较；
+  // gameOp/gameValue 对应 Rust 侧 serde rename 后的字段名
+  | {
+      type: 'ratio'
+      metric: string
+      gameOp: Operator
+      gameValue: number
+      op: Operator
+      value: number
+    }
 
 export type TagCondition =
   | { type: 'and'; conditions: TagCondition[] }

--- a/lol-record-analysis-tauri/src/views/settings/TagConditionNode.vue
+++ b/lol-record-analysis-tauri/src/views/settings/TagConditionNode.vue
@@ -499,9 +499,11 @@ function handleRefreshTypeChange(refresh: any, newType: string) {
     refresh.kind = 'win'
     refresh.min = 3
   } else if (newType === 'distinctChampions') {
-    refresh.op = '>='
-    refresh.value = 12
+    // 对齐后端「专精」语义（default_champion_pool_narrow：英雄数 ≤ 3）
+    refresh.op = '<='
+    refresh.value = 3
   } else if (newType === 'ratio') {
+    // 阈值 0.05 / 0.3 与后端 user_tag_config.rs 的 default_int_risk 保持一致，调参需同步
     refresh.metric = 'damageShare'
     refresh.gameOp = '<'
     refresh.gameValue = 0.05

--- a/lol-record-analysis-tauri/src/views/settings/TagConditionNode.vue
+++ b/lol-record-analysis-tauri/src/views/settings/TagConditionNode.vue
@@ -129,6 +129,19 @@
               />
             </template>
 
+            <!-- Recent Filter -->
+            <template v-if="filter.type === 'recent'">
+              <n-input-number
+                size="small"
+                v-model:value="filter.count"
+                :min="1"
+                :max="50"
+                :show-button="false"
+                class="num-input"
+              />
+              <span class="text-label">场</span>
+            </template>
+
             <n-button
               size="tiny"
               circle
@@ -152,17 +165,22 @@
         <div v-if="condition.refresh" class="refresh-row">
           <n-select
             size="small"
-            v-model:value="condition.refresh.type"
+            :value="condition.refresh.type"
+            @update:value="val => handleRefreshTypeChange(condition.refresh, val)"
             :options="refreshTypeOptions"
             class="sel-type"
           />
 
-          <!-- Count/Sum/Avg/Max/Min -->
+          <!-- Count/Sum/Avg/Max/Min/DistinctChampions（共用 op + value 控件） -->
           <template
-            v-if="['count', 'sum', 'average', 'max', 'min'].includes(condition.refresh.type)"
+            v-if="
+              ['count', 'sum', 'average', 'max', 'min', 'distinctChampions'].includes(
+                condition.refresh.type
+              )
+            "
           >
             <n-select
-              v-if="condition.refresh.type !== 'count'"
+              v-if="!['count', 'distinctChampions'].includes(condition.refresh.type)"
               size="small"
               v-model:value="condition.refresh.metric"
               :options="metricOptions"
@@ -202,6 +220,42 @@
               class="num-input"
             />
             <span class="text-label">场</span>
+          </template>
+
+          <!-- Ratio: 单场指标满足 (gameOp, gameValue) 的场次占比与 (op, value) 比较 -->
+          <template v-if="condition.refresh.type === 'ratio'">
+            <n-select
+              size="small"
+              v-model:value="condition.refresh.metric"
+              :options="metricOptions"
+              placeholder="指标"
+              class="sel-metric"
+            />
+            <n-select
+              size="small"
+              v-model:value="condition.refresh.gameOp"
+              :options="opOptions"
+              class="sel-op"
+            />
+            <n-input-number
+              size="small"
+              v-model:value="condition.refresh.gameValue"
+              :show-button="false"
+              class="num-input"
+            />
+            <span class="text-label">的场次占比</span>
+            <n-select
+              size="small"
+              v-model:value="condition.refresh.op"
+              :options="opOptions"
+              class="sel-op"
+            />
+            <n-input-number
+              size="small"
+              v-model:value="condition.refresh.value"
+              :show-button="false"
+              class="num-input"
+            />
           </template>
         </div>
       </div>
@@ -293,7 +347,8 @@ const { modelValue: condition } = toRefs(props)
 const filterTypeOptions = [
   { label: '模式', value: 'queue' },
   { label: '英雄', value: 'champion' },
-  { label: '单场数据', value: 'stat' }
+  { label: '单场数据', value: 'stat' },
+  { label: '最近 N 场', value: 'recent' }
 ]
 
 const metricOptions = [
@@ -306,7 +361,9 @@ const metricOptions = [
   { label: '补刀 (CS)', value: 'cs' },
   { label: '造成伤害', value: 'damage' },
   { label: '承受伤害', value: 'damageTaken' },
-  { label: '游戏时长', value: 'gameDuration' }
+  { label: '游戏时长', value: 'gameDuration' },
+  { label: '伤害占比 (0-1)', value: 'damageShare' },
+  { label: '参团率 (0-1)', value: 'participation' }
 ]
 
 const opOptions = [
@@ -324,7 +381,9 @@ const refreshTypeOptions = [
   { label: '求和', value: 'sum' },
   { label: '最大值', value: 'max' },
   { label: '最小值', value: 'min' },
-  { label: '连胜/败', value: 'streak' }
+  { label: '连胜/败', value: 'streak' },
+  { label: '英雄数量', value: 'distinctChampions' },
+  { label: '场次占比', value: 'ratio' }
 ]
 
 // --- Actions ---
@@ -392,17 +451,62 @@ function handleFilterTypeChange(filter: any, newType: string) {
     delete filter.metric
     delete filter.op
     delete filter.value
+    delete filter.count
     filter.ids = []
   } else if (newType === 'champion') {
     delete filter.metric
     delete filter.op
     delete filter.value
+    delete filter.count
     filter.ids = []
   } else if (newType === 'stat') {
     delete filter.ids
+    delete filter.count
     filter.metric = 'kda'
     filter.op = '>='
     filter.value = 0
+  } else if (newType === 'recent') {
+    delete filter.ids
+    delete filter.metric
+    delete filter.op
+    delete filter.value
+    filter.count = 20
+  }
+  emitUpdate()
+}
+
+/**
+ * 切换 Check 类型时清理旧类型专属字段并写入新类型的合法初值，
+ * 避免残留字段导致后端反序列化失败（如 streak 的 min/kind 混进 ratio）
+ */
+function handleRefreshTypeChange(refresh: any, newType: string) {
+  delete refresh.metric
+  delete refresh.op
+  delete refresh.value
+  delete refresh.min
+  delete refresh.kind
+  delete refresh.gameOp
+  delete refresh.gameValue
+  refresh.type = newType
+  if (newType === 'count') {
+    refresh.op = '>='
+    refresh.value = 1
+  } else if (['average', 'sum', 'max', 'min'].includes(newType)) {
+    refresh.metric = 'kda'
+    refresh.op = '>='
+    refresh.value = 0
+  } else if (newType === 'streak') {
+    refresh.kind = 'win'
+    refresh.min = 3
+  } else if (newType === 'distinctChampions') {
+    refresh.op = '>='
+    refresh.value = 12
+  } else if (newType === 'ratio') {
+    refresh.metric = 'damageShare'
+    refresh.gameOp = '<'
+    refresh.gameValue = 0.05
+    refresh.op = '>='
+    refresh.value = 0.3
   }
   emitUpdate()
 }


### PR DESCRIPTION
## Summary
- 新增五个语义类默认标签：炸鱼嫌疑 / 专精 / 手热 / 低谷 / 伤害贡献低（负面标签阈值保守、措辞事实化，desc 均注明「仅供参考」）
- 「英雄海」经评审撤下：按"玩过的不同英雄数"算池宽会被随机英雄模式污染，待引擎支持 per-champion 统计后再迭代（spec 已记录）
- load_config 自动补齐版本新增的默认标签：按 id 只追加缺失项，用户的禁用/改名/调阈值一律不覆盖，幂等，仅长度变化时回写
- 前端：tagSuggest.ts 类型镜像（gameOp/gameValue 与 serde rename 逐字对齐 + 序列化一致性测试）；TagConditionNode 编辑器支持 Recent/DistinctChampions/Ratio 三原语；新增 refresh 类型切换默认值工厂（顺带修复切换类型残留脏字段、缺必填字段导致保存失败的既有问题）

依赖 #82（引擎原语）。设计与决策记录：docs/superpowers/specs/2026-07-02-tag-iteration-design.md

## Test plan
- [x] Rust 单测 9 个新增（语义级正反例、合并幂等）——Windows CI 验证
- [x] 前端 vitest 443/443、vue-tsc、prettier/eslint 本地通过
- [ ] Windows CI：cargo test + clippy -D warnings
- [ ] 合入后手动：老配置用户升级后看到新默认标签且旧修改保留