### PR TITLE
feat(observability): Release Health 会话 + 大区维度标签 + 功能用量打点

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/launcher.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/launcher.rs
@@ -123,6 +123,7 @@ pub async fn launch_league() -> Result<(), String> {
     persist_install_root(&root).await;
     spawn_detached(&target)?;
     log::info!("已拉起国服登录客户端（免 WeGame）");
+    crate::observability::track_feature("launch_league");
     Ok(())
 }
 

--- a/lol-record-analysis-tauri/src-tauri/src/command/sgp.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/sgp.rs
@@ -70,6 +70,7 @@ pub async fn get_sgp_match_history_by_name(
     beg_index: i32,
     count: i32,
 ) -> Result<MatchHistory, String> {
+    crate::observability::track_feature("sgp_cross_region_query");
     sgp::get_match_history_by_name(&region, &name, beg_index, count).await
 }
 

--- a/lol-record-analysis-tauri/src-tauri/src/command/system.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/system.rs
@@ -8,6 +8,14 @@
 //! UAC，并与 `currentUser` 安装模式、自动更新静默重启相冲突。只在真正需要时提权，
 //! 普通使用路径不受影响。
 
+/// 获取匿名设备 ID（「关于」页展示用）。
+///
+/// 用户报障时附上此 ID，即可在 Sentry 侧按 `user.id` 精确定位其事件/日志/会话。
+#[tauri::command]
+pub fn get_device_id() -> String {
+    crate::observability::current_device_id()
+}
+
 /// 以管理员身份重新启动本程序。
 ///
 /// 通过 `ShellExecuteW` 的 `runas` 动词拉起一个提权实例（触发 UAC），成功后退出

--- a/lol-record-analysis-tauri/src-tauri/src/game_state_monitor.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/game_state_monitor.rs
@@ -188,6 +188,14 @@ impl GameStateMonitor {
                 crate::command::launcher::remember_install_root().await;
             });
 
+            // 维度标签：把当前登录大区（HN1/TJ100…）挂到 Sentry 全局 scope，
+            // 错误/日志可按大区切片（粗粒度非 PII；上报关闭时为 no-op）。
+            tokio::spawn(async {
+                if let Ok(pid) = crate::lcu::api::sgp::get_current_platform_id().await {
+                    crate::observability::set_region_tag(&pid);
+                }
+            });
+
             if crate::lcu::api::asset::champion_cache_is_empty() {
                 log::info!("LCU 已连接，正在补全静态资源缓存...");
                 tokio::spawn(async move {

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -147,6 +147,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::fandom::update_fandom_data,
             command::fandom::get_aram_balance,
             command::system::relaunch_as_admin,
+            command::system::get_device_id,
             command::launcher::launch_league,
             command::sgp::get_sgp_regions,
             command::sgp::get_current_sgp_region,

--- a/lol-record-analysis-tauri/src-tauri/src/observability.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/observability.rs
@@ -92,9 +92,20 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
             // 国服网络下 sentry.io 常不可达：关闭时最多只等 1s flush（默认 2s），
             // 避免每次退出都顿挫。
             shutdown_timeout: std::time::Duration::from_secs(1),
-            // 关闭 release health 的 session 上报，省掉启动/关闭的网络包；
-            // 崩溃率统计对小项目意义不大，需要时再开。
-            auto_session_tracking: false,
+            // Release Health 会话：Sentry 原生的 DAU / WAU / 版本采用率 / crash-free
+            // 数据源（每次启动一个 session，配合 user.id 去重出活跃用户）。
+            auto_session_tracking: true,
+            session_mode: sentry::SessionMode::Application,
+            // 维度：debug / release 分环境，Sentry 侧所有面板都可按此过滤，
+            // 开发期自己的会话不再污染真实用户数据。
+            environment: Some(
+                if cfg!(debug_assertions) {
+                    "debug"
+                } else {
+                    "release"
+                }
+                .into(),
+            ),
             ..Default::default()
         },
     ));
@@ -108,6 +119,24 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
     });
     log::info!("Sentry error reporting ENABLED");
     Some(guard)
+}
+
+/// 把当前登录大区（如 `HN1` / `TJ100`）设为全局 tag，供 Sentry 侧按大区切片。
+///
+/// 大区是粗粒度服务器标识、非 PII。由 `game_state_monitor` 在 LCU 连接后调用；
+/// 上报未开启时 `configure_scope` 是无客户端 no-op，无需额外判断。
+pub fn set_region_tag(platform_id: &str) {
+    sentry::configure_scope(|scope| {
+        scope.set_tag("region", platform_id);
+    });
+}
+
+/// 功能用量打点：向 Sentry Logs 发一条带 `feature` attribute 的结构化日志。
+///
+/// 在 Logs 面板按 `feature` 聚合即得各功能使用量 / 使用用户数（配合 user.id）。
+/// 只传静态功能名，不携带任何用户数据；上报未开启时为 no-op。
+pub fn track_feature(feature: &'static str) {
+    sentry::logger_info!(feature = feature, kind = "usage", "feature_used");
 }
 
 /// 读取或首次生成匿名设备 ID。

