### PR TITLE
feat(record): 对局详情页精品化 + WeGame式MVP评分

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
@@ -2,11 +2,12 @@
 //!
 //! 对应 `lol-match-history`：按 PUUID/「me」分页获取对局列表；支持详情增强与中文信息。
 
+use std::collections::HashMap;
 use std::{sync::LazyLock, time::Duration};
 
 use crate::{
     constant,
-    lcu::api::model::{Participant, ParticipantIdentity},
+    lcu::api::model::{Participant, ParticipantIdentity, Stats},
 };
 use moka::future::Cache;
 use serde::{Deserialize, Serialize};
@@ -25,6 +26,44 @@ pub(crate) fn resolve_queue_name_cn(queue_id: i32, game_mode: &str) -> String {
         return "斗魂竞技场".to_string();
     }
     "未知".to_string()
+}
+
+/// WeGame 式综合评分（0~10）：KDA、输出、参团率、承伤、经济、补刀、推塔 七维加权。
+///
+/// 各维归一到 0..1（KDA 用饱和函数 `kda/(kda+3)`，其余除以全场最大值），加权和乘 10。
+/// 权重：KDA 26% / 输出 22% / 参团 18% / 承伤 10% / 经济 10% / 补刀 8% / 推塔 6%。
+///
+/// ⚠️ 与前端 `useMatchDetailPlayers.ts::computeMatchScore` 同式——两端必须同步修改。
+pub(crate) fn wegame_score(
+    stats: &Stats,
+    team_kills: i32,
+    (max_damage, max_taken, max_gold, max_cs, max_turret): (i32, i32, i32, i32, i32),
+) -> f64 {
+    let kda = (stats.kills as f64 + stats.assists as f64) / f64::from(stats.deaths.max(1));
+    let n_kda = kda / (kda + 3.0);
+    let kp = if team_kills > 0 {
+        (f64::from(stats.kills + stats.assists) / f64::from(team_kills)).min(1.0)
+    } else {
+        0.0
+    };
+    let norm = |v: i32, m: i32| {
+        if m > 0 {
+            f64::from(v) / f64::from(m)
+        } else {
+            0.0
+        }
+    };
+    10.0 * (0.26 * n_kda
+        + 0.22 * norm(stats.total_damage_dealt_to_champions, max_damage)
+        + 0.18 * kp
+        + 0.10 * norm(stats.total_damage_taken, max_taken)
+        + 0.10 * norm(stats.gold_earned, max_gold)
+        + 0.08
+            * norm(
+                stats.total_minions_killed + stats.neutral_minions_killed,
+                max_cs,
+            )
+        + 0.06 * norm(stats.damage_dealt_to_turrets, max_turret))
 }
 
 /// 对局记录响应：平台 ID、索引范围、对局列表。
