### PR TITLE
feat(record): 标签与备注融合视图 + 一键固化

### DIFF
--- a/docs/superpowers/specs/2026-07-02-tag-iteration-design.md
+++ b/docs/superpowers/specs/2026-07-02-tag-iteration-design.md
@@ -106,6 +106,11 @@ Recent { count: i32 },
 - **一键固化**：点击系统标签 chip 弹 popover「存为备注」，预填内容 `tag_name + tag_desc`、推荐色档（good → friendly，bad → careful），可编辑后调用现有 `playerNotes.setNote` 保存。已有备注的玩家固化时追加到原文本（换行分隔），不覆盖色档。
 - 不做（本期）：备注管理页显示来源标签、固化时附带战绩快照（评审时已排除「完整双向融合」方案）。
 
+### 实现偏差记录（2026-07-03）
+
+1. **MatchDetailModal 未接入**——经核实该文件从未渲染过系统标签（plan 阶段假设错误），实际替换为 PlayerCard 与 UserRecord 两处；对局详情如需展示系统标签需先为每行玩家拉取 userTag，属新功能另立。
+2. **固化 popover 为一键确认而非 inline 可编辑**——编辑入口统一走 PlayerNoteBadge 面板，避免两处编辑器；固化路径有去重与 100 字上限保护。
+
 ## 测试
 
 - **Rust 单测**（`user_tag_config.rs` 子模块测试，Windows CI 跑，mac 本地只验 fmt）：

--- a/lol-record-analysis-tauri/src/components/common/UnifiedTagRow.vue
+++ b/lol-record-analysis-tauri/src/components/common/UnifiedTagRow.vue
@@ -92,19 +92,33 @@ function truncated(text: string): string {
   return chars.length > NOTE_PREVIEW_LEN ? chars.slice(0, NOTE_PREVIEW_LEN).join('') + '…' : text
 }
 