--- a/lol-record-analysis-tauri/src-tauri/src/observability.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/observability.rs
@@ -121,6 +121,13 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
     Some(guard)
 }
 
+/// 当前设备的匿名 ID（供「关于」页展示，用户报障时附上即可在 Sentry 按 user.id 定位）。
+///
+/// 文件不存在时会生成并落盘——即使上报未开启也返回稳定 ID，便于将来开启后对上。
+pub fn current_device_id() -> String {
+    device_id(Path::new(DEVICE_ID_FILE))
+}
+
 /// 把当前登录大区（如 `HN1` / `TJ100`）设为全局 tag，供 Sentry 侧按大区切片。
 ///
 /// 大区是粗粒度服务器标识、非 PII。由 `game_state_monitor` 在 LCU 连接后调用；

--- a/lol-record-analysis-tauri/src/views/settings/About.vue
+++ b/lol-record-analysis-tauri/src/views/settings/About.vue
@@ -103,6 +103,21 @@
             <div class="spacer"></div>
             <n-button size="small" @click="sendEmail">邮件</n-button>
           </div>
+
+          <!-- 匿名设备 ID：报障时附上，可在 Sentry 按 user.id 精确定位该设备的事件/日志 -->
+          <div class="nav-item">
+            <div class="nav-icon">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                <path
+                  d="M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28zM3.5 9.72c-.1 0-.2-.03-.29-.09-.23-.16-.28-.47-.12-.7.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25.16.22.11.54-.12.7-.23.16-.54.11-.7-.12-.9-1.26-2.04-2.25-3.39-2.94-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21zm6.25 12.07c-.13 0-.26-.05-.35-.15-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39-2.57 0-4.66 1.97-4.66 4.39 0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15zm7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12z"
+                />
+              </svg>
+            </div>
+            <span>设备标识</span>
+            <div class="spacer"></div>
+            <span class="device-id-text font-number">{{ deviceId || '加载中…' }}</span>
+            <n-button size="small" :disabled="!deviceId" @click="copyDeviceId">复制</n-button>
+          </div>
         </n-space>
       </div>
     </n-card>
@@ -111,7 +126,8 @@
 
 <script setup lang="ts">
 import { onMounted, ref, computed, h } from 'vue'
-import { useNotification, useDialog, NProgress } from 'naive-ui'
+import { useNotification, useDialog, useMessage, NProgress } from 'naive-ui'
+import { invoke } from '@tauri-apps/api/core'
 import { getVersion } from '@tauri-apps/api/app'
 import { check } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
@@ -122,8 +138,23 @@ const md = new MarkdownIt()
 
 // Component state
 const currentVersion = ref('')
+
+/** 匿名设备 ID：用户报障时附上，可在 Sentry 按 user.id 精确定位其事件/日志 */
+const deviceId = ref('')
+const message = useMessage()
+
+const copyDeviceId = () => {
+  navigator.clipboard
+    .writeText(deviceId.value)
+    .then(() => message.success('设备标识已复制'))
+    .catch(() => message.error('复制失败'))
+}
+
 onMounted(() => {
   fetchAppVersion()
+  invoke<string>('get_device_id')
+    .then(id => (deviceId.value = id))
+    .catch(e => console.error('获取设备标识失败:', e))
 })
 async function fetchAppVersion() {
   try {
@@ -374,6 +405,13 @@ const sendEmail = () => {
 
 .spacer {
   flex: 1;
+}
+
+.device-id-text {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-right: 10px;
+  user-select: text;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- **DAU 之类**：开启 Release Health 会话（`auto_session_tracking` + Application 模式）——Sentry 原生 DAU/WAU、版本采用率、crash-free 率，配合既有匿名 device_id 的 `user.id` 去重
- **维度**：`environment` 区分 debug/release（开发数据不再混入）；LCU 连接后挂 `region` 全局 tag（HN1/TJ100…，粗粒度非 PII），错误/日志可按大区切片
- **功能用量**：`track_feature()` 向 Sentry Logs 发带 `feature` attribute 的结构化日志，按 attribute 聚合即得各功能使用量与使用用户数；首批埋点：一键启动、SGP 跨区查询
- 隐私边界不变：仍是 opt-in、`scrub_event`/`scrub_log` 脱敏管道全覆盖、打点只含静态功能名

## Test plan
- [x] `npm run check` passes（prettier + eslint + vue-tsc + cargo fmt + clippy -Dwarnings）
- [x] `cargo test` passes（165 tests）
- [ ] Manual: debug 构建跑一次后在 Sentry 侧确认 Releases→Session 数据、region tag、feature_used 日志出现