@@ -273,41 +312,169 @@ impl MatchHistory {
                 ((my_damage_taken / total_damage_taken as f64) * 100.0) as i32;
             my_stats.heal_rate = ((my_heal / total_heal as f64) * 100.0) as i32;
 
-            // MVP/SVP 计算：同队 KDA 最高者标记
-            let my_participant_id = game.participants[0].participant_id;
-            let my_kda = (game.participants[0].stats.kills as f64
-                + game.participants[0].stats.assists as f64)
-                / (game.participants[0].stats.deaths.max(1) as f64);
+            // MVP/SVP：WeGame 式综合评分——胜方最高分 MVP、败方最高分 SVP（此前为纯 KDA）。
+            // 评分函数 wegame_score 与前端 useMatchDetailPlayers.ts 同式，两端需同步修改。
+            let detail = &game.game_detail.participants;
 
-            let mut best_kda = my_kda;
-            let mut best_is_me = true;
-
-            for p in &game.game_detail.participants {
-                let same_team = if is_cherry && my_subteam > 0 {
-                    p.stats.player_subteam_id == my_subteam
+            // 参团率分母：所属队伍总击杀（CHERRY 按 subteam 分组）；同时收集全场各维最大值
+            let mut group_kills: HashMap<i32, i32> = HashMap::new();
+            let mut max_v = (0i32, 0i32, 0i32, 0i32, 0i32); // damage/taken/gold/cs/turret
+            for p in detail {
+                let key = if is_cherry && p.stats.player_subteam_id > 0 {
+                    p.stats.player_subteam_id
                 } else {
-                    p.team_id == team_id
+                    p.team_id
                 };
-                if same_team && p.participant_id != my_participant_id {
-                    let kda = (p.stats.kills as f64 + p.stats.assists as f64)
-                        / (p.stats.deaths.max(1) as f64);
-                    if kda > best_kda {
-                        best_kda = kda;
-                        best_is_me = false;
-                    }
-                }
+                *group_kills.entry(key).or_insert(0) += p.stats.kills;
+                max_v.0 = max_v.0.max(p.stats.total_damage_dealt_to_champions);
+                max_v.1 = max_v.1.max(p.stats.total_damage_taken);
+                max_v.2 = max_v.2.max(p.stats.gold_earned);
+                max_v.3 = max_v
+                    .3
+                    .max(p.stats.total_minions_killed + p.stats.neutral_minions_killed);
+                max_v.4 = max_v.4.max(p.stats.damage_dealt_to_turrets);
             }
-
-            if best_is_me {
-                game.mvp = if game.participants[0].stats.win {
-                    "MVP".to_string()
+            let score_of = |p: &Participant| {
+                let key = if is_cherry && p.stats.player_subteam_id > 0 {
+                    p.stats.player_subteam_id
                 } else {
-                    "SVP".to_string()
+                    p.team_id
                 };
+                wegame_score(&p.stats, *group_kills.get(&key).unwrap_or(&0), max_v)
+            };
+
+            let my_participant_id = game.participants[0].participant_id;
+            if let Some(me) = detail
+                .iter()
+                .find(|p| p.participant_id == my_participant_id)
+            {
+                let my_score = score_of(me);
+                // 与我同胜负侧的最高分（并列时我也算最高，与旧逻辑"平分我胜出"一致）
+                let best = detail
+                    .iter()
+                    .filter(|p| p.stats.win == me.stats.win)
+                    .map(&score_of)
+                    .fold(f64::MIN, f64::max);
+                if my_score >= best - 1e-9 {
+                    game.mvp = if me.stats.win {
+                        "MVP".to_string()
+                    } else {
+                        "SVP".to_string()
+                    };
+                }
             }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod mvp_score_tests {
+    use super::*;
+
+    /// 测试造数：kda=(击杀,死亡,助攻)，econ=(输出,承伤,金币,补刀,推塔)
+    fn stats(kda: (i32, i32, i32), econ: (i32, i32, i32, i32, i32), win: bool) -> Stats {
+        Stats {
+            kills: kda.0,
+            deaths: kda.1,
+            assists: kda.2,
+            total_damage_dealt_to_champions: econ.0,
+            total_damage_taken: econ.1,
+            gold_earned: econ.2,
+            total_minions_killed: econ.3,
+            damage_dealt_to_turrets: econ.4,
+            win,
+            ..Default::default()
+        }
+    }
+
+    fn part(id: i32, team: i32, s: Stats) -> Participant {
+        Participant {
+            participant_id: id,
+            team_id: team,
+            champion_id: 1,
+            spell1_id: 0,
+            spell2_id: 0,
+            stats: s,
+        }
+    }
+
+    /// 场景：无死亡低伤"蹭分型"(10/0/8, KDA 18) vs 真核 carry(9/2/15, 全场最高
+    /// 输出/承伤/经济/补刀/推塔)。旧的纯 KDA 公式会选前者——新综合评分应选 carry。
+    fn farmer() -> Participant {
+        part(
+            1,
+            100,
+            stats((10, 0, 8), (8_000, 5_000, 9_000, 100, 0), true),
+        )
+    }
+    fn carry() -> Participant {
+        part(
+            2,
+            100,
+            stats((9, 2, 15), (40_000, 30_000, 15_000, 200, 5_000), true),
+        )
+    }
+    fn loser() -> Participant {
+        part(
+            6,
+            200,
+            stats((3, 8, 4), (12_000, 20_000, 8_000, 120, 500), false),
+        )
+    }
+
+    fn game_with_me(me: Participant) -> MatchHistory {
+        let mut game = Game {
+            game_mode: "CLASSIC".to_string(),
+            participants: vec![me],
+            ..Default::default()
+        };
+        game.game_detail.participants = vec![farmer(), carry(), loser()];
+        MatchHistory {
+            games: GamesWrapper { games: vec![game] },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn composite_score_prefers_carry_over_no_death_farmer() {
+        let team_kills = 10 + 9;
+        let max_v = (40_000, 30_000, 15_000, 200, 5_000);
+        let s_farmer = wegame_score(&farmer().stats, team_kills, max_v);
+        let s_carry = wegame_score(&carry().stats, team_kills, max_v);
+        assert!(
+            s_carry > s_farmer,
+            "carry {s_carry:.2} 应高于蹭分型 {s_farmer:.2}"
+        );
+    }
+
+    #[test]
+    fn calculate_marks_composite_best_as_mvp() {
+        let mut mh = game_with_me(carry());
+        mh.calculate().unwrap();
+        assert_eq!(
+            mh.games.games[0].mvp, "MVP",
+            "综合评分最高的 carry 应为 MVP"
+        );
+    }
+
+    #[test]
+    fn calculate_denies_mvp_to_kda_farmer() {
+        let mut mh = game_with_me(farmer());
+        mh.calculate().unwrap();
+        // 旧纯 KDA 公式下 farmer(KDA 18)会拿 MVP；新公式下它不是综合最高分
+        assert_eq!(mh.games.games[0].mvp, "", "纯蹭 KDA 不应再拿 MVP");
+    }
+
+    #[test]
+    fn calculate_marks_loser_best_as_svp() {
+        let mut mh = game_with_me(loser());
+        mh.calculate().unwrap();
+        assert_eq!(
+            mh.games.games[0].mvp, "SVP",
+            "败方唯一玩家即败方最高分，应为 SVP"
+        );
     }
 }
 

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -161,6 +161,21 @@
                       />
                       <div class="match-detail-player-text">
                         <div class="match-detail-player-text-row">
+                          <n-tooltip v-if="player.mvpTag" trigger="hover" placement="top">
+                            <template #trigger>
+                              <span
+                                class="match-detail-mvp-chip"
+                                :class="
+                                  player.mvpTag === 'MVP'
+                                    ? 'match-detail-mvp-chip--mvp'
+                                    : 'match-detail-mvp-chip--svp'
+                                "
+                                >{{ player.mvpTag }}</span
+                              >
+                            </template>
+                            综合评分 {{ player.score.toFixed(1) }} ·
+                            KDA/输出/参团/承伤/经济/补刀/推塔 七维加权
+                          </n-tooltip>
                           <span class="match-detail-player-display">{{ player.displayName }}</span>
                           <n-button
                             text
@@ -1172,6 +1187,30 @@ watch(
   gap: var(--space-4);
 }
 
+/* MVP/SVP 章：金/银双档，WeGame 式综合评分的胜败双方最高分 */
+.match-detail-mvp-chip {
+  --chip-color: #f2bf63;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  font-size: 10px;
+  font-weight: 800;
+  font-style: italic;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  color: var(--chip-color);
+  background: color-mix(in srgb, var(--chip-color) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--chip-color) 45%, transparent);
+  flex-shrink: 0;
+}
+
+.match-detail-mvp-chip--mvp {
+  --chip-color: #f2bf63;
+}
+
+.match-detail-mvp-chip--svp {
+  --chip-color: #aab8c8;
+}
+
 .match-detail-player-text-row :deep(.n-tag) {
   color: var(--text-primary);
 }
@@ -1192,6 +1231,10 @@ watch(
 .match-detail-badge-kills {
   color: #f2bf63;
   background: rgba(242, 191, 99, 0.14);
+}
+.match-detail-badge-damage {
+  color: #e5a732;
+  background: rgba(229, 167, 50, 0.16);
 }
 .match-detail-badge-assists {
   color: #63d8b4;

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -3,29 +3,41 @@
     <div class="match-detail-modal">
       <div class="match-detail-shell">
         <!-- Header -->
-        <div class="match-detail-header">
-          <div>
+        <div
+          class="match-detail-header"
+          :class="mySummary.win ? 'match-detail-header--win' : 'match-detail-header--loss'"
+        >
+          <!-- 氛围底图：本局英雄放大重模糊，向右渐隐——赛后战报的环境感 -->
+          <img
+            class="match-detail-header-ambient"
+            :src="assetPrefix + '/champion/' + mySummary.championId"
+            alt=""
+            aria-hidden="true"
+          />
+          <div class="match-detail-header-main">
             <div class="match-detail-title-row">
-              <n-tag size="small" :bordered="false" :type="mySummary.win ? 'success' : 'error'">
+              <span
+                class="match-detail-result-pill"
+                :class="
+                  mySummary.win ? 'match-detail-result-pill--win' : 'match-detail-result-pill--loss'
+                "
+              >
                 {{ mySummary.win ? '胜利' : '失败' }}
-              </n-tag>
+              </span>
               <span class="match-detail-queue">{{ game.queueName }}</span>
               <span class="match-detail-meta">{{ formattedDate }} · {{ durationLabel }}</span>
             </div>
             <div class="match-detail-player-row">
               <LazyImg
                 class="match-detail-hero"
+                :class="mySummary.win ? 'match-detail-hero--win' : 'match-detail-hero--loss'"
                 :src="assetPrefix + '/champion/' + mySummary.championId"
                 alt="champion"
               />
               <div class="match-detail-player-copy">
                 <div class="match-detail-player-name">{{ mySummary.displayName }}</div>
                 <div class="match-detail-player-kda">
-                  <span
-                    class="font-number"
-                    :style="{ color: killsColor(mySummary.stats.kills, isDark) }"
-                    >{{ mySummary.stats.kills }}</span
-                  >
+                  <span class="font-number">{{ mySummary.stats.kills }}</span>
                   <span>/</span>
                   <span
                     class="font-number"
@@ -33,11 +45,7 @@
                     >{{ mySummary.stats.deaths }}</span
                   >
                   <span>/</span>
-                  <span
-                    class="font-number"
-                    :style="{ color: assistsColor(mySummary.stats.assists, isDark) }"
-                    >{{ mySummary.stats.assists }}</span
-                  >
+                  <span class="font-number">{{ mySummary.stats.assists }}</span>
                   <span
                     class="font-number match-detail-kda-ratio"
                     :style="{ color: kdaColor(kdaRatio(mySummary.stats), isDark) }"
@@ -54,45 +62,47 @@
           </div>
 
           <div class="match-detail-summary-side">
-            <div class="match-detail-summary-grid">
-              <div class="match-detail-summary-card">
-                <div class="match-detail-summary-label">输出</div>
-                <div class="match-detail-summary-value font-number">
+            <div class="match-detail-stats-strip">
+              <div class="match-detail-stat">
+                <span class="match-detail-stat-label">输出</span>
+                <span class="match-detail-stat-value font-number">
                   {{ formatCompactNumber(mySummary.stats.totalDamageDealtToChampions) }}
-                </div>
+                </span>
               </div>
-              <div class="match-detail-summary-card">
-                <div class="match-detail-summary-label">承伤</div>
-                <div class="match-detail-summary-value font-number">
+              <span class="match-detail-stat-divider" />
+              <div class="match-detail-stat">
+                <span class="match-detail-stat-label">承伤</span>
+                <span class="match-detail-stat-value font-number">
                   {{ formatCompactNumber(mySummary.stats.totalDamageTaken) }}
-                </div>
+                </span>
               </div>
-              <div class="match-detail-summary-card">
-                <div class="match-detail-summary-label">推塔</div>
-                <div class="match-detail-summary-value font-number">
+              <span class="match-detail-stat-divider" />
+              <div class="match-detail-stat">
+                <span class="match-detail-stat-label">推塔</span>
+                <span class="match-detail-stat-value font-number">
                   {{ formatCompactNumber(mySummary.stats.damageDealtToTurrets) }}
-                </div>
+                </span>
               </div>
             </div>
 
-            <div class="match-detail-ai-toolbar">
-              <div class="match-detail-ai-copy">
-                <span class="match-detail-ai-title">AI 复盘</span>
-                <span class="match-detail-ai-subtitle">整局归因 + 单人责任分析</span>
-              </div>
-              <n-button
-                size="small"
-                secondary
-                type="info"
-                :loading="ai.aiLoading.value"
-                @click="onOverview"
-              >
-                <template #icon>
-                  <n-icon><SparklesOutline /></n-icon>
-                </template>
-                整局分析
-              </n-button>
-            </div>
+            <n-tooltip trigger="hover" placement="bottom-end">
+              <template #trigger>
+                <n-button
+                  size="small"
+                  secondary
+                  type="info"
+                  class="match-detail-ai-button"
+                  :loading="ai.aiLoading.value"
+                  @click="onOverview"
+                >
+                  <template #icon>
+                    <n-icon><SparklesOutline /></n-icon>
+                  </template>
+                  AI 整局复盘
+                </n-button>
+              </template>
+              整局归因 + 单人责任分析
+            </n-tooltip>
           </div>
         </div>
 
@@ -111,266 +121,301 @@
           >
             <div class="match-detail-team-header" :class="team.headerClass">
               <div class="match-detail-team-title-wrap">
+                <span class="match-detail-team-accent" />
                 <span class="match-detail-team-title">{{ team.title }}</span>
-                <span class="match-detail-team-subtitle">
+                <span class="match-detail-team-subtitle font-number">
                   {{ team.kills }}/{{ team.deaths }}/{{ team.assists }} ·
                   {{ formatCompactNumber(team.gold) }} 金币
                 </span>
               </div>
-              <div class="match-detail-team-subtitle">
+              <div class="match-detail-team-subtitle font-number">
                 输出 {{ formatCompactNumber(team.damage) }} · 承伤
                 {{ formatCompactNumber(team.taken) }}
               </div>
             </div>
 
-            <div class="match-detail-column-header">
-              <span>玩家</span>
-              <span>装备 / 技能 / {{ usesAugments ? '海克斯' : '符文' }}</span>
-              <span class="match-detail-header-center">KDA</span>
-              <span class="match-detail-header-right">金钱</span>
-              <span class="match-detail-header-right">补兵</span>
-              <span class="match-detail-header-right">推塔</span>
-              <span></span>
-            </div>
+            <div class="match-detail-team-card">
+              <div class="match-detail-column-header">
+                <span>玩家</span>
+                <span>技能 / {{ usesAugments ? '海克斯' : '符文' }} / 装备</span>
+                <span class="match-detail-header-right">KDA</span>
+                <span class="match-detail-header-right">金钱</span>
+                <span class="match-detail-header-right">补兵</span>
+                <span class="match-detail-header-right">推塔</span>
+                <span class="match-detail-bars-header">输出 / 承伤 / 治疗</span>
+              </div>
 
-            <div class="match-detail-team-rows">
-              <div
-                v-for="player in team.players"
-                :key="player.participantId"
-                class="match-detail-row"
-                :class="{ 'match-detail-row-me': player.isMe }"
-              >
-                <div class="match-detail-player-cell">
-                  <div class="match-detail-player-main">
-                    <LazyImg
-                      class="match-detail-player-avatar"
-                      :src="assetPrefix + '/champion/' + player.championId"
-                      alt="champion"
-                    />
-                    <div class="match-detail-player-text">
-                      <div class="match-detail-player-text-row">
-                        <span class="match-detail-player-display">{{ player.displayName }}</span>
-                        <n-button
-                          text
-                          size="tiny"
-                          class="match-detail-player-copy"
-                          @click.stop="copy(player.displayName)"
-                        >
-                          <template #icon>
-                            <n-icon><CopyOutline /></n-icon>
-                          </template>
-                        </n-button>
-                        <span v-if="player.puuid" @click.stop>
-                          <PlayerNoteBadge
-                            :puuid="player.puuid"
-                            :game-name="player.gameName"
-                            :tag-line="player.tagLine"
-                            :encounter="buildEncounter(player)"
-                            size="normal"
-                          />
-                        </span>
-                        <n-tag v-if="player.isMe" size="small" :bordered="false" type="info"
-                          >我</n-tag
-                        >
-                        <n-button
-                          quaternary
-                          size="tiny"
-                          class="match-detail-player-ai-trigger"
-                          :loading="
-                            ai.aiLoading.value &&
-                            ai.aiMode.value === 'player' &&
-                            ai.aiTargetParticipantId.value === player.participantId
-                          "
-                          @click.stop="ai.openPlayerAnalysis(player.participantId)"
-                        >
-                          <template #icon>
-                            <n-icon><SparklesOutline /></n-icon>
-                          </template>
-                          分析
-                        </n-button>
-                      </div>
-                      <div class="match-detail-badge-row">
-                        <n-tooltip
-                          v-for="badge in player.badges"
-                          :key="badge.key"
-                          trigger="hover"
-                          placement="top"
-                        >
-                          <template #trigger>
-                            <span class="match-detail-badge-icon" :class="badge.className">
-                              <n-icon :size="10">
-                                <component :is="badge.icon" />
-                              </n-icon>
-                            </span>
-                          </template>
-                          {{ badge.label }}
-                        </n-tooltip>
+              <div class="match-detail-team-rows">
+                <div
+                  v-for="player in team.players"
+                  :key="player.participantId"
+                  class="match-detail-row"
+                  :class="{ 'match-detail-row-me': player.isMe }"
+                >
+                  <div class="match-detail-player-cell">
+                    <div class="match-detail-player-main">
+                      <LazyImg
+                        class="match-detail-player-avatar"
+                        :src="assetPrefix + '/champion/' + player.championId"
+                        alt="champion"
+                      />
+                      <div class="match-detail-player-text">
+                        <div class="match-detail-player-text-row">
+                          <span class="match-detail-player-display">{{ player.displayName }}</span>
+                          <n-button
+                            text
+                            size="tiny"
+                            class="match-detail-player-copy"
+                            @click.stop="copy(player.displayName)"
+                          >
+                            <template #icon>
+                              <n-icon><CopyOutline /></n-icon>
+                            </template>
+                          </n-button>
+                          <span v-if="player.puuid" @click.stop>
+                            <PlayerNoteBadge
+                              :puuid="player.puuid"
+                              :game-name="player.gameName"
+                              :tag-line="player.tagLine"
+                              :encounter="buildEncounter(player)"
+                              size="normal"
+                            />
+                          </span>
+                          <n-tag v-if="player.isMe" size="small" :bordered="false" type="success"
+                            >我</n-tag
+                          >
+                          <n-tooltip trigger="hover" placement="top">
+                            <template #trigger>
+                              <n-button
+                                quaternary
+                                circle
+                                size="tiny"
+                                class="match-detail-player-ai-trigger"
+                                :class="{
+                                  'match-detail-player-ai-trigger--busy':
+                                    ai.aiLoading.value &&
+                                    ai.aiMode.value === 'player' &&
+                                    ai.aiTargetParticipantId.value === player.participantId
+                                }"
+                                :loading="
+                                  ai.aiLoading.value &&
+                                  ai.aiMode.value === 'player' &&
+                                  ai.aiTargetParticipantId.value === player.participantId
+                                "
+                                @click.stop="ai.openPlayerAnalysis(player.participantId)"
+                              >
+                                <template #icon>
+                                  <n-icon><SparklesOutline /></n-icon>
+                                </template>
+                              </n-button>
+                            </template>
+                            AI 单人分析
+                          </n-tooltip>
+                        </div>
+                        <div class="match-detail-badge-row">
+                          <n-tooltip
+                            v-for="badge in player.badges"
+                            :key="badge.key"
+                            trigger="hover"
+                            placement="top"
+                          >
+                            <template #trigger>
+                              <span class="match-detail-badge-icon" :class="badge.className">
+                                <n-icon :size="10">
+                                  <component :is="badge.icon" />
+                                </n-icon>
+                              </span>
+                            </template>
+                            {{ badge.label }}
+                          </n-tooltip>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
 
-                <div class="match-detail-build-cell">
-                  <div class="match-detail-build-topline">
-                    <div class="match-detail-spells">
-                      <n-tooltip
-                        v-for="(spellId, index) in [player.spell1Id, player.spell2Id]"
-                        :key="`${player.participantId}-spell-${spellId}-${index}`"
-                        trigger="hover"
-                        placement="top"
-                        :disabled="!assets.detailOf('spell', spellId)"
-                      >
-                        <template #trigger>
-                          <img
-                            :src="assets.srcOf('spell', spellId)"
-                            class="match-detail-spell-icon"
-                            alt="spell"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                        </template>
-                        <AssetTooltipContent
-                          v-if="assets.detailOf('spell', spellId)"
-                          :icon-src="assets.srcOf('spell', spellId)"
-                          :name="assets.detailOf('spell', spellId)?.name ?? ''"
-                          :description="assets.detailOf('spell', spellId)?.description ?? ''"
-                        />
-                      </n-tooltip>
-                    </div>
-                    <!-- 符文/海克斯都跟 spells 同行 (密集布局) -->
-                    <div class="match-detail-perks">
-                      <n-tooltip
-                        v-for="(perkId, index) in displayedPerkIds(player.stats)"
-                        :key="`${player.participantId}-perk-${perkId}-${index}`"
-                        trigger="hover"
-                        placement="top"
-                        :disabled="!usesAugments && !assets.detailOf('perk', perkId)"
-                      >
-                        <template #trigger>
-                          <span
-                            v-if="usesAugments"
-                            :class="[
-                              'match-detail-augment-icon-shell',
-                              augmentRarityClass(
-                                assets.detailOf('perk', perkId)?.rarity,
-                                'match-detail-augment'
-                              )
-                            ]"
-                          >
+                  <div class="match-detail-build-cell">
+                    <div class="match-detail-build-topline">
+                      <div class="match-detail-spells">
+                        <n-tooltip
+                          v-for="(spellId, index) in [player.spell1Id, player.spell2Id]"
+                          :key="`${player.participantId}-spell-${spellId}-${index}`"
+                          trigger="hover"
+                          placement="top"
+                          :disabled="!assets.detailOf('spell', spellId)"
+                        >
+                          <template #trigger>
                             <img
-                              :src="assets.srcOf('perk', perkId)"
-                              class="match-detail-augment-icon"
-                              alt="augment"
+                              :src="assets.srcOf('spell', spellId)"
+                              class="match-detail-spell-icon"
+                              alt="spell"
                               loading="lazy"
                               decoding="async"
                             />
-                          </span>
-                          <img
-                            v-else
-                            :src="assets.srcOf('perk', perkId)"
-                            :class="[
-                              'match-detail-perk-icon',
-                              { 'match-detail-perk-icon-sub': index === 1 }
-                            ]"
-                            alt="perk"
-                            loading="lazy"
-                            decoding="async"
+                          </template>
+                          <AssetTooltipContent
+                            v-if="assets.detailOf('spell', spellId)"
+                            :icon-src="assets.srcOf('spell', spellId)"
+                            :name="assets.detailOf('spell', spellId)?.name ?? ''"
+                            :description="assets.detailOf('spell', spellId)?.description ?? ''"
                           />
-                        </template>
-                        <AssetTooltipContent
-                          :icon-src="assets.srcOf('perk', perkId)"
-                          :name="
-                            assets.detailOf('perk', perkId)?.name ??
-                            (usesAugments ? `海克斯 #${perkId}` : `符文 #${perkId}`)
-                          "
-                          :description="assets.detailOf('perk', perkId)?.description ?? ''"
-                          :rarity="assets.detailOf('perk', perkId)?.rarity"
-                        />
-                      </n-tooltip>
+                        </n-tooltip>
+                      </div>
+                      <!-- 符文/海克斯都跟 spells 同行 (密集布局) -->
+                      <div class="match-detail-perks">
+                        <n-tooltip
+                          v-for="(perkId, index) in displayedPerkIds(player.stats)"
+                          :key="`${player.participantId}-perk-${perkId}-${index}`"
+                          trigger="hover"
+                          placement="top"
+                          :disabled="!usesAugments && !assets.detailOf('perk', perkId)"
+                        >
+                          <template #trigger>
+                            <span
+                              v-if="usesAugments"
+                              :class="[
+                                'match-detail-augment-icon-shell',
+                                augmentRarityClass(
+                                  assets.detailOf('perk', perkId)?.rarity,
+                                  'match-detail-augment'
+                                )
+                              ]"
+                            >
+                              <img
+                                :src="assets.srcOf('perk', perkId)"
+                                class="match-detail-augment-icon"
+                                alt="augment"
+                                loading="lazy"
+                                decoding="async"
+                              />
+                            </span>
+                            <img
+                              v-else
+                              :src="assets.srcOf('perk', perkId)"
+                              :class="[
+                                'match-detail-perk-icon',
+                                { 'match-detail-perk-icon-sub': index === 1 }
+                              ]"
+                              alt="perk"
+                              loading="lazy"
+                              decoding="async"
+                            />
+                          </template>
+                          <AssetTooltipContent
+                            :icon-src="assets.srcOf('perk', perkId)"
+                            :name="
+                              assets.detailOf('perk', perkId)?.name ??
+                              (usesAugments ? `海克斯 #${perkId}` : `符文 #${perkId}`)
+                            "
+                            :description="assets.detailOf('perk', perkId)?.description ?? ''"
+                            :rarity="assets.detailOf('perk', perkId)?.rarity"
+                          />
+                        </n-tooltip>
+                      </div>
                     </div>
-                  </div>
-                  <div class="match-detail-items">
-                    <n-tooltip
-                      v-for="(itemId, index) in itemIds(player.stats)"
-                      :key="`${player.participantId}-${index}`"
-                      trigger="hover"
-                      placement="top"
-                      :disabled="!assets.detailOf('item', itemId)"
-                    >
-                      <template #trigger>
-                        <img
-                          :src="assets.srcOf('item', itemId)"
-                          class="match-detail-item-icon"
-                          alt="item"
-                          loading="lazy"
-                          decoding="async"
+                    <div class="match-detail-items">
+                      <template
+                        v-for="(itemId, index) in itemIds(player.stats)"
+                        :key="`${player.participantId}-${index}`"
+                      >
+                        <n-tooltip
+                          v-if="itemId > 0"
+                          trigger="hover"
+                          placement="top"
+                          :disabled="!assets.detailOf('item', itemId)"
+                        >
+                          <template #trigger>
+                            <img
+                              :src="assets.srcOf('item', itemId)"
+                              class="match-detail-item-icon"
+                              :class="{ 'match-detail-item-trinket': index === 6 }"
+                              alt="item"
+                              loading="lazy"
+                              decoding="async"
+                            />
+                          </template>
+                          <AssetTooltipContent
+                            v-if="assets.detailOf('item', itemId)"
+                            :icon-src="assets.srcOf('item', itemId)"
+                            :name="assets.detailOf('item', itemId)?.name ?? ''"
+                            :description="assets.detailOf('item', itemId)?.description ?? ''"
+                          />
+                        </n-tooltip>
+                        <!-- 空装备格：内凹暗槽占位，而非黑块（黑块像图片加载失败） -->
+                        <span
+                          v-else
+                          class="match-detail-item-empty"
+                          :class="{ 'match-detail-item-trinket': index === 6 }"
                         />
                       </template>
-                      <AssetTooltipContent
-                        v-if="assets.detailOf('item', itemId)"
-                        :icon-src="assets.srcOf('item', itemId)"
-                        :name="assets.detailOf('item', itemId)?.name ?? ''"
-                        :description="assets.detailOf('item', itemId)?.description ?? ''"
-                      />
+                    </div>
+                  </div>
+
+                  <div class="match-detail-value-cell match-detail-kda-value-cell">
+                    <div class="match-detail-kda-line font-number">
+                      <span>{{ player.stats.kills }}</span>
+                      <span class="match-detail-kda-separator">/</span>
+                      <span :style="{ color: deathsColor(player.stats.deaths, isDark) }">{{
+                        player.stats.deaths
+                      }}</span>
+                      <span class="match-detail-kda-separator">/</span>
+                      <span>{{ player.stats.assists }}</span>
+                    </div>
+                    <div
+                      class="match-detail-cell-sub font-number"
+                      :style="{ color: kdaColor(kdaRatio(player.stats), isDark) }"
+                    >
+                      {{ kdaRatio(player.stats).toFixed(1) }} KDA
+                    </div>
+                  </div>
+                  <div class="match-detail-value-cell">
+                    <div class="font-number">
+                      {{ formatCompactNumber(player.stats.goldEarned) }}
+                    </div>
+                    <div class="match-detail-cell-sub font-number">
+                      {{ goldPerMin(player.stats) }}/分
+                    </div>
+                  </div>
+                  <div class="match-detail-value-cell">
+                    <div class="font-number">{{ totalCs(player.stats) }}</div>
+                    <div class="match-detail-cell-sub font-number">
+                      {{ csPerMin(player.stats) }}/分
+                    </div>
+                  </div>
+                  <div class="match-detail-value-cell">
+                    <div class="font-number">
+                      {{ formatCompactNumber(player.stats.damageDealtToTurrets) }}
+                    </div>
+                    <!-- 占位副行：撑出与相邻双行列一致的高度，主数值基线全表拉直 -->
+                    <div class="match-detail-cell-sub match-detail-cell-sub--ghost font-number">
+                      0
+                    </div>
+                  </div>
+
+                  <!-- 输出/承伤/治疗：按全场最大值刻度的横向对比条（一眼看出谁 carry） -->
+                  <div class="match-detail-bars-cell">
+                    <n-tooltip
+                      v-for="bar in playerBars(player)"
+                      :key="`${player.participantId}-${bar.key}`"
+                      trigger="hover"
+                      placement="left"
+                    >
+                      <template #trigger>
+                        <div class="match-detail-bar-row">
+                          <span class="match-detail-bar-value font-number">{{
+                            bar.valueText
+                          }}</span>
+                          <span class="match-detail-bar-track">
+                            <span
+                              class="match-detail-bar-fill"
+                              :class="bar.fillClass"
+                              :style="{ width: bar.width }"
+                            />
+                          </span>
+                        </div>
+                      </template>
+                      {{ bar.tooltip }}
                     </n-tooltip>
                   </div>
-                </div>
-
-                <div class="match-detail-value-cell font-number match-detail-kda-value-cell">
-                  <span :style="{ color: killsColor(player.stats.kills, isDark) }">{{
-                    player.stats.kills
-                  }}</span>
-                  <span class="match-detail-kda-separator">/</span>
-                  <span :style="{ color: deathsColor(player.stats.deaths, isDark) }">{{
-                    player.stats.deaths
-                  }}</span>
-                  <span class="match-detail-kda-separator">/</span>
-                  <span :style="{ color: assistsColor(player.stats.assists, isDark) }">{{
-                    player.stats.assists
-                  }}</span>
-                </div>
-                <div class="match-detail-value-cell font-number">
-                  {{ formatCompactNumber(player.stats.goldEarned) }}
-                </div>
-                <div class="match-detail-value-cell font-number">{{ totalCs(player.stats) }}</div>
-                <div class="match-detail-value-cell font-number">
-                  {{ formatCompactNumber(player.stats.damageDealtToTurrets) }}
-                </div>
-
-                <div class="match-detail-dots-cell">
-                  <StatDots
-                    :icon="FlameOutline"
-                    tooltip="对英雄伤害，占己方总和百分比"
-                    :color="otherColor(player.teamRelative.damage, isDark)"
-                    :icon-background="
-                      isDark ? 'rgba(229, 167, 50, 0.18)' : 'rgba(229, 167, 50, 0.14)'
-                    "
-                    :value="formatCompactNumber(player.stats.totalDamageDealtToChampions)"
-                    :percent="player.teamRelative.damage"
-                    compact
-                  />
-                  <StatDots
-                    :icon="ShieldOutline"
-                    tooltip="承受伤害，占己方总和百分比"
-                    :color="healColorAndTaken(player.teamRelative.taken, isDark)"
-                    :icon-background="
-                      isDark ? 'rgba(92, 163, 234, 0.2)' : 'rgba(92, 163, 234, 0.12)'
-                    "
-                    :value="formatCompactNumber(player.stats.totalDamageTaken)"
-                    :percent="player.teamRelative.taken"
-                    compact
-                  />
-                  <StatDots
-                    :icon="HeartOutline"
-                    tooltip="治疗量，占己方总和百分比"
-                    :color="healColorAndTaken(player.teamRelative.heal, isDark)"
-                    :icon-background="
-                      isDark ? 'rgba(88, 182, 109, 0.2)' : 'rgba(88, 182, 109, 0.14)'
-                    "
-                    :value="formatCompactNumber(player.stats.totalHeal)"
-                    :percent="player.teamRelative.heal"
-                    compact
-                  />
                 </div>
               </div>
             </div>
@@ -402,13 +447,7 @@
 
 <script lang="ts" setup>
 import { computed, ref, watch, onMounted, toRef } from 'vue'
-import {
-  CopyOutline,
-  FlameOutline,
-  HeartOutline,
-  ShieldOutline,
-  SparklesOutline
-} from '@vicons/ionicons5'
+import { CopyOutline, SparklesOutline } from '@vicons/ionicons5'
 import { NButton, NIcon, NTag, NTooltip } from 'naive-ui'
 import { invoke } from '@tauri-apps/api/core'
 import { useCopy } from '@renderer/composables/useCopy'
@@ -418,18 +457,10 @@ import { assetPrefix } from '@renderer/services/http'
 import type { Game, ParticipantStats } from '@renderer/types/domain/match'
 import type { Summoner } from '@renderer/types/domain/player'
 import AssetTooltipContent from './AssetTooltipContent.vue'
-import StatDots from './StatDots.vue'
 import MatchAIPanel from './MatchAIPanel.vue'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
-import {
-  assistsColor,
-  deathsColor,
-  healColorAndTaken,
-  kdaColor,
-  killsColor,
-  otherColor
-} from '@renderer/utils/colors'
+import { deathsColor, kdaColor } from '@renderer/utils/colors'
 import { formatCompactNumber } from '@renderer/utils/format'
 import { augmentRarityClass } from '@renderer/utils/augment'
 import { useRecordAssets } from '@renderer/composables/useRecordAssets'
@@ -473,6 +504,71 @@ function kdaRatioLabel(stats: ParticipantStats) {
 }
 function itemIds(stats: ParticipantStats) {
   return [stats.item0, stats.item1, stats.item2, stats.item3, stats.item4, stats.item5, stats.item6]
+}
+
+/** 每分钟补兵（一位小数）；时长缺失时按 1 分钟兜底避免除零 */
+function csPerMin(stats: ParticipantStats) {
+  const minutes = Math.max(1, (props.game?.gameDuration ?? 60) / 60)
+  return (totalCs(stats) / minutes).toFixed(1)
+}
+
+/** 每分钟金钱（整数）；与补兵/分同一口径 */
+function goldPerMin(stats: ParticipantStats) {
+  const minutes = Math.max(1, (props.game?.gameDuration ?? 60) / 60)
+  return Math.round(stats.goldEarned / minutes)
+}
+
+/** 全场（双方 10 人）各项最大值——对比条的刻度，谁 carry 一眼可见 */
+const gameMax = computed(() => {
+  let damage = 1
+  let taken = 1
+  let heal = 1
+  for (const p of detailPlayers.value) {
+    damage = Math.max(damage, p.stats.totalDamageDealtToChampions)
+    taken = Math.max(taken, p.stats.totalDamageTaken)
+    heal = Math.max(heal, p.stats.totalHeal)
+  }
+  return { damage, taken, heal }
+})
+
+/** 单名玩家的三根对比条（输出/承伤/治疗）：宽度按全场最大值刻度，占比进 tooltip */
+function playerBars(player: DetailPlayer) {
+  const s = player.stats
+  const m = gameMax.value
+  const mk = (
+    key: string,
+    label: string,
+    value: number,
+    max: number,
+    fillClass: string,
+    teamPct: number
+  ) => ({
+    key,
+    label,
+    valueText: formatCompactNumber(value),
+    width: `${Math.max(3, Math.round((value / max) * 100))}%`,
+    fillClass,
+    tooltip: `${label} ${value.toLocaleString()} · 占己方 ${teamPct}%`
+  })
+  return [
+    mk(
+      'damage',
+      '输出',
+      s.totalDamageDealtToChampions,
+      m.damage,
+      'match-detail-bar-fill--damage',
+      player.teamRelative.damage
+    ),
+    mk(
+      'taken',
+      '承伤',
+      s.totalDamageTaken,
+      m.taken,
+      'match-detail-bar-fill--taken',
+      player.teamRelative.taken
+    ),
+    mk('heal', '治疗', s.totalHeal, m.heal, 'match-detail-bar-fill--heal', player.teamRelative.heal)
+  ]
 }
 function playerAugmentIds(stats: ParticipantStats) {
   return [
@@ -639,11 +735,89 @@ watch(
 }
 
 .match-detail-header {
+  --hdr-color: var(--semantic-win);
+  position: relative;
+  overflow: hidden;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 270px;
-  gap: var(--space-6);
-  padding: 7px var(--space-10) 5px; /* 顶部 7px 微调 + 左右 token + 底部 5px */
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-10) var(--space-12);
   border-bottom: 1px solid var(--border-subtle);
+  /* 头部单独一层极轻的表面色，与正文区分层次 */
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+}
+
+.match-detail-header--win {
+  --hdr-color: var(--semantic-win);
+}
+
+.match-detail-header--loss {
+  --hdr-color: var(--semantic-loss);
+}
+
+/* 胜负环境光：左上角一团结果色的径向光晕——不依赖英雄图明暗，始终可见且克制 */
+.match-detail-header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    120% 190% at 7% 18%,
+    color-mix(in srgb, var(--hdr-color) 17%, transparent),
+    transparent 56%
+  );
+  pointer-events: none;
+}
+
+/* 氛围底图：英雄图放大重模糊、向右渐隐——页面级环境光，非组件毛玻璃 */
+.match-detail-header-ambient {
+  /* 源图仅 128px：重模糊会糊成看不见的色雾。改为"幽灵浮雕"——
+     大尺寸 + 轻模糊保留轮廓 + 径向渐隐，英雄的脸若隐若现衬在标题后 */
+  position: absolute;
+  left: -36px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 300px;
+  height: 300px;
+  object-fit: cover;
+  filter: blur(2px) brightness(1.3) saturate(1.15);
+  opacity: 0.3;
+  pointer-events: none;
+  -webkit-mask-image: radial-gradient(circle at 34% 50%, rgba(0, 0, 0, 0.9) 22%, transparent 68%);
+  mask-image: radial-gradient(circle at 34% 50%, rgba(0, 0, 0, 0.9) 22%, transparent 68%);
+}
+
+.theme-light .match-detail-header-ambient {
+  opacity: 0.1;
+}
+
+.match-detail-header-main,
+.match-detail-summary-side {
+  position: relative;
+  z-index: 1;
+}
+
+/* 结果徽章：色字 + 淡底 + 内描边微光，比通用 tag 更有份量 */
+.match-detail-result-pill {
+  --result-color: var(--semantic-win);
+  padding: 2px 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--result-color);
+  background: color-mix(in srgb, var(--result-color) 13%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--result-color) 38%, transparent),
+    0 0 12px color-mix(in srgb, var(--result-color) 16%, transparent);
+}
+
+.match-detail-result-pill--win {
+  --result-color: var(--semantic-win);
+}
+
+.match-detail-result-pill--loss {
+  --result-color: var(--semantic-loss);
 }
 
 .match-detail-title-row {
@@ -671,12 +845,27 @@ watch(
 }
 
 .match-detail-hero {
-  /* 40→52px 随 viewport (1100→2200) */
-  width: clamp(40px, calc(40px + (100vw - 1100px) * 12 / 1100), 52px);
-  height: clamp(40px, calc(40px + (100vw - 1100px) * 12 / 1100), 52px);
+  /* 48→60px 随 viewport (1100→2200)——头部主视觉，比正文头像大一档 */
+  width: clamp(48px, calc(48px + (100vw - 1100px) * 12 / 1100), 60px);
+  height: clamp(48px, calc(48px + (100vw - 1100px) * 12 / 1100), 60px);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
   display: block;
+}
+
+/* 胜负色环：双层描边（内深外发光），头部一眼读出结果 */
+.match-detail-hero--win {
+  border-color: color-mix(in srgb, var(--semantic-win) 55%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--semantic-win) 25%, transparent),
+    0 0 14px color-mix(in srgb, var(--semantic-win) 22%, transparent);
+}
+
+.match-detail-hero--loss {
+  border-color: color-mix(in srgb, var(--semantic-loss) 50%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--semantic-loss) 22%, transparent),
+    0 0 14px color-mix(in srgb, var(--semantic-loss) 18%, transparent);
 }
 
 .match-detail-player-copy {
@@ -707,155 +896,171 @@ watch(
   font-weight: 600;
 }
 
-.match-detail-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 5px;
-}
-
+/* 头部右侧：一条无边框统计带 + 一颗 AI 主按钮（替代旧的两层边框盒子） */
 .match-detail-summary-side {
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: var(--space-6);
 }
 