+/** 备注最大长度（与 PlayerNoteBadge 手动输入框的 :maxlength="100" 对齐） */
+const NOTE_MAX_LEN = 100
+
 /**
  * 把系统标签一键固化为持久备注
  *
  * - 文本行：`tagName`（tagDesc 非空则 `tagName：tagDesc`）
  * - 已有备注：文本追加（`\n` 分隔），色档保留原值
  * - 无备注：色档 = good→friendly / bad→careful
+ * - 去重：已有备注按行包含完全相同的一行时不重复写入
+ * - 上限：拼接后超过 {@link NOTE_MAX_LEN} 字时不写入（不截断，避免静默丢内容）
  *
  * @param tag - 要固化的系统标签
  */
 async function solidifyTag(tag: RankTag): Promise<void> {
   const line = tag.tagDesc ? `${tag.tagName}：${tag.tagDesc}` : tag.tagName
   const existing = note.value
+  // 按行精确匹配去重（不能用 includes 子串匹配：「专精」是「专精：xxx」的子串会误判）
+  if (existing?.note?.split('\n').includes(line)) {
+    message.info('该标签已在备注中')
+    return
+  }
   const nextNote = existing?.note ? `${existing.note}\n${line}` : line
+  if (Array.from(nextNote).length > NOTE_MAX_LEN) {
+    message.warning('备注已达长度上限，请先在备注面板整理')
+    return
+  }
   const label = existing?.label ?? (tag.good ? 'friendly' : 'careful')
   try {
     await store.setNote(props.puuid, {

--- a/lol-record-analysis-tauri/src/components/common/UnifiedTagRow.vue
+++ b/lol-record-analysis-tauri/src/components/common/UnifiedTagRow.vue
@@ -1,0 +1,148 @@
+<template>
+  <div class="unified-tag-row">
+    <!-- 备注 chip：有备注时排最前，hover 显示完整「[色档] 备注全文」 -->
+    <n-popover v-if="note" trigger="hover">
+      <template #trigger>
+        <n-tag data-test="note-chip" size="small" round :type="noteMeta.naiveType">
+          ✎ {{ note.note ? truncated(note.note) : noteMeta.text }}
+        </n-tag>
+      </template>
+      <span>[{{ noteMeta.text }}] {{ note.note || '（未填写文字）' }}</span>
+    </n-popover>
+
+    <!-- 系统标签 chips：hover 看 tagDesc，点击弹「存为备注」确认 -->
+    <n-popover v-for="tag in tags" :key="tag.tagName" trigger="click">
+      <template #trigger>
+        <n-tooltip trigger="hover" :disabled="!tag.tagDesc">
+          <template #trigger>
+            <n-tag
+              size="small"
+              round
+              :type="tag.good ? 'success' : 'error'"
+              :bordered="false"
+              class="unified-tag-chip"
+            >
+              {{ tag.tagName }}
+            </n-tag>
+          </template>
+          <span>{{ tag.tagDesc }}</span>
+        </n-tooltip>
+      </template>
+      <div class="solidify-pop">
+        <div class="solidify-pop-text">把「{{ tag.tagName }}」存为对该玩家的备注？</div>
+        <n-button size="tiny" type="primary" @click="solidifyTag(tag)">存为备注</n-button>
+      </div>
+    </n-popover>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * 统一标签行：系统标签 + 手动备注同排展示，并支持一键固化
+ *
+ * - 备注 chip（有备注时排最前）：色档颜色 + 文本截断，hover 看全文
+ * - 系统标签 chips（good 绿 / bad 红）：hover 看 tagDesc，点击可把该标签
+ *   「固化」为对该玩家的持久备注（追加文本、保留已有色档）
+ *
+ * 数据走 {@link usePlayerNotesStore}，组件不直接碰 IPC。props 保持通用
+ * （puuid + 名字 + 标签数组），不依赖 session 特有结构，供玩家卡 /
+ * 战绩页 / 对局详情三处复用。
+ *
+ * @see issue #67（手动打备注费劲 → 系统先算标签、用户点一下固化）
+ */
+import { computed } from 'vue'
+import { NPopover, NTooltip, NTag, NButton, useMessage } from 'naive-ui'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import { getNoteLabelMeta } from '@renderer/types/domain/playerNote'
+import type { RankTag } from '@renderer/types/domain/analysis'
+
+/**
+ * 组件属性
+ * @property tags - 系统计算出的标签列表（后端 camelCase: tagName/tagDesc/good）
+ * @property puuid - 玩家唯一标识（备注存取的 key）
+ * @property gameName - 游戏名（固化备注时冗余写入，供设置列表展示）
+ * @property tagLine - 标签行
+ */
+interface Props {
+  tags: RankTag[]
+  puuid: string
+  gameName: string
+  tagLine: string
+}
+const props = defineProps<Props>()
+
+const store = usePlayerNotesStore()
+const message = useMessage()
+
+/** 当前玩家已保存的备注（响应式跟随 store） */
+const note = computed(() => store.getNote(props.puuid))
+/** 备注色档元信息（无备注时回退 normal，仅在 note 存在时被渲染使用） */
+const noteMeta = computed(() => getNoteLabelMeta(note.value?.label ?? 'normal'))
+
+/** 备注 chip 文本最多展示的字符数（全文放 hover popover） */
+const NOTE_PREVIEW_LEN = 8
+
+/**
+ * 截断备注文本用于 chip 展示
+ * @param text - 备注全文
+ * @returns 超过 {@link NOTE_PREVIEW_LEN} 字时截断并加省略号
+ */
+function truncated(text: string): string {
+  const chars = Array.from(text)
+  return chars.length > NOTE_PREVIEW_LEN ? chars.slice(0, NOTE_PREVIEW_LEN).join('') + '…' : text
+}
+
+/**
+ * 把系统标签一键固化为持久备注
+ *
+ * - 文本行：`tagName`（tagDesc 非空则 `tagName：tagDesc`）
+ * - 已有备注：文本追加（`\n` 分隔），色档保留原值
+ * - 无备注：色档 = good→friendly / bad→careful
+ *
+ * @param tag - 要固化的系统标签
+ */
+async function solidifyTag(tag: RankTag): Promise<void> {
+  const line = tag.tagDesc ? `${tag.tagName}：${tag.tagDesc}` : tag.tagName
+  const existing = note.value
+  const nextNote = existing?.note ? `${existing.note}\n${line}` : line
+  const label = existing?.label ?? (tag.good ? 'friendly' : 'careful')
+  try {
+    await store.setNote(props.puuid, {
+      note: nextNote,
+      label,
+      gameName: props.gameName,
+      tagLine: props.tagLine
+    })
+    message.success('已存为备注')
+  } catch {
+    message.error('保存失败')
+  }
+}
+
+defineExpose({ solidifyTag })
+</script>
+
+<style scoped>
+.unified-tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.unified-tag-chip {
+  cursor: pointer;
+}
+
+.solidify-pop {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-6, 6px);
+}
+
+.solidify-pop-text {
+  font-size: var(--font-size-xs, 12px);
+  color: var(--text-secondary);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/common/__tests__/UnifiedTagRow.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/UnifiedTagRow.spec.ts
@@ -6,6 +6,8 @@
  * - 有备注时渲染备注 chip（data-test="note-chip"）
  * - solidifyTag 一键固化：good→friendly / bad→careful、文本追加、色档保留
  * - tagDesc 为空时固化文本不带「：」
+ * - 重复固化同一标签按行精确去重，不重复写入
+ * - 拼接后超过 100 字上限时不写入、原备注保持不变
  *
  * @module components/common/__tests__/UnifiedTagRow
  */
@@ -137,5 +139,39 @@ describe('UnifiedTagRow', () => {
     await w.vm.solidifyTag(tags[1])
 
     expect(store.getNote('puuid-1')?.note).toBe('专精')
+  })
+
+  it('同一标签固化两次时第二次不重复写入（按行精确去重）', async () => {
+    const store = usePlayerNotesStore()
+    const w = mountRow()
+
+    await w.vm.solidifyTag(tags[0])
+    await w.vm.solidifyTag(tags[0])
+
+    const saved = store.getNote('puuid-1')
+    expect(saved?.note).toBe('炸鱼嫌疑：仅供参考')
+    expect(saved?.note?.split('\n')).toHaveLength(1)
+    expect(messageMock.info).toHaveBeenCalledWith('该标签已在备注中')
+  })
+
+  it('拼接后超过 100 字时不写入且原备注不变', async () => {
+    const store = usePlayerNotesStore()
+    // 95 字备注：追加任意标签行（换行 + ≥5 字）必超 100 字上限
+    const longNote = '备'.repeat(95)
+    await store.setNote('puuid-1', {
+      note: longNote,
+      label: 'friendly',
+      gameName: 'Hide on bush',
+      tagLine: 'KR1'
+    })
+    const w = mountRow()
+
+    await w.vm.solidifyTag(tags[0])
+
+    const saved = store.getNote('puuid-1')
+    expect(saved?.note).toBe(longNote)
+    expect(saved?.label).toBe('friendly')
+    expect(messageMock.warning).toHaveBeenCalledWith('备注已达长度上限，请先在备注面板整理')
+    expect(messageMock.success).not.toHaveBeenCalled()
   })
 })

--- a/lol-record-analysis-tauri/src/components/common/__tests__/UnifiedTagRow.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/UnifiedTagRow.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * UnifiedTagRow 组件单元测试
+ *
+ * 验证：
+ * - 系统标签 chips 渲染（good/bad 均展示 tagName）
+ * - 有备注时渲染备注 chip（data-test="note-chip"）
+ * - solidifyTag 一键固化：good→friendly / bad→careful、文本追加、色档保留
+ * - tagDesc 为空时固化文本不带「：」
+ *
+ * @module components/common/__tests__/UnifiedTagRow
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+// Mock config IPC，避免触达 Tauri runtime（照抄 pinia/__tests__/playerNotes.spec.ts）
+vi.mock('@renderer/services/ipc', () => ({
+  getConfigByIpc: vi.fn(),
+  putConfigByIpc: vi.fn(() => Promise.resolve())
+}))
+
+// Mock Tauri 事件（跨窗口同步用），jsdom 下无 Tauri runtime
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(() => Promise.resolve()),
+  listen: vi.fn(() => Promise.resolve(() => {}))
+}))
+
+// jsdom 下没有 n-message-provider，替换 useMessage 为共享 mock（其余 naive-ui 导出保持原样）
+const messageMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn()
+}))
+vi.mock('naive-ui', async importOriginal => {
+  const actual = await importOriginal<typeof import('naive-ui')>()
+  return { ...actual, useMessage: () => messageMock }
+})
+
+import UnifiedTagRow from '../UnifiedTagRow.vue'
+import { usePlayerNotesStore } from '../../../pinia/playerNotes'
+import type { RankTag } from '@renderer/types/domain/analysis'
+
+/**
+ * Naive-UI 的 popover/tooltip 在 jsdom 中经 teleport 渲染，slot 内容会脱离
+ * wrapper。按组件名注册 stub 让内容内联渲染（同 AISuggestModal.spec.ts 方案）。
+ */
+const stubs = {
+  Popover: { template: '<div><slot name="trigger" /><slot /></div>' },
+  Tooltip: { template: '<div><slot name="trigger" /><slot /></div>' },
+  Tag: { template: '<span><slot /></span>' },
+  Button: { template: '<button @click="$emit(\'click\')"><slot /></button>' }
+}
+
+const tags: RankTag[] = [
+  { tagName: '炸鱼嫌疑', tagDesc: '仅供参考', good: false },
+  { tagName: '专精', tagDesc: '', good: true }
+]
+
+/** 便捷挂载：默认无备注玩家 */
+function mountRow(props: Partial<InstanceType<typeof UnifiedTagRow>['$props']> = {}) {
+  return mount(UnifiedTagRow, {
+    props: {
+      tags,
+      puuid: 'puuid-1',
+      gameName: 'Hide on bush',
+      tagLine: 'KR1',
+      ...props
+    },
+    global: { stubs }
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('UnifiedTagRow', () => {
+  it('渲染系统标签 chips（两个 tagName 都在文本中）', () => {
+    const w = mountRow()
+
+    expect(w.text()).toContain('炸鱼嫌疑')
+    expect(w.text()).toContain('专精')
+    // 无备注时不渲染备注 chip
+    expect(w.find('[data-test="note-chip"]').exists()).toBe(false)
+  })
+
+  it('有备注时渲染 note-chip', async () => {
+    const store = usePlayerNotesStore()
+    await store.setNote('puuid-1', {
+      note: '别抢我蓝',
+      label: 'friendly',
+      gameName: 'Hide on bush',
+      tagLine: 'KR1'
+    })
+
+    const w = mountRow()
+
+    const chip = w.find('[data-test="note-chip"]')
+    expect(chip.exists()).toBe(true)
+    expect(chip.text()).toContain('别抢我蓝')
+  })
+
+  it('solidifyTag 固化：good→friendly、note 含 tagName；再固化第二个色档保持、note 含两行', async () => {
+    const store = usePlayerNotesStore()
+    const w = mountRow()
+
+    // 固化 good 标签（专精）：无备注 → 色档 friendly
+    await w.vm.solidifyTag(tags[1])
+    expect(store.getNote('puuid-1')?.label).toBe('friendly')
+    expect(store.getNote('puuid-1')?.note).toContain('专精')
+    expect(messageMock.success).toHaveBeenCalled()
+
+    // 再固化 bad 标签（炸鱼嫌疑）：文本追加两行，色档保留原值 friendly
+    await w.vm.solidifyTag(tags[0])
+    const saved = store.getNote('puuid-1')
+    expect(saved?.label).toBe('friendly')
+    expect(saved?.note).toBe('专精\n炸鱼嫌疑：仅供参考')
+  })
+
+  it('bad 标签固化到无备注玩家时色档为 careful', async () => {
+    const store = usePlayerNotesStore()
+    const w = mountRow()
+
+    await w.vm.solidifyTag(tags[0])
+
+    expect(store.getNote('puuid-1')?.label).toBe('careful')
+    expect(store.getNote('puuid-1')?.note).toBe('炸鱼嫌疑：仅供参考')
+  })
+
+  it('tagDesc 为空时固化文本不带「：」', async () => {
+    const store = usePlayerNotesStore()
+    const w = mountRow()
+
+    await w.vm.solidifyTag(tags[1])
+
+    expect(store.getNote('puuid-1')?.note).toBe('专精')
+  })
+})

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -145,18 +145,12 @@
                   <MettingPlayersCard :meet-games="sessionSummoner.meetGames"></MettingPlayersCard>
                 </n-popover>
               </n-tag>
-              <n-tooltip
-                v-for="tag in sessionSummoner?.userTag.tag"
-                :key="tag.tagName"
-                trigger="hover"
-              >
-                <template #trigger>
-                  <n-tag size="small" :type="tag.good ? 'success' : 'error'" :bordered="false">
-                    {{ tag.tagName }}
-                  </n-tag>
-                </template>
-                <span>{{ tag.tagDesc }}</span>
-              </n-tooltip>
+              <UnifiedTagRow
+                :tags="sessionSummoner?.userTag?.tag || []"
+                :puuid="sessionSummoner.summoner.puuid"
+                :game-name="sessionSummoner.summoner.gameName"
+                :tag-line="sessionSummoner.summoner.tagLine"
+              />
             </div>
           </n-flex>
         </div>
@@ -175,18 +169,7 @@
 
 <script setup lang="ts">
 import { computed, toRef } from 'vue'
-import {
-  NCard,
-  NFlex,
-  NAvatar,
-  NImage,
-  NButton,
-  NIcon,
-  NEllipsis,
-  NPopover,
-  NTag,
-  NTooltip
-} from 'naive-ui'
+import { NCard, NFlex, NAvatar, NImage, NButton, NIcon, NEllipsis, NPopover, NTag } from 'naive-ui'
 import { CopyOutline, HelpCircleOutline } from '@vicons/ionicons5'
 import MettingPlayersCard from './MettingPlayersCard.vue'
 import { useCopy } from '@renderer/composables/useCopy'
@@ -201,6 +184,7 @@ import PlayerHistoryGrid from './PlayerHistoryGrid.vue'
 import PlayerStatsCard from './PlayerStatsCard.vue'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
+import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
 
 interface Props {
   sessionSummoner: SessionSummoner

--- a/lol-record-analysis-tauri/src/components/record/UserRecord.vue
+++ b/lol-record-analysis-tauri/src/components/record/UserRecord.vue
@@ -59,17 +59,15 @@
         </n-flex>
       </n-flex>
 
-      <!-- Tags -->
-      <n-flex v-if="tags.length > 0" class="user-record-tags" :size="6" wrap>
-        <n-tooltip trigger="hover" v-for="tag in tags" :key="tag.tagName">
-          <template #trigger>
-            <n-tag size="small" :type="tag.good ? 'primary' : 'error'" :bordered="false" round>
-              {{ tag.tagName }}
-            </n-tag>
-          </template>
-          <span>{{ tag.tagDesc }}</span>
-        </n-tooltip>
-      </n-flex>
+      <!-- Tags：系统标签 + 备注 chip 统一行（备注为空且无标签时整行隐藏，避免空 margin） -->
+      <UnifiedTagRow
+        v-if="tags.length > 0 || hasNote"
+        class="user-record-tags"
+        :tags="tags"
+        :puuid="summoner.puuid"
+        :game-name="summoner.gameName"
+        :tag-line="summoner.tagLine"
+      />
     </n-card>
 
     <!-- Friends & Rivals -->
@@ -124,7 +122,6 @@ import {
   NEllipsis,
   NText,
   NTag,
-  NTooltip,
   NPopover
 } from 'naive-ui'
 import { useRoute } from 'vue-router'
@@ -150,6 +147,8 @@ import RelationshipPanel from './RelationshipPanel.vue'
 import RankCard from './RankCard.vue'
 import RecentStatsTable from './RecentStatsTable.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
+import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
 
 const settingsStore = useSettingsStore()
 const isDark = computed(
@@ -228,6 +227,10 @@ const updateModel = (value: string | number, option: any) => {
   getTags(name, selectMode)
   mode.value = option.label as string
 }
+
+const notesStore = usePlayerNotesStore()
+/** 当前玩家是否已有手动备注（决定标签行在无系统标签时是否仍展示备注 chip） */
+const hasNote = computed(() => !!summoner.value.puuid && !!notesStore.getNote(summoner.value.puuid))
 
 const tags = ref<RankTag[]>([])
 const getTags = async (name: string, mode: number) => {


### PR DESCRIPTION
## Summary
- 新组件 UnifiedTagRow：系统标签与手动备注 chip 混排一行（备注带 ✎ 图标排最前），good→success / bad→error，hover 显示 tagDesc
- 一键固化（issue #67 痛点延伸）：点系统标签「存为备注」——已有备注则换行追加且保留色档，无备注按 good→friendly / bad→careful 建档；带按行去重与 100 字上限（对齐 PlayerNoteBadge 约束）
- 接入 PlayerCard（对局中）与 UserRecord（战绩页，无标签但有备注时也展示）；MatchDetailModal 经核实从未渲染过系统标签，不适用本次替换（spec 已补偏差记录）
- UserRecord 的 good 标签配色由 primary 统一为 success（有意收敛，与 PlayerCard 一致）

设计：docs/superpowers/specs/2026-07-02-tag-iteration-design.md 子项 6

## Test plan
- [x] UnifiedTagRow 组件测试 7 用例（固化语义、去重、长度上限均断言 store 状态）；vitest 450/450、vue-tsc、prettier/eslint 本地通过（纯前端 PR）
- [ ] CI 通过
- [ ] 合入后手动：玩家卡点标签固化 → 备注 chip 出现、PlayerNoteBadge 圆点变色；战绩页删备注后空行收起