### PR TITLE
feat(updater): GitCode 更新端点设为首位

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -50,6 +50,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDM2Mzg1MkEyODFGMTdBNTAKUldSUWV2R0JvbEk0TnF1VGlJT1lWUjhTRFRZWjRzTjcxWVNrTjRsbGl4N3g1M0xqQ25UY21DN1MK",
       "endpoints": [
+        "https://gitcode.com/wnzzer/rank-analysis/releases/download/latest/latest.json",
         "https://api.upgrade.toolsetlink.com/v1/tauri/upgrade?tauriKey=rX76p0GShXom2yNnlsSDYw&versionName={{current_version}}&target={{target}}&arch={{arch}}",
         "https://github.com/wnzzer/rank-analysis/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
## Summary
- updater endpoints 新增 GitCode 端点并置于首位：`https://gitcode.com/wnzzer/rank-analysis/releases/download/latest/latest.json`；toolsetlink 与 GitHub 顺次后移作为兜底
- 依据既有发版流程：release.yml 的 gitcode-release job 会把 latest.json 的下载 URL 改写为 gitcode.com host 后上传，manifest 自洽（检查与下载全程走 GitCode/华为云 CDN）

## 裸连实测（--noproxy 直连）
- `releases/download/latest/latest.json` 别名可用：HTTP 200，重定向 file-cdn.gitcode.com 签名 URL，匿名访问，内容为最新版 v1.8.4 且含 signature 字段
- 安装包完整下载：5,585,422 bytes @ ~1.9MB/s，SHA256 与 GitHub 原始资产逐字节一致（e6608a15…38fa）
- 旧命名空间 URL（v1.8.4 latest.json 内仍是 faker1234546，改名前同步的）仍可 302 正常下载；OWNER 已在 9f2192d 修正，下次发版起为 wnzzer

## Test plan
- [x] JSON 语法校验
- [x] 裸连下载链路实测（见上）
- [ ] CI
- [ ] 下次发版后确认新 latest.json 的 URL 为 wnzzer 命名空间