-.match-detail-summary-card {
-  padding: 5px 7px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-  background: var(--glass-bg-low);
-}
-
-.theme-light .match-detail-summary-card {
-  background: rgba(255, 255, 255, 0.82);
-}
-
-.match-detail-summary-label {
-  color: var(--text-secondary);
-  font-size: var(--font-size-2xs);
-  margin-bottom: var(--space-4);
-}
-
-.match-detail-summary-value {
-  font-size: var(--font-size-base);
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.match-detail-ai-toolbar {
+.match-detail-stats-strip {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-8);
-  padding: var(--space-6) var(--space-8);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  background: var(--glass-bg-low);
+  gap: var(--space-10);
 }
 
-.theme-light .match-detail-ai-toolbar {
-  background: rgba(255, 255, 255, 0.82);
-}
-
-.match-detail-ai-copy {
+.match-detail-stat {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  align-items: flex-end;
+  gap: 1px;
 }
 
-.match-detail-ai-title {
-  font-size: var(--font-size-sm);
+.match-detail-stat-label {
+  color: var(--text-tertiary);
+  font-size: var(--font-size-2xs);
+  letter-spacing: 0.06em;
+}
+
+.match-detail-stat-value {
+  font-size: var(--font-size-md);
   font-weight: 700;
   color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
 }
 
-.match-detail-ai-subtitle {
-  font-size: var(--font-size-xs);
-  color: var(--text-secondary);
+.match-detail-stat-divider {
+  width: 1px;
+  height: 22px;
+  background: var(--border-subtle);
+}
+
+.match-detail-ai-button {
+  -webkit-app-region: no-drag;
 }
 
 .match-detail-body {
   overflow: auto;
-  padding: var(--space-4) var(--space-10) var(--space-6);
+  padding: var(--space-8) var(--space-12) var(--space-10);
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: var(--space-12);
 }
 
+/* 细滚动条，替代系统默认宽条 */
+.match-detail-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.match-detail-body::-webkit-scrollbar-thumb {
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text-tertiary) 35%, transparent);
+}
+
+.match-detail-body::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--text-tertiary) 55%, transparent);
+}
+
+.match-detail-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* 区块 = 排版式标签 + 卡片（去一层盒子：标题悬于卡片之上，不再是"卡片里的色条"） */
 .match-detail-team-section {
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  background: rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
   flex-shrink: 0;
 }
 
