### PR TITLE
feat(ai): 手动备注接入 AI 分析（带隐私开关）

### DIFF
--- a/lol-record-analysis-tauri/src/composables/useMatchAIAnalysis.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchAIAnalysis.ts
@@ -12,7 +12,10 @@ import {
   type MatchAIState
 } from '@renderer/services/ai'
 import { renderAnalysisReport } from '@renderer/services/ai/matchDetail/renderReport'
-import { fetchBatchProfiles } from '@renderer/services/ai/shared/recentProfile.batch'
+import {
+  fetchBatchProfiles,
+  injectNoteBriefs
+} from '@renderer/services/ai/shared/recentProfile.batch'
 import type { RecentPlayerProfile, TeamPosition } from '@renderer/services/ai/shared/types'
 
 export function useMatchAIAnalysis(game: MaybeRefOrGetter<Game | null>) {
@@ -41,12 +44,14 @@ export function useMatchAIAnalysis(game: MaybeRefOrGetter<Game | null>) {
     }
   })
 
-  // Per-game profile cache so re-opening the modal doesn't re-fetch
+  // Per-game profile cache so re-opening the modal doesn't re-fetch.
+  // 只缓存"干净"（未注入备注的）map——备注注入必须在每次返回前实时做，
+  // 否则隐私开关切换后缓存命中会绕过开关（旁路）。
   const profileCache = new Map<number, Map<string, RecentPlayerProfile | null>>()
 
   async function ensureProfiles(g: Game): Promise<Map<string, RecentPlayerProfile | null>> {
     const cached = profileCache.get(g.gameId)
-    if (cached) return cached
+    if (cached) return injectNoteBriefs(cached)
     const identities = g.participantIdentities ?? []
     const participants = g.participants ?? []
     const requests = identities
@@ -64,7 +69,7 @@ export function useMatchAIAnalysis(game: MaybeRefOrGetter<Game | null>) {
       .filter((x): x is NonNullable<typeof x> => x !== null)
     const profiles = await fetchBatchProfiles(requests)
     profileCache.set(g.gameId, profiles)
-    return profiles
+    return injectNoteBriefs(profiles)
   }
 
   async function runCurrentAiAnalysis() {

--- a/lol-record-analysis-tauri/src/services/ai/index.ts
+++ b/lol-record-analysis-tauri/src/services/ai/index.ts
@@ -5,6 +5,8 @@
  */
 
 import type { Game } from '@renderer/types/domain/match'
+import { getConfigByIpc } from '@renderer/services/ipc'
+import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import type { AIAnalysisResult, MatchDetailAnalysisOptions, StreamCallbacks } from './types'
 import { loadChampionNames } from './champion-names'
 import { requestAIContentStream } from './stream'
@@ -31,8 +33,12 @@ export async function analyzeGameWithAIStream(
 ): Promise<void> {
   try {
     await loadChampionNames()
+    // 隐私开关：键不存在视为开（默认开），显式 false 时两条链路都不注入备注
+    const useNotes = (await getConfigByIpc<boolean>(CONFIG_KEYS.aiUsePlayerNotes)) !== false
     const prompt =
-      type === 'team' ? buildTeamAnalysisPrompt(gameData) : buildPlayerAnalysisPrompt(gameData)
+      type === 'team'
+        ? buildTeamAnalysisPrompt(gameData, { useNotes })
+        : buildPlayerAnalysisPrompt(gameData, { useNotes })
     await requestAIContentStream(prompt, callbacks, IN_GAME_SYSTEM_PROMPT)
   } catch (error: any) {
     console.error('AI analysis error:', error)

--- a/lol-record-analysis-tauri/src/services/ai/matchDetail/prompts/stage1-attribution.ts
+++ b/lol-record-analysis-tauri/src/services/ai/matchDetail/prompts/stage1-attribution.ts
@@ -40,6 +40,10 @@ isTeamMode: ${mc.isTeamMode}
 - mainPosition: TOP|JUNGLE|MIDDLE|BOTTOM|UTILITY|UNCLEAR — 主玩位置（占比≥40%才认）
 直接采用这些字段的值，不要重新计算。
 
+【使用者主观备注】
+- recentProfile.note: 使用者对该玩家的主观历史印象（[色档] 文本），仅供参考，
+  不作为事实依据，不得写入 evidenceMetrics。
+
 【标签定义（量化标准）】
 - 尽力：数据明显高于队内均值（伤害占比/经济占比/参团率中任意 2 项进入队内前 2）+ 该队伍胜
 - 犯罪：数据明显低于队内均值（死亡数最多 + 参团 < 30% + KDA 队内倒数）+ 该队伍输

--- a/lol-record-analysis-tauri/src/services/ai/player-insight.ts
+++ b/lol-record-analysis-tauri/src/services/ai/player-insight.ts
@@ -86,8 +86,14 @@ function recentGamePreview(g: any, includeEconomy = true) {
   }
 }
 
-/** 抽取玩家画像（用于队伍对比场景） */
-export function extractPlayerInsight(p: any, opts: { detailed: boolean }) {
+/**
+ * 抽取玩家画像（用于队伍对比场景）
+ * @param p - 会话玩家对象（SessionSummoner 形状）
+ * @param opts.detailed - 是否输出更详细的统计（我方队伍用）
+ * @param opts.noteBrief - 使用者手动备注速览（`[色档] 文本`），有值时以 `userNote`
+ *   字段注入返回对象；开关关闭时调用方不传，返回对象不含该字段
+ */
+export function extractPlayerInsight(p: any, opts: { detailed: boolean; noteBrief?: string }) {
   const recentGames = p.matchHistory?.games?.games || []
   const tags = p.userTag?.tag || []
   const recent = p.userTag?.recentData
@@ -123,6 +129,7 @@ export function extractPlayerInsight(p: any, opts: { detailed: boolean }) {
       desc: t.tagDesc,
       isGood: t.good
     })),
+    ...(opts.noteBrief ? { userNote: opts.noteBrief } : {}),
     recentGamesPreview: recentGames
       .slice(0, 10)
       .map((g: any) => recentGamePreview(g, opts.detailed))

--- a/lol-record-analysis-tauri/src/services/ai/prompts/team-player.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/team-player.ts
@@ -8,11 +8,11 @@ import { buildNoteBrief } from '../shared/noteBrief'
 /**
  * 构建单玩家深度分析 prompt
  * @param player - 会话玩家对象（SessionSummoner 形状）
- * @param opts.useNotes - 是否注入使用者手动备注（隐私开关，默认 true）
+ * @param opts.useNotes - 是否注入使用者手动备注（隐私开关，默认 false，fail-closed）
  */
 export function buildPlayerAnalysisPrompt(player: any, opts: { useNotes?: boolean } = {}): string {
   const noteBrief =
-    opts.useNotes !== false ? buildNoteBrief(player.summoner?.puuid ?? '') : undefined
+    opts.useNotes === true ? buildNoteBrief(player.summoner?.puuid ?? '') : undefined
   const noteSection = noteBrief
     ? `\n【使用者备注】\n${noteBrief}\n（使用者对该玩家的主观历史备注（[色档] 文本），仅供参考，不作为事实依据）\n`
     : ''

--- a/lol-record-analysis-tauri/src/services/ai/prompts/team-player.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/team-player.ts
@@ -3,8 +3,19 @@
  */
 
 import { extractPlayerDeepDive } from '../player-insight'
+import { buildNoteBrief } from '../shared/noteBrief'
 
-export function buildPlayerAnalysisPrompt(player: any): string {
+/**
+ * 构建单玩家深度分析 prompt
+ * @param player - 会话玩家对象（SessionSummoner 形状）
+ * @param opts.useNotes - 是否注入使用者手动备注（隐私开关，默认 true）
+ */
+export function buildPlayerAnalysisPrompt(player: any, opts: { useNotes?: boolean } = {}): string {
+  const noteBrief =
+    opts.useNotes !== false ? buildNoteBrief(player.summoner?.puuid ?? '') : undefined
+  const noteSection = noteBrief
+    ? `\n【使用者备注】\n${noteBrief}\n（使用者对该玩家的主观历史备注（[色档] 文本），仅供参考，不作为事实依据）\n`
+    : ''
   const tags = player.userTag?.tag || []
   const recent = player.userTag?.recentData
   const winRate =
@@ -37,7 +48,7 @@ ${JSON.stringify(positionStats, null, 2)}
 
 【标签列表】
 ${tags.length > 0 ? tags.map((t: any) => `• ${t.tagName}(${t.tagDesc}) - ${t.good ? '正面' : '负面'}`).join('\n') : '无标签'}
-
+${noteSection}
 【最近15场详细战绩】
 ${JSON.stringify(detailedGames, null, 2)}
 

--- a/lol-record-analysis-tauri/src/services/ai/prompts/team.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/team.ts
@@ -4,6 +4,7 @@
  */
 
 import { extractPlayerInsight } from '../player-insight'
+import { buildNoteBrief } from '../shared/noteBrief'
 
 interface SessionDataLike {
   typeCn?: string
@@ -12,14 +13,28 @@ interface SessionDataLike {
   subteams?: Array<{ subteamId: number; players: any[] }>
 }
 
-export function buildTeamAnalysisPrompt(sessionData: SessionDataLike): string {
+/**
+ * 构建整队分析 prompt
+ * @param sessionData - 对局会话数据（subteams 统一模型）
+ * @param opts.useNotes - 是否注入使用者手动备注（隐私开关，默认 true）
+ */
+export function buildTeamAnalysisPrompt(
+  sessionData: SessionDataLike,
+  opts: { useNotes?: boolean } = {}
+): string {
   const isMulti = !!sessionData.isMultiTeam
   const mySubteamId = sessionData.mySubteamId ?? 0
   const subteams = sessionData.subteams ?? []
+  const useNotes = opts.useNotes !== false
 
   const blocks = subteams.map(st => {
     const detailed = st.subteamId === mySubteamId
-    const playersInfo = st.players.map(p => extractPlayerInsight(p, { detailed }))
+    const playersInfo = st.players.map(p =>
+      extractPlayerInsight(p, {
+        detailed,
+        noteBrief: useNotes ? buildNoteBrief(p.summoner?.puuid ?? '') : undefined
+      })
+    )
     const label = isMulti
       ? `队伍 ${st.subteamId}${st.subteamId === mySubteamId ? '（我方）' : ''}`
       : st.subteamId === mySubteamId
@@ -43,6 +58,8 @@ ${blocks.join('\n\n')}
 严格按下面 markdown 模板，章节标题与顺序不可改；每条要点用
 \`- 名字：一句话判断 — 数字依据\` 的格式，数字必须来自上面的数据
 （胜率 / KDA / 伤害占比 / 参团率 / 英雄胜率与场次等），不要编造新数字。
+玩家数据里的 userNote 字段是使用者对该玩家的主观历史备注（[色档] 文本），
+仅供参考，不作为事实依据。
 
 ## 一句话判断
 {一句话点明这局关键看点：哪边阵容/状态更稳、该围绕谁打。要有网感、别空泛}

--- a/lol-record-analysis-tauri/src/services/ai/prompts/team.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/team.ts
@@ -16,7 +16,7 @@ interface SessionDataLike {
 /**
  * 构建整队分析 prompt
  * @param sessionData - 对局会话数据（subteams 统一模型）
- * @param opts.useNotes - 是否注入使用者手动备注（隐私开关，默认 true）
+ * @param opts.useNotes - 是否注入使用者手动备注（隐私开关，默认 false，fail-closed）
  */
 export function buildTeamAnalysisPrompt(
   sessionData: SessionDataLike,
@@ -25,7 +25,7 @@ export function buildTeamAnalysisPrompt(
   const isMulti = !!sessionData.isMultiTeam
   const mySubteamId = sessionData.mySubteamId ?? 0
   const subteams = sessionData.subteams ?? []
-  const useNotes = opts.useNotes !== false
+  const useNotes = opts.useNotes === true
 
   const blocks = subteams.map(st => {
     const detailed = st.subteamId === mySubteamId

--- a/lol-record-analysis-tauri/src/services/ai/shared/__tests__/noteBrief.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/__tests__/noteBrief.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * buildNoteBrief 单元测试 + extractPlayerInsight 的 userNote 注入测试
+ * @module services/ai/shared/noteBrief
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// Mock config IPC，避免触达 Tauri runtime（setNote 会落盘）
+vi.mock('@renderer/services/ipc', () => ({
+  getConfigByIpc: vi.fn(),
+  putConfigByIpc: vi.fn(() => Promise.resolve())
+}))
+
+// Mock Tauri 事件（playerNotes store 落盘后跨窗口广播用）
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(() => Promise.resolve()),
+  listen: vi.fn(() => Promise.resolve(() => {}))
+}))
+
+import { buildNoteBrief } from '../noteBrief'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import { extractPlayerInsight } from '../../player-insight'
+
+describe('buildNoteBrief', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('无备注返回 undefined', () => {
+    expect(buildNoteBrief('nobody')).toBeUndefined()
+  })
+
+  it('有备注返回 [色档] 文本，超 50 字截断', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p1', {
+      note: 'x'.repeat(80),
+      label: 'blacklist',
+      gameName: 'A',
+      tagLine: '1'
+    })
+    const brief = buildNoteBrief('p1')
+    expect(brief).toContain('[拉黑]')
+    expect(brief!.length).toBeLessThanOrEqual('[拉黑] '.length + 50)
+  })
+
+  it('只标色档不写字时仅返回 [色档]', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p2', { note: '', label: 'friendly', gameName: 'B', tagLine: '2' })
+    expect(buildNoteBrief('p2')).toBe('[友好]')
+  })
+
+  it('备注为纯空白时也仅返回 [色档]', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p3', { note: '   ', label: 'careful', gameName: 'C', tagLine: '3' })
+    expect(buildNoteBrief('p3')).toBe('[小心]')
+  })
+})
+
+describe('extractPlayerInsight 的 noteBrief 注入', () => {
+  /** 最小玩家对象：extractPlayerInsight 对缺失字段均有兜底 */
+  const minimalPlayer = { summoner: { gameName: '测试玩家' } }
+
+  it('不传 noteBrief 时返回对象无 userNote 字段（开关关闭场景）', () => {
+    const out = extractPlayerInsight(minimalPlayer, { detailed: false })
+    expect('userNote' in out).toBe(false)
+  })
+
+  it('传 noteBrief 时返回对象带 userNote', () => {
+    const out = extractPlayerInsight(minimalPlayer, {
+      detailed: false,
+      noteBrief: '[拉黑] 演员'
+    })
+    expect(out.userNote).toBe('[拉黑] 演员')
+  })
+})

--- a/lol-record-analysis-tauri/src/services/ai/shared/__tests__/recentProfile.batch.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/__tests__/recentProfile.batch.spec.ts
@@ -13,7 +13,7 @@ vi.mock('@tauri-apps/api/event', () => ({
 }))
 
 import { invoke } from '@tauri-apps/api/core'
-import { fetchBatchProfiles, __resetCacheForTests } from '../recentProfile.batch'
+import { fetchBatchProfiles, injectNoteBriefs, __resetCacheForTests } from '../recentProfile.batch'
 import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
 
 const mockInvoke = invoke as ReturnType<typeof vi.fn>
@@ -119,67 +119,93 @@ describe('fetchBatchProfiles', () => {
     vi.useRealTimers()
   })
 
-  describe('手动备注注入', () => {
-    /** get_match_history 返回一场对局，get_config 按 aiUsePlayerNotes 返回指定值 */
-    function mockLcuWithConfig(useNotesValue: boolean | undefined) {
-      mockInvoke.mockImplementation(async (cmd, args: any) => {
-        if (cmd === 'get_match_history_by_puuid') {
-          return rawHistory(args.puuid, [
-            rawMatch({ puuid: args.puuid, teamPosition: 'JUNGLE', championId: 64, win: true })
-          ])
-        }
-        if (cmd === 'get_config') {
-          return useNotesValue === undefined ? null : { value: useNotesValue }
-        }
-        return null
-      })
-    }
-
-    it('开关默认开（键不存在）时注入 profile.note', async () => {
-      const store = usePlayerNotesStore()
-      await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
-      mockLcuWithConfig(undefined)
-
-      const result = await fetchBatchProfiles([
-        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 },
-        { puuid: 'p2', teamPosition: 'TOP', championId: 86 }
-      ])
-
-      expect(result.get('p1')?.note).toBe('[拉黑] 演员')
-      // 无备注的玩家不带 note 字段
-      expect(result.get('p2')?.note).toBeUndefined()
+  it('恒返回干净 profile：即使开关开且有备注也不含 note（注入是 injectNoteBriefs 的职责）', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+    mockInvoke.mockImplementation(async (cmd, args: any) => {
+      if (cmd === 'get_match_history_by_puuid') {
+        return rawHistory(args.puuid, [
+          rawMatch({ puuid: args.puuid, teamPosition: 'JUNGLE', championId: 64, win: true })
+        ])
+      }
+      // 开关键不存在（视为开）——即便如此 fetchBatchProfiles 也不注入
+      return null
     })
 
-    it('开关显式关闭时不注入', async () => {
-      const store = usePlayerNotesStore()
-      await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
-      mockLcuWithConfig(false)
+    const result = await fetchBatchProfiles([
+      { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
+    ])
 
-      const result = await fetchBatchProfiles([
-        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
-      ])
+    expect(result.get('p1')).not.toBeNull()
+    expect(result.get('p1')?.note).toBeUndefined()
+  })
+})
 
-      expect(result.get('p1')?.note).toBeUndefined()
+describe('injectNoteBriefs', () => {
+  /** get_config 按 aiUsePlayerNotes 返回指定值 */
+  function mockConfig(useNotesValue: boolean | undefined) {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_config') {
+        return useNotesValue === undefined ? null : { value: useNotesValue }
+      }
+      return null
     })
+  }
 
-    it('note 不写入 LRU 缓存：开关关闭后缓存命中也不带 note', async () => {
-      const store = usePlayerNotesStore()
-      await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
-
-      // 第一次：开关开 → 带 note
-      mockLcuWithConfig(undefined)
-      const first = await fetchBatchProfiles([
-        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
-      ])
-      expect(first.get('p1')?.note).toBe('[拉黑] 演员')
-
-      // 第二次：缓存命中（不再拉战绩），但开关已关 → 不得残留 note
-      mockLcuWithConfig(false)
-      const second = await fetchBatchProfiles([
-        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
-      ])
-      expect(historyCallCount()).toBe(1)
-      expect(second.get('p1')?.note).toBeUndefined()
+  /** 构造一个干净（无 note）的 profile map */
+  async function buildCleanMap(puuids: string[]) {
+    mockInvoke.mockImplementation(async (cmd, args: any) => {
+      if (cmd === 'get_match_history_by_puuid') {
+        return rawHistory(args.puuid, [
+          rawMatch({ puuid: args.puuid, teamPosition: 'JUNGLE', championId: 64, win: true })
+        ])
+      }
+      return null
     })
+    return fetchBatchProfiles(
+      puuids.map(puuid => ({ puuid, teamPosition: 'JUNGLE' as const, championId: 64 }))
+    )
+  }
+
+  it('开关默认开（键不存在）时注入 profile.note', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+    const cleanMap = await buildCleanMap(['p1', 'p2'])
+    mockConfig(undefined)
+
+    const result = await injectNoteBriefs(cleanMap)
+
+    expect(result.get('p1')?.note).toBe('[拉黑] 演员')
+    // 无备注的玩家不带 note 字段
+    expect(result.get('p2')?.note).toBeUndefined()
+    // 入参 map 不被就地修改
+    expect(cleanMap.get('p1')?.note).toBeUndefined()
+  })
+
+  it('开关显式关闭时不注入', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+    const cleanMap = await buildCleanMap(['p1'])
+    mockConfig(false)
+
+    const result = await injectNoteBriefs(cleanMap)
+
+    expect(result.get('p1')?.note).toBeUndefined()
+  })
+
+  it('回归：先开后关——对同一个干净 map 再注入不得残留 note（隐私旁路）', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+    const cleanMap = await buildCleanMap(['p1'])
+
+    // 第一次：开关开 → 带 note
+    mockConfig(undefined)
+    const first = await injectNoteBriefs(cleanMap)
+    expect(first.get('p1')?.note).toBe('[拉黑] 演员')
+
+    // 开关关掉后，对同一个干净 map 再调 → 不得带 note
+    mockConfig(false)
+    const second = await injectNoteBriefs(cleanMap)
+    expect(second.get('p1')?.note).toBeUndefined()
   })
 })

--- a/lol-record-analysis-tauri/src/services/ai/shared/__tests__/recentProfile.batch.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/__tests__/recentProfile.batch.spec.ts
@@ -1,18 +1,32 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
 
 // Mock @tauri-apps/api/core BEFORE importing the module under test
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn()
 }))
 
+// Mock Tauri 事件（playerNotes store 落盘后跨窗口广播用）
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(() => Promise.resolve()),
+  listen: vi.fn(() => Promise.resolve(() => {}))
+}))
+
 import { invoke } from '@tauri-apps/api/core'
 import { fetchBatchProfiles, __resetCacheForTests } from '../recentProfile.batch'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
 
 const mockInvoke = invoke as ReturnType<typeof vi.fn>
+
+/** 只统计战绩拉取的 invoke 次数（备注开关的 get_config 调用不计入） */
+const historyCallCount = () =>
+  mockInvoke.mock.calls.filter(c => c[0] === 'get_match_history_by_puuid').length
 
 beforeEach(() => {
   mockInvoke.mockReset()
   __resetCacheForTests()
+  // buildNoteBrief（备注注入）依赖 pinia store
+  setActivePinia(createPinia())
 })
 
 function rawMatch(opts: { puuid: string; teamPosition: string; championId: number; win: boolean }) {
@@ -85,8 +99,8 @@ describe('fetchBatchProfiles', () => {
     await fetchBatchProfiles([{ puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }])
     await fetchBatchProfiles([{ puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }])
 
-    // First call: 1 invoke. Second call: cache hit → no additional invoke.
-    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    // First call: 1 history invoke. Second call: cache hit → no additional invoke.
+    expect(historyCallCount()).toBe(1)
   })
 
   it('re-fetches if cache expired (advance fake timers)', async () => {
@@ -101,7 +115,71 @@ describe('fetchBatchProfiles', () => {
     vi.advanceTimersByTime(11 * 60 * 1000) // 11 minutes
     await fetchBatchProfiles([{ puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }])
 
-    expect(mockInvoke).toHaveBeenCalledTimes(2)
+    expect(historyCallCount()).toBe(2)
     vi.useRealTimers()
+  })
+
+  describe('手动备注注入', () => {
+    /** get_match_history 返回一场对局，get_config 按 aiUsePlayerNotes 返回指定值 */
+    function mockLcuWithConfig(useNotesValue: boolean | undefined) {
+      mockInvoke.mockImplementation(async (cmd, args: any) => {
+        if (cmd === 'get_match_history_by_puuid') {
+          return rawHistory(args.puuid, [
+            rawMatch({ puuid: args.puuid, teamPosition: 'JUNGLE', championId: 64, win: true })
+          ])
+        }
+        if (cmd === 'get_config') {
+          return useNotesValue === undefined ? null : { value: useNotesValue }
+        }
+        return null
+      })
+    }
+
+    it('开关默认开（键不存在）时注入 profile.note', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+      mockLcuWithConfig(undefined)
+
+      const result = await fetchBatchProfiles([
+        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 },
+        { puuid: 'p2', teamPosition: 'TOP', championId: 86 }
+      ])
+
+      expect(result.get('p1')?.note).toBe('[拉黑] 演员')
+      // 无备注的玩家不带 note 字段
+      expect(result.get('p2')?.note).toBeUndefined()
+    })
+
+    it('开关显式关闭时不注入', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+      mockLcuWithConfig(false)
+
+      const result = await fetchBatchProfiles([
+        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
+      ])
+
+      expect(result.get('p1')?.note).toBeUndefined()
+    })
+
+    it('note 不写入 LRU 缓存：开关关闭后缓存命中也不带 note', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p1', { note: '演员', label: 'blacklist', gameName: 'A', tagLine: '1' })
+
+      // 第一次：开关开 → 带 note
+      mockLcuWithConfig(undefined)
+      const first = await fetchBatchProfiles([
+        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
+      ])
+      expect(first.get('p1')?.note).toBe('[拉黑] 演员')
+
+      // 第二次：缓存命中（不再拉战绩），但开关已关 → 不得残留 note
+      mockLcuWithConfig(false)
+      const second = await fetchBatchProfiles([
+        { puuid: 'p1', teamPosition: 'JUNGLE', championId: 64 }
+      ])
+      expect(historyCallCount()).toBe(1)
+      expect(second.get('p1')?.note).toBeUndefined()
+    })
   })
 })

--- a/lol-record-analysis-tauri/src/services/ai/shared/noteBrief.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/noteBrief.ts
@@ -1,0 +1,33 @@
+/**
+ * 把玩家手动备注压缩成一行供 AI prompt 使用。
+ *
+ * 返回格式：`[色档中文] 备注文本(≤50字)`；无备注返回 undefined。
+ * 截断到 50 字防 prompt 膨胀（一局最多 10 人都有备注）。
+ *
+ * 注意：调用方负责先检查 `CONFIG_KEYS.aiUsePlayerNotes` 开关，本函数不读配置。
+ *
+ * @module services/ai/shared/noteBrief
+ */
+
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import { getNoteLabelMeta } from '@renderer/types/domain/playerNote'
+
+/** 备注文本注入 prompt 时的最大长度（字符数） */
+const MAX_NOTE_LENGTH = 50
+
+/**
+ * 生成某玩家的备注速览（供 AI prompt 注入）
+ * @param puuid - 玩家唯一标识
+ * @returns `[色档] 文本` / 只标色不写字时 `[色档]` / 无备注时 undefined
+ * @example
+ * ```ts
+ * buildNoteBrief('puuid-1') // => '[拉黑] 上局挂机'
+ * ```
+ */
+export function buildNoteBrief(puuid: string): string | undefined {
+  const note = usePlayerNotesStore().getNote(puuid)
+  if (!note) return undefined
+  const label = `[${getNoteLabelMeta(note.label).text}]`
+  const text = note.note.trim().slice(0, MAX_NOTE_LENGTH)
+  return text ? `${label} ${text}` : label
+}

--- a/lol-record-analysis-tauri/src/services/ai/shared/recentProfile.batch.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/recentProfile.batch.ts
@@ -75,18 +75,30 @@ export async function fetchBatchProfiles(requests: ProfileRequest[]): Promise<Pr
     }
   }
 
-  // 手动备注注入（隐私开关，键不存在视为开）。
-  // 注意：注入发生在返回值组装阶段且写的是浅拷贝——CACHE 里只存"干净" profile，
-  // 这样开关切换 / 备注变更在缓存 TTL 内也能即时生效。
-  const useNotes = (await getConfigByIpc<boolean>(CONFIG_KEYS.aiUsePlayerNotes)) !== false
-  if (useNotes) {
-    for (const [puuid, profile] of result) {
-      if (!profile) continue
-      const brief = buildNoteBrief(puuid)
-      if (brief) result.set(puuid, { ...profile, note: brief })
-    }
-  }
+  return result
+}
 
+/**
+ * 按隐私开关向 profile map 注入使用者手动备注
+ *
+ * 每次调用时实时读取 `aiUsePlayerNotes` 开关（键不存在视为开）——
+ * **结果不可缓存**：任何缓存层（模块级 LRU、per-game 缓存等）都只能存
+ * 本函数注入前的"干净" map，并在每次使用前重新调用本函数，
+ * 否则开关切换 / 备注变更在缓存生效期内不会生效（隐私旁路）。
+ *
+ * @param profileMap - fetchBatchProfiles 返回的干净 profile map（不会被就地修改）
+ * @returns 开关关闭时原样返回入参；开启时返回新 map，
+ *          有备注的 profile 为注入 `note` 的浅拷贝（无备注不加字段）
+ */
+export async function injectNoteBriefs(profileMap: ProfileMap): Promise<ProfileMap> {
+  const useNotes = (await getConfigByIpc<boolean>(CONFIG_KEYS.aiUsePlayerNotes)) !== false
+  if (!useNotes) return profileMap
+
+  const result: ProfileMap = new Map()
+  for (const [puuid, profile] of profileMap) {
+    const brief = profile ? buildNoteBrief(puuid) : undefined
+    result.set(puuid, brief && profile ? { ...profile, note: brief } : profile)
+  }
   return result
 }
 

--- a/lol-record-analysis-tauri/src/services/ai/shared/recentProfile.batch.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/recentProfile.batch.ts
@@ -7,7 +7,10 @@
  */
 
 import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc } from '@renderer/services/ipc'
+import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import { buildRecentProfile, type RecentGameRaw } from './recentProfile'
+import { buildNoteBrief } from './noteBrief'
 import type { RecentPlayerProfile, TeamPosition } from './types'
 
 const CACHE_TTL_MS = 10 * 60 * 1000
@@ -69,6 +72,18 @@ export async function fetchBatchProfiles(requests: ProfileRequest[]): Promise<Pr
     result.set(req.puuid, profile)
     if (profile !== null) {
       CACHE.set(req.puuid, { profile, expireAt: now + CACHE_TTL_MS })
+    }
+  }
+
+  // 手动备注注入（隐私开关，键不存在视为开）。
+  // 注意：注入发生在返回值组装阶段且写的是浅拷贝——CACHE 里只存"干净" profile，
+  // 这样开关切换 / 备注变更在缓存 TTL 内也能即时生效。
+  const useNotes = (await getConfigByIpc<boolean>(CONFIG_KEYS.aiUsePlayerNotes)) !== false
+  if (useNotes) {
+    for (const [puuid, profile] of result) {
+      if (!profile) continue
+      const brief = buildNoteBrief(puuid)
+      if (brief) result.set(puuid, { ...profile, note: brief })
     }
   }
 

--- a/lol-record-analysis-tauri/src/services/ai/shared/types.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/types.ts
@@ -49,4 +49,7 @@ export interface RecentPlayerProfile {
   /** TS 算好的事实，AI 直接消费 */
   isOffRole: boolean
   offRoleSeverity: 'none' | 'mild' | 'severe'
+
+  /** 使用者对该玩家的主观备注（[色档] 文本），可能不存在 */
+  note?: string
 }

--- a/lol-record-analysis-tauri/src/services/configKeys.ts
+++ b/lol-record-analysis-tauri/src/services/configKeys.ts
@@ -18,5 +18,7 @@ export const CONFIG_KEYS = {
   /** 是否已就错误上报询问过用户（首次同意弹窗用，问过即不再弹） */
   errorReportingConsentShown: 'errorReportingConsentShown',
   /** 用户自定义 DashScope API Key（留空用内置打包 key） */
-  dashscopeApiKey: 'dashscopeApiKey'
+  dashscopeApiKey: 'dashscopeApiKey',
+  /** 玩家备注是否随 AI 分析请求发送到云端模型（默认开） */
+  aiUsePlayerNotes: 'aiUsePlayerNotes'
 } as const

--- a/lol-record-analysis-tauri/src/views/settings/General.vue
+++ b/lol-record-analysis-tauri/src/views/settings/General.vue
@@ -31,6 +31,14 @@
           </n-text>
         </n-space>
       </n-form-item>
+      <n-form-item label="AI 分析携带玩家备注">
+        <n-space vertical :size="4">
+          <n-switch v-model:value="aiUseNotes" @update:value="handleAiUseNotesUpdate" />
+          <n-text :depth="3" style="font-size: 12px">
+            开启后你的玩家备注会随分析请求发送到 AI 服务。
+          </n-text>
+        </n-space>
+      </n-form-item>
     </n-form>
   </n-card>
 </template>
@@ -44,6 +52,8 @@ import { useMessage } from 'naive-ui'
 const matchCount = ref(4)
 const errorReporting = ref(false)
 const dashscopeKey = ref('')
+/** AI 分析是否携带玩家备注（默认开：键不存在时视为 true） */
+const aiUseNotes = ref(true)
 const message = useMessage()
 
 onMounted(async () => {
@@ -71,6 +81,14 @@ onMounted(async () => {
   } catch (e) {
     console.error(e)
   }
+  try {
+    const useNotes = await getConfigByIpc<boolean>(CONFIG_KEYS.aiUsePlayerNotes)
+    if (typeof useNotes === 'boolean') {
+      aiUseNotes.value = useNotes
+    }
+  } catch (e) {
+    console.error(e)
+  }
 })
 
 const handleUpdate = async (value: number | null) => {
@@ -87,6 +105,15 @@ const handleReportingUpdate = async (value: boolean) => {
   try {
     await putConfigByIpc(CONFIG_KEYS.errorReportingEnabled, value)
     message.success('设置已保存，重启后生效')
+  } catch (e) {
+    message.error('保存失败')
+  }
+}
+
+const handleAiUseNotesUpdate = async (value: boolean) => {
+  try {
+    await putConfigByIpc(CONFIG_KEYS.aiUsePlayerNotes, value)
+    message.success('设置已保存')
   } catch (e) {
     message.error('保存失败')
   }


### PR DESCRIPTION
## Summary
- 新增设置「AI 分析携带玩家备注」开关（默认开，键不存在视为开）
- noteBrief 工具：备注压缩为「[色档] 文本(≤50字)」单行，三个注入点共用一个 choke point
- 链路 3（对局中 team/player 分析）与链路 1（战绩复盘 stage1 快照）注入备注，prompt 均标注「仅供参考，不作为事实依据」，stage1 明确禁止写入 evidenceMetrics
- 隐私保证：所有缓存层（模块 LRU + 复盘 per-game 缓存）只存干净数据，injectNoteBriefs 每次实时读开关，开↔关切换即时生效；prompt builder 默认 fail-closed；含「先开后关不残留」回归测试

设计：docs/superpowers/specs/2026-07-02-tag-iteration-design.md 子项 5

## Test plan
- [x] vitest 450/450、vue-tsc、prettier/eslint 本地通过（纯前端 PR，Rust 侧无改动）
- [ ] CI 通过
- [ ] 合入后手动：开关关闭后对局中/复盘分析的请求 payload 无备注内容