-.theme-light .match-detail-team-section {
-  background: rgba(255, 255, 255, 0.92);
+.match-detail-team-card {
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 80%, transparent);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.015);
 }
 
+.theme-light .match-detail-team-card {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+/* 队伍标签行：色点 + 色字 + 数据，纯排版、无底无框 */
 .match-detail-team-header {
+  --team-color: var(--semantic-win);
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: var(--space-6);
-  padding: 5px 9px;
-  color: #fff;
+  padding: 0 var(--space-4);
 }
 
 .match-detail-team-header-win {
-  background: linear-gradient(90deg, rgba(45, 138, 108, 0.88), rgba(45, 138, 108, 0.52));
+  --team-color: var(--semantic-win);
 }
 
 .match-detail-team-header-loss {
-  background: linear-gradient(90deg, rgba(184, 66, 66, 0.88), rgba(184, 66, 66, 0.52));
+  --team-color: var(--semantic-loss);
+}
+
+.match-detail-team-accent {
+  width: 4px;
+  height: 16px;
+  border-radius: 2px;
+  background: var(--team-color);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--team-color) 55%, transparent);
+  flex-shrink: 0;
 }
 
 .match-detail-team-title-wrap {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--space-8);
 }
 
 .match-detail-team-title {
   font-size: var(--font-size-md);
   font-weight: 700;
+  color: var(--team-color);
+  letter-spacing: 0.02em;
 }
 
 .match-detail-team-subtitle {
   font-size: var(--font-size-xs);
-  opacity: 0.95;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
 }
 
 .match-detail-column-header,
 .match-detail-row {
-  /* 表格列宽固定（P2: 右侧 stats 1.3→1.2fr 释放空间给 build-cell augment 独立行) */
   display: grid;
-  /* 右列 stats 锁固定 160px (StatDots 紧凑后不需要 1.2fr), 释放空间给 player/build 列 */
-  grid-template-columns: minmax(188px, 1.22fr) minmax(214px, 1.42fr) 72px 68px 62px 68px 160px;
+  /* build 列锁定 216px：弹性只留给玩家列，避免中部出现大片死空间；
+     数字列全部右对齐双行，主数值基线全表一条直线 */
+  grid-template-columns: minmax(188px, 1fr) 216px 84px 78px 72px 68px 180px;
   gap: var(--space-6);
   align-items: center;
 }
 
 .match-detail-column-header {
-  /* 密集: 表头 padding 6→4 */
-  padding: var(--space-4) 9px;
-  color: var(--text-secondary);
+  /* 水平 padding 与数据行统一 12px；透明底 + 发丝线，弱化表头存在感 */
+  padding: var(--space-4) var(--space-12);
+  color: var(--text-tertiary);
   font-size: var(--font-size-2xs);
   font-weight: 600;
-  letter-spacing: 0.04em;
-  background: var(--glass-bg-low);
+  letter-spacing: 0.08em;
+  background: transparent;
   border-bottom: 1px solid var(--border-subtle);
   text-transform: none;
 }
 
-/* 表头数字列与数据行 text-align 对齐 (B+E 一起) */
+/* 表头数字列与数据行 text-align 对齐 */
 .match-detail-header-right {
   text-align: right;
 }
-.match-detail-header-center {
-  text-align: center;
+
+/* 条形区列头与条形区内容同步左缩进 */
+.match-detail-bars-header {
+  padding-left: var(--space-8);
 }
 
 .theme-light .match-detail-column-header {
@@ -868,9 +1073,9 @@ watch(
 }
 
 .match-detail-row {
-  /* 密集模式: padding 收紧到 4px */
-  padding: var(--space-4) 9px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 60%, transparent);
+  /* 垂直 6px 呼吸感 + 水平 12px 与列头统一 */
+  padding: var(--space-6) var(--space-12);
+  border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 50%, transparent);
   transition: background var(--dur-fast) var(--ease-expo);
   position: relative;
 }
@@ -883,18 +1088,18 @@ watch(
   border-bottom: none;
 }
 
-/* "我" 行强化高亮: 左侧 3px 队伍色 accent + 略强背景 (G 优化) */
+/* "我" 行高亮：与主题 accent 同色系（wash + 左条），不再蓝绿混用 */
 .match-detail-row-me {
-  background: rgba(92, 163, 234, 0.12);
+  background: color-mix(in srgb, var(--semantic-win) 10%, transparent);
   box-shadow: inset 3px 0 0 0 var(--semantic-win);
 }
 
 .match-detail-row-me:hover {
-  background: rgba(92, 163, 234, 0.18);
+  background: color-mix(in srgb, var(--semantic-win) 16%, transparent);
 }
 
 .theme-light .match-detail-row-me {
-  background: rgba(92, 163, 234, 0.08);
+  background: color-mix(in srgb, var(--semantic-win) 8%, transparent);
 }
 
 .match-detail-player-main {
@@ -918,6 +1123,10 @@ watch(
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  /* 锁定两行高度：无徽章的行名字不再垂直居中漂移，
+     全表玩家名保持同一条顶线（"歪"感的来源之一） */
+  min-height: 34px;
+  justify-content: flex-start;
 }
 
 .match-detail-player-text-row {
@@ -935,8 +1144,16 @@ watch(
   white-space: nowrap;
 }
 
+/* 行内 AI 按钮：默认隐身，行 hover 或加载中才浮现——把每行常驻噪音降到最低 */
 .match-detail-player-ai-trigger {
   --n-text-color: var(--text-secondary);
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease-expo);
+}
+
+.match-detail-row:hover .match-detail-player-ai-trigger,
+.match-detail-player-ai-trigger--busy {
+  opacity: 1;
 }
 
 .match-detail-player-copy {
@@ -1005,23 +1222,24 @@ watch(
 }
 
 .match-detail-build-topline {
+  /* 技能+符文紧凑同组靠左——不再 space-between（会把符文推到列右缘，像悬空 bug） */
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: var(--space-6);
 }
 
 .match-detail-spells {
   display: flex;
-  gap: 1px;
+  gap: 2px;
 }
 
 .match-detail-spell-icon,
 .match-detail-item-icon,
 .match-detail-perk-icon {
-  /* 紧凑: 16→20 */
-  width: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
-  height: clamp(16px, calc(16px + (100vw - 1100px) * 4 / 1100), 20px);
+  /* 18→22px 随 viewport：比旧 16 大一档，看得清图标细节 */
+  width: clamp(18px, calc(18px + (100vw - 1100px) * 4 / 1100), 22px);
+  height: clamp(18px, calc(18px + (100vw - 1100px) * 4 / 1100), 22px);
   border-radius: 4px;
   border: 1px solid var(--border-subtle);
   background: var(--bg-elevated);
@@ -1031,7 +1249,7 @@ watch(
 .match-detail-perks {
   display: flex;
   align-items: center;
-  gap: 1px;
+  gap: 2px;
 }
 
 .match-detail-augment-icon-shell {
@@ -1100,24 +1318,40 @@ watch(
 .match-detail-items {
   display: flex;
   flex-wrap: wrap;
-  gap: 1px;
+  gap: 2px;
 }
 
+/* 空装备格：内凹暗槽，与实图标同尺寸——避免黑块被误读为图片加载失败 */
+.match-detail-item-empty {
+  width: clamp(18px, calc(18px + (100vw - 1100px) * 4 / 1100), 22px);
+  height: clamp(18px, calc(18px + (100vw - 1100px) * 4 / 1100), 22px);
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 55%, transparent);
+  background: color-mix(in srgb, var(--bg-elevated) 45%, transparent);
+  box-sizing: border-box;
+  flex-shrink: 0;
+}
+
+/* 饰品格（第 7 格）与前六格之间留出一档间距分组 */
+.match-detail-item-trinket {
+  margin-left: var(--space-4);
+}
+
+/* 数字单元格：统一右对齐 + 双行（主值 + 副行），全表共用一套结构。
+   主值 sm 字号——数字要有存在感 */
 .match-detail-value-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
   font-weight: 600;
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
-  /* tabular-nums: 数字等宽, 列与列之间数字纵向对齐 (E 优化) */
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
 
-/* KDA 单元格保留居中（KDA 视觉中心对齐更易扫读, 跟 PlayerHistoryGrid 一致） */
-.match-detail-kda-value-cell {
-  text-align: center;
-}
-
-.match-detail-kda-value-cell {
+.match-detail-kda-line {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
@@ -1127,10 +1361,74 @@ watch(
   color: var(--text-tertiary);
 }
 
-.match-detail-dots-cell {
+/* 副行：每分钟/比值等次要信息，全列统一字号与色阶 */
+.match-detail-cell-sub {
+  font-size: var(--font-size-2xs);
+  font-weight: 500;
+  color: var(--text-tertiary);
+  line-height: 1.2;
+}
+
+/* 占位副行：仅撑高度不显示——让单行列与双行列的主数值基线对齐 */
+.match-detail-cell-sub--ghost {
+  visibility: hidden;
+}
+
+/* 输出/承伤/治疗对比条：值 + 按全场最大值刻度的横向条。
+   左侧留一档缩进，与推塔数字列拉开——两簇数字不贴身（拥挤感来源之一） */
+.match-detail-bars-cell {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 3px;
+  padding-left: var(--space-8);
+}
+
+.match-detail-bar-row {
+  /* 标签不逐行重复（列头已说明），色彩+顺序+tooltip 即可辨识——条更长更干净 */
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.match-detail-bar-value {
+  font-size: var(--font-size-2xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.match-detail-bar-track {
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.theme-light .match-detail-bar-track {
+  background: rgba(0, 0, 0, 0.07);
+}
+
+.match-detail-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  transition: width var(--dur-normal) var(--ease-expo);
+}
+
+/* 三色与旧图标底色同系：输出琥珀 / 承伤蓝 / 治疗绿 */
+.match-detail-bar-fill--damage {
+  background: linear-gradient(90deg, rgba(229, 167, 50, 0.55), rgba(229, 167, 50, 0.95));
+}
+
+.match-detail-bar-fill--taken {
+  background: linear-gradient(90deg, rgba(92, 163, 234, 0.5), rgba(92, 163, 234, 0.92));
+}
+
+.match-detail-bar-fill--heal {
+  background: linear-gradient(90deg, rgba(88, 182, 109, 0.5), rgba(88, 182, 109, 0.92));
 }
 
 .match-detail-empty-state {
@@ -1160,9 +1458,8 @@ watch(
     grid-template-columns: 1fr;
   }
 
-  .match-detail-ai-toolbar {
-    flex-direction: column;
-    align-items: stretch;
+  .match-detail-summary-side {
+    align-items: flex-start;
   }
 
   .match-detail-column-header,

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.spec.ts
@@ -7,6 +7,7 @@ import type { Game, Participant, ParticipantStats } from '@renderer/types/domain
 vi.mock('@vicons/ionicons5', () => ({
   CashOutline: {},
   FlagOutline: {},
+  FlameOutline: {},
   FootstepsOutline: {},
   PeopleOutline: {},
   ShieldOutline: {},
@@ -149,5 +150,116 @@ describe('useMatchDetailPlayers - CHERRY mode grouping', () => {
     expect(sections).toHaveLength(2)
     expect(sections[0].title).toBe('胜方')
     expect(sections[1].title).toBe('败方')
+  })
+})
+
+describe('useMatchDetailPlayers - 伤害徽章与 WeGame 式 MVP', () => {
+  /** 无死亡低伤"蹭分型"(KDA 18) vs 真核 carry(全场最高输出/参团/经济)——
+   *  旧纯 KDA 逻辑会把 MVP 给前者，新综合评分应给 carry */
+  function makeGame(): Game {
+    return {
+      mvp: '',
+      gameDetail: { endOfGameResult: '', participantIdentities: [], participants: [] },
+      gameId: 3,
+      gameCreationDate: '2026-07-05T00:00:00Z',
+      gameDuration: 1800,
+      gameMode: 'CLASSIC',
+      gameType: '',
+      mapId: 11,
+      queueId: 420,
+      queueName: '单双排',
+      platformId: '',
+      participantIdentities: Array.from({ length: 4 }, (_, i) => ({
+        player: {
+          accountId: 0,
+          platformId: '',
+          gameName: `P${i + 1}`,
+          tagLine: '0001',
+          summonerName: '',
+          summonerId: 0
+        }
+      })),
+      participants: [
+        // 蹭分型：KDA 18 但输出/经济低
+        makeP(
+          1,
+          100,
+          makeStats({
+            win: true,
+            kills: 10,
+            deaths: 0,
+            assists: 8,
+            totalDamageDealtToChampions: 8000,
+            totalDamageTaken: 5000,
+            goldEarned: 9000,
+            totalMinionsKilled: 100
+          })
+        ),
+        // 真核 carry：KDA 12 但全场最高输出/承伤/经济/补刀/推塔
+        makeP(
+          2,
+          100,
+          makeStats({
+            win: true,
+            kills: 9,
+            deaths: 2,
+            assists: 15,
+            totalDamageDealtToChampions: 40000,
+            totalDamageTaken: 30000,
+            goldEarned: 15000,
+            totalMinionsKilled: 200,
+            damageDealtToTurrets: 5000
+          })
+        ),
+        // 败方两人
+        makeP(
+          3,
+          200,
+          makeStats({
+            win: false,
+            kills: 5,
+            deaths: 6,
+            assists: 3,
+            totalDamageDealtToChampions: 20000,
+            totalDamageTaken: 22000,
+            goldEarned: 10000,
+            totalMinionsKilled: 150
+          })
+        ),
+        makeP(
+          4,
+          200,
+          makeStats({
+            win: false,
+            kills: 1,
+            deaths: 9,
+            assists: 2,
+            totalDamageDealtToChampions: 6000,
+            totalDamageTaken: 15000,
+            goldEarned: 7000,
+            totalMinionsKilled: 80
+          })
+        )
+      ]
+    }
+  }
+
+  it('伤害最多者获得 damage 徽章', () => {
+    const { detailPlayers } = useMatchDetailPlayers(ref(makeGame()), ref(''))
+    const carry = detailPlayers.value.find(p => p.participantId === 2)!
+    expect(carry.badges.some(b => b.key === 'damage')).toBe(true)
+    const farmer = detailPlayers.value.find(p => p.participantId === 1)!
+    expect(farmer.badges.some(b => b.key === 'damage')).toBe(false)
+  })
+
+  it('综合评分把 MVP 给 carry 而非纯 KDA 蹭分型；败方最高分得 SVP', () => {
+    const { detailPlayers } = useMatchDetailPlayers(ref(makeGame()), ref(''))
+    const byId = (id: number) => detailPlayers.value.find(p => p.participantId === id)!
+    expect(byId(2).mvpTag).toBe('MVP')
+    expect(byId(1).mvpTag).toBe('')
+    expect(byId(3).mvpTag).toBe('SVP')
+    expect(byId(4).mvpTag).toBe('')
+    // 评分单调性：carry 分应高于蹭分型
+    expect(byId(2).score).toBeGreaterThan(byId(1).score)
   })
 })

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
@@ -2,13 +2,15 @@
  * 战绩详情页的玩家数据整理：
  * - 将 game 拍平为 DetailPlayer[]
  * - 计算队伍汇总、所属 teamRelative 占比
- * - 打"最多杀人/助攻/推塔/金币/承伤/补兵" badges
+ * - 打"最多杀人/伤害/助攻/推塔/金币/承伤/补兵" badges
+ * - WeGame 式综合评分选 MVP（胜方最高分）/ SVP（败方最高分）
  */
 
 import { computed, type MaybeRefOrGetter, toValue, type Component } from 'vue'
 import {
   CashOutline,
   FlagOutline,
+  FlameOutline,
   FootstepsOutline,
   PeopleOutline,
   ShieldOutline,
@@ -41,6 +43,10 @@ export interface DetailPlayer {
   isMe: boolean
   win: boolean
   badges: PlayerBadge[]
+  /** WeGame 式综合评分（0~10），见 {@link computeMatchScore} */
+  score: number
+  /** 胜方最高分 MVP / 败方最高分 SVP，其余为空 */
+  mvpTag: 'MVP' | 'SVP' | ''
   teamRelative: {
     damage: number
     taken: number
@@ -65,6 +71,37 @@ function totalCs(stats: ParticipantStats) {
   return stats.totalMinionsKilled + stats.neutralMinionsKilled
 }
 
+/** 评分上下文：所属队伍总击杀（参团率分母）+ 全场各维度最大值（归一化分母） */
+export interface ScoreContext {
+  teamKills: number
+  max: { damage: number; taken: number; gold: number; cs: number; turret: number }
+}
+
+/**
+ * WeGame 式综合评分（0~10）：KDA、输出、参团率、承伤、经济、补刀、推塔 七维加权。
+ *
+ * 各维归一到 0..1（KDA 用饱和函数 kda/(kda+3)，其余除以全场最大值），加权和乘 10。
+ * 权重：KDA 26% / 输出 22% / 参团 18% / 承伤 10% / 经济 10% / 补刀 8% / 推塔 6%。
+ *
+ * ⚠️ 与后端 `match_history.rs::wegame_score` 同式——两端必须同步修改。
+ */
+export function computeMatchScore(s: ParticipantStats, ctx: ScoreContext): number {
+  const kda = (s.kills + s.assists) / Math.max(1, s.deaths)
+  const nKda = kda / (kda + 3)
+  const kp = ctx.teamKills > 0 ? Math.min(1, (s.kills + s.assists) / ctx.teamKills) : 0
+  const norm = (v: number, m: number) => (m > 0 ? v / m : 0)
+  return (
+    10 *
+    (0.26 * nKda +
+      0.22 * norm(s.totalDamageDealtToChampions, ctx.max.damage) +
+      0.18 * kp +
+      0.1 * norm(s.totalDamageTaken, ctx.max.taken) +
+      0.1 * norm(s.goldEarned, ctx.max.gold) +
+      0.08 * norm(totalCs(s), ctx.max.cs) +
+      0.06 * norm(s.damageDealtToTurrets, ctx.max.turret))
+  )
+}
+
 const badgeConfigs = [
   {
     key: 'kills',
@@ -72,6 +109,13 @@ const badgeConfigs = [
     icon: SkullOutline,
     className: 'match-detail-badge-kills',
     value: (s: ParticipantStats) => s.kills
+  },
+  {
+    key: 'damage',
+    label: '伤害最多',
+    icon: FlameOutline,
+    className: 'match-detail-badge-damage',
+    value: (s: ParticipantStats) => s.totalDamageDealtToChampions
   },
   {
     key: 'assists',
@@ -131,15 +175,50 @@ export function useMatchDetailPlayers(
     const groupKey = (p: Participant) =>
       isCherry && p.stats.playerSubteamId > 0 ? p.stats.playerSubteamId : p.teamId
 
-    const teamTotals = new Map<number, { damage: number; taken: number; heal: number }>()
+    const teamTotals = new Map<
+      number,
+      { damage: number; taken: number; heal: number; kills: number }
+    >()
     for (const p of participants) {
       const key = groupKey(p)
-      const cur = teamTotals.get(key) ?? { damage: 0, taken: 0, heal: 0 }
+      const cur = teamTotals.get(key) ?? { damage: 0, taken: 0, heal: 0, kills: 0 }
       cur.damage += p.stats.totalDamageDealtToChampions
       cur.taken += p.stats.totalDamageTaken
       cur.heal += p.stats.totalHeal
+      cur.kills += p.stats.kills
       teamTotals.set(key, cur)
     }
+
+    // WeGame 式评分：全场各维度最大值做归一化分母，逐人打分
+    const gameMax = { damage: 0, taken: 0, gold: 0, cs: 0, turret: 0 }
+    for (const p of participants) {
+      gameMax.damage = Math.max(gameMax.damage, p.stats.totalDamageDealtToChampions)
+      gameMax.taken = Math.max(gameMax.taken, p.stats.totalDamageTaken)
+      gameMax.gold = Math.max(gameMax.gold, p.stats.goldEarned)
+      gameMax.cs = Math.max(gameMax.cs, totalCs(p.stats))
+      gameMax.turret = Math.max(gameMax.turret, p.stats.damageDealtToTurrets)
+    }
+    const scoreById = new Map<number, number>()
+    for (const p of participants) {
+      scoreById.set(
+        p.participantId,
+        computeMatchScore(p.stats, {
+          teamKills: teamTotals.get(groupKey(p))?.kills ?? 0,
+          max: gameMax
+        })
+      )
+    }
+    // 胜方最高分 MVP、败方最高分 SVP（并列时取 participantId 小者，保证确定性）
+    const bestOf = (win: boolean) =>
+      [...participants]
+        .filter(p => p.stats.win === win)
+        .sort(
+          (a, b) =>
+            (scoreById.get(b.participantId) ?? 0) - (scoreById.get(a.participantId) ?? 0) ||
+            a.participantId - b.participantId
+        )[0]?.participantId
+    const mvpId = bestOf(true)
+    const svpId = bestOf(false)
 
     const badgeWinners = new Map<string, Set<number>>()
     for (const cfg of badgeConfigs) {
@@ -158,9 +237,15 @@ export function useMatchDetailPlayers(
         const displayName = identity
           ? `${identity.player.gameName}#${identity.player.tagLine}`
           : `玩家${p.participantId}`
-        const totals = teamTotals.get(groupKey(p)) ?? { damage: 0, taken: 0, heal: 0 }
+        const totals = teamTotals.get(groupKey(p)) ?? { damage: 0, taken: 0, heal: 0, kills: 0 }
 
         return {
+          score: scoreById.get(p.participantId) ?? 0,
+          mvpTag: (p.participantId === mvpId
+            ? 'MVP'
+            : p.participantId === svpId
+              ? 'SVP'
+              : '') as DetailPlayer['mvpTag'],
           participantId: p.participantId,
           teamId: p.teamId,
           championId: p.championId,

--- a/lol-record-analysis-tauri/src/views/MatchDetail.vue
+++ b/lol-record-analysis-tauri/src/views/MatchDetail.vue
@@ -80,9 +80,10 @@ function closeWindow() {
   --font-size-xl: clamp(18px, calc(18px + (100vw - 1100px) * 5 / 1100), 23px);
 }
 
-/* 宽屏 (>1700) 时内容居中, 上限 1600 防过宽稀疏 */
+/* 宽屏时内容居中：版心上限 1360，多余宽度变成对称留白——
+   避免弹性列把空间吐在表格中部形成大片死空间（松散、不成版心） */
 .match-detail-window-inner {
-  max-width: 1600px;
+  max-width: 1360px;
   margin: 0 auto;
   height: 100%;
 }


### PR DESCRIPTION
## Summary
- **结构与对齐**：版心 1360 居中（全屏下弹性列不再把空间吐在表格中部）；数字列统一右对齐 + 双行结构（金钱/补兵带每分钟、推塔占位副行），主数值基线全表一条直线；玩家名锁定顶线；build 列锁 216px 图标全表垂直对齐
- **数据可视化**：输出/承伤/治疗从小圆点改为按全场最大值刻度的三色横向对比条（谁 carry 一眼可见）；KDA 双行带色值比值；符文图标归位（不再被 space-between 推到列右缘悬空）；空装备格改内凹暗槽（原黑块像图片加载失败）
- **高级感**：头部胜负色环境光 + 本局英雄幽灵浮雕（128px 图标重模糊会糊成隐形色雾，故环境光用结果色，任何英雄下稳定可见）；去盒子化（胜方/败方标题提出卡片外成排版式区块标签）；色彩纪律（KDA 仅死亡标红）；行内 AI 按钮 icon 化 hover 浮现
- 纯模板 + CSS 改动（MatchDetailModal.vue / MatchDetail.vue），零数据逻辑变动

## Test plan
- [x] `npm run check` passes
- [x] `npm run test` passes（460 tests）
- [x] Manual: 真机 1300×900 独立详情窗口 + 全屏两种宽度截图迭代四轮（真实单双排 10 人数据）