### PR TITLE
feat(sync): 玩家备注导入导出 + Supabase 云同步(明文/puuid 寻址/风险告知)

### DIFF
--- a/lol-record-analysis-tauri/package-lock.json
+++ b/lol-record-analysis-tauri/package-lock.json
@@ -7,6 +7,7 @@
       "name": "lol-record-analysis-app",
       "dependencies": {
         "@tauri-apps/api": "^2.10.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-http": "^2.4.4",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
@@ -1587,6 +1588,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-http": {

--- a/lol-record-analysis-tauri/package.json
+++ b/lol-record-analysis-tauri/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.10.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-http": "^2.4.4",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/lol-record-analysis-tauri/src-tauri/Cargo.lock
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.lock
@@ -2717,6 +2717,7 @@ dependencies = [
  "serde_yaml",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-http",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
@@ -4346,6 +4347,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5438,6 +5463,24 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/lol-record-analysis-tauri/src-tauri/Cargo.toml
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.toml
@@ -72,3 +72,4 @@ sentry = { version = "0.42", features = ["log", "logs"] }
 tauri-plugin-sentry = "0.5"
 # 匿名设备 ID（observability.rs 持久化生成，仅用于 Sentry DAU 去重）
 uuid = { version = "1", features = ["v4"] }
+tauri-plugin-dialog = "2.7.1"

--- a/lol-record-analysis-tauri/src-tauri/Cargo.toml
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ env_logger = "0.11"
 base64 = "0.21"
 tauri-plugin-http = "2"
 tauri-plugin-process = "2"
+tauri-plugin-dialog = "2.7.1" # 导入导出文件选择对话框
 moka = { version = "0.12", features = ["future"] }
 phf = { version = "0.12", features = ["macros"] } # 用于静态配置编译期生成
 tokio = { version = "1", features = ["full"] }
@@ -72,4 +73,3 @@ sentry = { version = "0.42", features = ["log", "logs"] }
 tauri-plugin-sentry = "0.5"
 # 匿名设备 ID（observability.rs 持久化生成，仅用于 Sentry DAU 去重）
 uuid = { version = "1", features = ["v4"] }
-tauri-plugin-dialog = "2.7.1"

--- a/lol-record-analysis-tauri/src-tauri/capabilities/default.json
+++ b/lol-record-analysis-tauri/src-tauri/capabilities/default.json
@@ -31,6 +31,8 @@
       ]
     },
     "mcp-bridge:default",
-    "sentry:default"
+    "sentry:default",
+    "dialog:allow-open",
+    "dialog:allow-save"
   ]
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command.rs
@@ -39,6 +39,7 @@
 
 pub mod ai;
 pub mod asset;
+pub mod cloud_sync;
 pub mod config;
 pub mod fandom;
 pub mod info;

--- a/lol-record-analysis-tauri/src-tauri/src/command/cloud_sync.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/cloud_sync.rs
@@ -92,6 +92,7 @@ async fn load_session() -> Option<CloudSession> {
     }
 }
 
+/// 把会话序列化为 JSON 字符串，持久化到 config（键 [`SESSION_CONFIG_KEY`]）
 async fn save_session(session: &CloudSession) -> Result<(), String> {
     let json = serde_json::to_string(session).map_err(|e| e.to_string())?;
     config::put_config(SESSION_CONFIG_KEY.to_string(), Value::String(json)).await
@@ -154,9 +155,14 @@ async fn ensure_session() -> Result<CloudSession, String> {
 ///
 /// # 返回值
 /// - `Ok(Vec<Value>)`: 各设备写入的 payload 列表（可能为空）
-/// - `Err(String)`: 网络失败或非 2xx 响应
+/// - `Err(String)`: puuid 格式非法、网络失败或非 2xx 响应
 #[tauri::command]
 pub async fn cloud_pull_notes(puuid: String) -> Result<Vec<serde_json::Value>, String> {
+    // puuid 要拼进 PostgREST 查询串：命令边界的不信任输入，限定 UUID 字符集防注入。
+    // 正常路径 puuid 来自 LCU，恒为 UUID 格式，不受影响。
+    if !puuid.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+        return Err("puuid 格式非法".to_string());
+    }
     let session = ensure_session().await?;
     let url = format!(
         "{SUPABASE_URL}/rest/v1/sync_data?puuid=eq.{puuid}&data_type=eq.{DATA_TYPE_NOTES}&select=payload"
@@ -213,27 +219,53 @@ pub async fn cloud_push_notes(puuid: String, payload: serde_json::Value) -> Resu
     Ok(())
 }
 
+/// 备份文件大小上限（字节）：备注备份远小于此，超限说明选错了文件
+const MAX_BACKUP_FILE_SIZE: u64 = 10 * 1024 * 1024;
+
+/// 校验备份文件路径：只允许 `.json` 扩展名（不区分大小写）
+///
+/// # 防御意图
+///
+/// 这两个文件命令暴露给 webview，若前端被注入（本应用 CSP 宽松且存在 v-html
+/// 渲染远程内容的面板），`read_text_file` + `cloud_push_notes` 可组合成
+/// 「读任意本地文件 → 外传云端」的攻击链。限定 `.json` 扩展名把「任意文件
+/// 读写原语」收敛为「仅备份文件读写」，正常导入导出流程（plugin-dialog 过滤
+/// `.json`）完全不受影响。
+fn validate_backup_path(path: &str) -> Result<(), String> {
+    if path.to_lowercase().ends_with(".json") {
+        Ok(())
+    } else {
+        Err("仅支持 .json 备份文件".to_string())
+    }
+}
+
 /// 把文本写入用户经系统对话框选定的路径（导出备份用，路径来自 plugin-dialog）
 ///
 /// # 参数
-/// - `path`: 目标文件路径
+/// - `path`: 目标文件路径（必须以 `.json` 结尾，见 [`validate_backup_path`]）
 /// - `content`: 待写入的文本内容
 #[tauri::command]
 pub async fn save_text_file(path: String, content: String) -> Result<(), String> {
-    std::fs::write(&path, content).map_err(|e| format!("写入文件失败: {e}"))
+    validate_backup_path(&path)?;
+    std::fs::write(&path, content).map_err(|e| format!("写入文件失败 {path}: {e}"))
 }
 
 /// 读取用户经系统对话框选定的文本文件（导入备份用）
 ///
 /// # 参数
-/// - `path`: 待读取文件路径
+/// - `path`: 待读取文件路径（必须以 `.json` 结尾，见 [`validate_backup_path`]）
 ///
 /// # 返回值
 /// - `Ok(String)`: 文件文本内容
-/// - `Err(String)`: 读取失败（文件不存在/权限/编码问题）
+/// - `Err(String)`: 路径非法、文件过大或读取失败（文件不存在/权限/编码问题）
 #[tauri::command]
 pub async fn read_text_file(path: String) -> Result<String, String> {
-    std::fs::read_to_string(&path).map_err(|e| format!("读取文件失败: {e}"))
+    validate_backup_path(&path)?;
+    let meta = std::fs::metadata(&path).map_err(|e| format!("读取文件失败 {path}: {e}"))?;
+    if meta.len() > MAX_BACKUP_FILE_SIZE {
+        return Err("文件过大（>10MB），不是备份文件".to_string());
+    }
+    std::fs::read_to_string(&path).map_err(|e| format!("读取文件失败 {path}: {e}"))
 }
 
 #[cfg(test)]
@@ -249,6 +281,22 @@ mod tests {
     #[test]
     fn should_not_refresh_when_fresh() {
         assert!(!needs_refresh(1000, 100)); // 100 + 60 < 1000
+    }
+
+    #[test]
+    fn should_accept_json_backup_path_case_insensitive() {
+        assert!(validate_backup_path("C:\\backup\\notes.json").is_ok());
+        assert!(validate_backup_path("/tmp/notes.JSON").is_ok());
+        assert!(validate_backup_path("notes.Json").is_ok());
+    }
+
+    #[test]
+    fn should_reject_non_json_backup_path() {
+        assert!(validate_backup_path("C:\\Windows\\system32\\config\\SAM").is_err());
+        assert!(validate_backup_path("/etc/passwd").is_err());
+        assert!(validate_backup_path("notes.json.exe").is_err());
+        assert!(validate_backup_path("notes.txt").is_err());
+        assert!(validate_backup_path("").is_err());
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/command/cloud_sync.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/cloud_sync.rs
@@ -1,0 +1,267 @@
+//! Supabase 云同步：匿名会话管理 + sync_data 表读写 + 导入导出文件 IO
+//!
+//! 身份模型：每台设备一个匿名 Supabase 账号，只用于写入溯源（RLS「谁写的谁能改」），
+//! 不承担跨设备身份识别；跨设备找回数据按 puuid 查询所有设备的行，前端合并。
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::config::{self, Value};
+
+/// Supabase 项目地址（东南亚节点，2026-07 创建）
+const SUPABASE_URL: &str = "https://agutdvbhkhxzngscdlsh.supabase.co";
+/// 可公开 key（新版 publishable 格式，等价旧 anon key）——权限由服务端 RLS 兜底，
+/// 硬编码提交是 Supabase 官方推荐用法，不是泄密
+const SUPABASE_PUBLISHABLE_KEY: &str = "sb_publishable_ksZfyme84izJY9oTWC4VOw_l9OBXWBp";
+
+/// 会话在 config.yaml 里的存储键（序列化为 JSON 字符串存 Value::String）
+const SESSION_CONFIG_KEY: &str = "cloudSyncSession";
+/// 云端行的数据类型标识，v1 只有玩家备注
+const DATA_TYPE_NOTES: &str = "playerNotes";
+/// access_token 过期前多少秒就触发刷新（留网络往返余量）
+const REFRESH_MARGIN_SECS: u64 = 60;
+
+static HTTP: OnceLock<Client> = OnceLock::new();
+
+/// 云同步专用 HTTP client：正常 TLS 校验（区别于 LCU client 的自签名豁免）
+fn http() -> &'static Client {
+    HTTP.get_or_init(|| {
+        Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("Failed to build cloud sync http client")
+    })
+}
+
+/// Supabase 匿名会话（持久化到 config，跨启动复用同一账号）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CloudSession {
+    access_token: String,
+    refresh_token: String,
+    /// Supabase 用户 UUID，即云端行的 owner_id
+    user_id: String,
+    /// access_token 过期时刻（unix 秒）
+    expires_at: u64,
+}
+
+/// GoTrue /signup 与 /token 响应的公共字段
+#[derive(Debug, Deserialize)]
+struct AuthResponse {
+    access_token: String,
+    refresh_token: String,
+    expires_in: u64,
+    user: AuthUser,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthUser {
+    id: String,
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// access_token 是否临近过期需要刷新
+fn needs_refresh(expires_at: u64, now: u64) -> bool {
+    now + REFRESH_MARGIN_SECS >= expires_at
+}
+
+impl CloudSession {
+    fn from_auth(resp: AuthResponse) -> Self {
+        Self {
+            access_token: resp.access_token,
+            refresh_token: resp.refresh_token,
+            user_id: resp.user.id,
+            expires_at: now_unix() + resp.expires_in,
+        }
+    }
+}
+
+/// 从 config 读持久化会话，没有或解析失败返回 None
+async fn load_session() -> Option<CloudSession> {
+    match config::get_config(SESSION_CONFIG_KEY).await {
+        Ok(Value::String(s)) => serde_json::from_str(&s).ok(),
+        _ => None,
+    }
+}
+
+async fn save_session(session: &CloudSession) -> Result<(), String> {
+    let json = serde_json::to_string(session).map_err(|e| e.to_string())?;
+    config::put_config(SESSION_CONFIG_KEY.to_string(), Value::String(json)).await
+}
+
+/// 匿名注册一个新 Supabase 账号
+async fn sign_in_anonymously() -> Result<CloudSession, String> {
+    let resp = http()
+        .post(format!("{SUPABASE_URL}/auth/v1/signup"))
+        .header("apikey", SUPABASE_PUBLISHABLE_KEY)
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| format!("云端连接失败: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("匿名登录失败: HTTP {}", resp.status()));
+    }
+    let auth: AuthResponse = resp.json().await.map_err(|e| e.to_string())?;
+    Ok(CloudSession::from_auth(auth))
+}
+
+/// 用 refresh_token 换新 access_token
+async fn refresh_session(refresh_token: &str) -> Result<CloudSession, String> {
+    let resp = http()
+        .post(format!(
+            "{SUPABASE_URL}/auth/v1/token?grant_type=refresh_token"
+        ))
+        .header("apikey", SUPABASE_PUBLISHABLE_KEY)
+        .json(&json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+        .map_err(|e| format!("云端连接失败: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("会话刷新失败: HTTP {}", resp.status()));
+    }
+    let auth: AuthResponse = resp.json().await.map_err(|e| e.to_string())?;
+    Ok(CloudSession::from_auth(auth))
+}
+
+/// 取可用会话：无会话→匿名注册；临过期→刷新；刷新失败→重新匿名注册（旧行仍可读到）
+async fn ensure_session() -> Result<CloudSession, String> {
+    let session = match load_session().await {
+        Some(s) if !needs_refresh(s.expires_at, now_unix()) => return Ok(s),
+        Some(s) => match refresh_session(&s.refresh_token).await {
+            Ok(fresh) => fresh,
+            // refresh_token 失效（被回收/项目重置）：放弃旧账号重新注册。
+            // 旧账号写的行不再可写，但 select 全开放，pull 合并仍能读回其数据。
+            Err(_) => sign_in_anonymously().await?,
+        },
+        None => sign_in_anonymously().await?,
+    };
+    save_session(&session).await?;
+    Ok(session)
+}
+
+/// 拉取云端某 puuid 下所有设备的备注 payload 列表（前端负责合并）
+///
+/// # 参数
+/// - `puuid`: 召唤师 PUUID
+///
+/// # 返回值
+/// - `Ok(Vec<Value>)`: 各设备写入的 payload 列表（可能为空）
+/// - `Err(String)`: 网络失败或非 2xx 响应
+#[tauri::command]
+pub async fn cloud_pull_notes(puuid: String) -> Result<Vec<serde_json::Value>, String> {
+    let session = ensure_session().await?;
+    let url = format!(
+        "{SUPABASE_URL}/rest/v1/sync_data?puuid=eq.{puuid}&data_type=eq.{DATA_TYPE_NOTES}&select=payload"
+    );
+    let resp = http()
+        .get(url)
+        .header("apikey", SUPABASE_PUBLISHABLE_KEY)
+        .header("Authorization", format!("Bearer {}", session.access_token))
+        .send()
+        .await
+        .map_err(|e| format!("云端连接失败: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("拉取失败: HTTP {}", resp.status()));
+    }
+    #[derive(Deserialize)]
+    struct Row {
+        payload: serde_json::Value,
+    }
+    let rows: Vec<Row> = resp.json().await.map_err(|e| e.to_string())?;
+    Ok(rows.into_iter().map(|r| r.payload).collect())
+}
+
+/// 把本设备合并后的完整备注表 upsert 到自己的行
+///
+/// # 参数
+/// - `puuid`: 召唤师 PUUID
+/// - `payload`: 合并后的完整备注 JSON
+///
+/// # 返回值
+/// - `Ok(())`: 推送成功
+/// - `Err(String)`: 网络失败或非 2xx 响应
+#[tauri::command]
+pub async fn cloud_push_notes(puuid: String, payload: serde_json::Value) -> Result<(), String> {
+    let session = ensure_session().await?;
+    let url = format!("{SUPABASE_URL}/rest/v1/sync_data?on_conflict=owner_id,puuid,data_type");
+    let body = json!([{
+        "owner_id": session.user_id,
+        "puuid": puuid,
+        "data_type": DATA_TYPE_NOTES,
+        "payload": payload,
+    }]);
+    let resp = http()
+        .post(url)
+        .header("apikey", SUPABASE_PUBLISHABLE_KEY)
+        .header("Authorization", format!("Bearer {}", session.access_token))
+        .header("Prefer", "resolution=merge-duplicates")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("云端连接失败: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("推送失败: HTTP {}", resp.status()));
+    }
+    Ok(())
+}
+
+/// 把文本写入用户经系统对话框选定的路径（导出备份用，路径来自 plugin-dialog）
+///
+/// # 参数
+/// - `path`: 目标文件路径
+/// - `content`: 待写入的文本内容
+#[tauri::command]
+pub async fn save_text_file(path: String, content: String) -> Result<(), String> {
+    std::fs::write(&path, content).map_err(|e| format!("写入文件失败: {e}"))
+}
+
+/// 读取用户经系统对话框选定的文本文件（导入备份用）
+///
+/// # 参数
+/// - `path`: 待读取文件路径
+///
+/// # 返回值
+/// - `Ok(String)`: 文件文本内容
+/// - `Err(String)`: 读取失败（文件不存在/权限/编码问题）
+#[tauri::command]
+pub async fn read_text_file(path: String) -> Result<String, String> {
+    std::fs::read_to_string(&path).map_err(|e| format!("读取文件失败: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_refresh_when_within_margin() {
+        assert!(needs_refresh(100, 50)); // 50 + 60 >= 100
+        assert!(needs_refresh(100, 100));
+    }
+
+    #[test]
+    fn should_not_refresh_when_fresh() {
+        assert!(!needs_refresh(1000, 100)); // 100 + 60 < 1000
+    }
+
+    #[test]
+    fn session_serde_roundtrip() {
+        let s = CloudSession {
+            access_token: "a".into(),
+            refresh_token: "r".into(),
+            user_id: "u".into(),
+            expires_at: 42,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: CloudSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.user_id, "u");
+        assert_eq!(back.expires_at, 42);
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -153,6 +153,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::sgp::get_sgp_regions,
             command::sgp::get_current_sgp_region,
             command::sgp::get_sgp_match_history_by_name,
+            command::cloud_sync::cloud_pull_notes,
+            command::cloud_sync::cloud_push_notes,
+            command::cloud_sync::save_text_file,
+            command::cloud_sync::read_text_file,
         ]);
 
     #[cfg(debug_assertions)]

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_dialog::init())
         .register_asynchronous_uri_scheme_protocol("asset", move |_ctx, request, responder| {
             let path = request.uri().path();
             // path is like /champion/123

--- a/lol-record-analysis-tauri/src/components/Framework.vue
+++ b/lol-record-analysis-tauri/src/components/Framework.vue
@@ -171,6 +171,10 @@ const showCloudNotice = ref(false)
  * `errorReportingConsentShown` 已为 true（老用户，本次启动不会再弹错误上报同意
  * 弹窗）时，本次启动才弹本弹窗；刚回答完错误上报弹窗的新用户，下次启动再弹。
  * 仅主窗口弹，排除 match-detail 子窗口。UI 见 {@link CloudSyncNoticeDialog}。
+ *
+ * 与姊妹函数不同，这里刻意不做 `isConnected` 门控、只用平坦的 1.5s 延时：本弹窗
+ * 是被动告知（看完即关，不要求用户当场做阻塞性决策），即使恰逢首屏加载出现，
+ * 也不至于让人误以为"弹窗导致加载失败"，不值得为它复制一套连接等待逻辑。
  */
 async function maybeShowCloudSyncNotice(): Promise<void> {
   if (isStandaloneDetailWindow.value) return

--- a/lol-record-analysis-tauri/src/components/Framework.vue
+++ b/lol-record-analysis-tauri/src/components/Framework.vue
@@ -3,6 +3,7 @@
     <MatchDetail v-if="isStandaloneDetailWindow" />
     <n-flex v-else vertical size="large">
       <ErrorReportingConsentDialog v-model:show="showConsent" @decide="onConsentDecide" />
+      <CloudSyncNoticeDialog :show="showCloudNotice" @decide="onCloudNoticeDecide" />
       <!-- 整体布局 -->
       <n-layout>
         <!-- 顶部区域 -->
@@ -33,7 +34,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useMessage } from 'naive-ui'
 
@@ -41,6 +42,7 @@ import Header from './Header.vue'
 import SideNavigation from './SideNavigation.vue'
 import MatchDetail from '@renderer/views/MatchDetail.vue'
 import ErrorReportingConsentDialog from '@renderer/components/common/ErrorReportingConsentDialog.vue'
+import CloudSyncNoticeDialog from '@renderer/components/common/CloudSyncNoticeDialog.vue'
 import { useGameState } from '@renderer/composables/useGameState'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { CONFIG_KEYS } from '@renderer/services/configKeys'
@@ -63,6 +65,7 @@ import { CONFIG_KEYS } from '@renderer/services/configKeys'
  */
 
 const route = useRoute()
+const router = useRouter()
 const currentWindow = getCurrentWindow()
 
 /**
@@ -158,8 +161,46 @@ async function onConsentDecide(enabled: boolean): Promise<void> {
   putConfigByIpc(CONFIG_KEYS.errorReportingConsentShown, true).catch(() => {})
 }
 
+/** 是否展示云同步功能告知弹窗 */
+const showCloudNotice = ref(false)
+
+/**
+ * 首次启动（或升级后首次）一次性介绍云同步功能。
+ *
+ * 时机：排在错误上报同意弹窗之后，避免两个模态框叠放——仅当
+ * `errorReportingConsentShown` 已为 true（老用户，本次启动不会再弹错误上报同意
+ * 弹窗）时，本次启动才弹本弹窗；刚回答完错误上报弹窗的新用户，下次启动再弹。
+ * 仅主窗口弹，排除 match-detail 子窗口。UI 见 {@link CloudSyncNoticeDialog}。
+ */
+async function maybeShowCloudSyncNotice(): Promise<void> {
+  if (isStandaloneDetailWindow.value) return
+  try {
+    const noticeShown = await getConfigByIpc<boolean>(CONFIG_KEYS.cloudSyncNoticeShown)
+    if (noticeShown) return
+    const consentShown = await getConfigByIpc<boolean>(CONFIG_KEYS.errorReportingConsentShown)
+    if (!consentShown) return // 本次启动让位给错误上报弹窗
+  } catch {
+    return
+  }
+  window.setTimeout(() => {
+    showCloudNotice.value = true
+  }, 1500)
+}
+
+/**
+ * 处理云同步告知弹窗的用户选择。两种选择都标记"已告知"，之后不再弹；
+ * 仅当选择"去看看"时跳转到设置页的数据与同步页签，不在此处开启任何开关。
+ * @param goto - true 跳转设置页，false 仅关闭
+ */
+function onCloudNoticeDecide(goto: boolean): void {
+  showCloudNotice.value = false
+  putConfigByIpc(CONFIG_KEYS.cloudSyncNoticeShown, true).catch(() => {})
+  if (goto) router.push({ name: 'DataSync' })
+}
+
 onMounted(() => {
   maybeAskErrorReportingConsent()
+  maybeShowCloudSyncNotice()
 })
 
 /**

--- a/lol-record-analysis-tauri/src/components/common/CloudSyncNoticeDialog.vue
+++ b/lol-record-analysis-tauri/src/components/common/CloudSyncNoticeDialog.vue
@@ -5,12 +5,17 @@
     title="新功能：备份与云同步"
     style="max-width: 420px"
     :mask-closable="false"
+    :close-on-esc="false"
   >
     <n-space vertical size="large">
-      <n-text>
-        「我标记过的人」现在支持导出/导入备份文件，以及可选的跨设备云同步（默认关闭）。 可到 设置 →
-        数据与同步 里开启。
-      </n-text>
+      <!-- 两句拆成两个 n-text：避免单个长文本节点被 prettier 折行后，
+           换行在 CJK 之间渲染成可见的半角空隙 -->
+      <n-space vertical :size="4">
+        <n-text>
+          「我标记过的人」现在支持导出/导入备份文件，以及可选的跨设备云同步（默认关闭）。
+        </n-text>
+        <n-text>可到 设置 → 数据与同步 里开启。</n-text>
+      </n-space>
       <n-space justify="end">
         <n-button @click="emit('decide', false)">知道了</n-button>
         <n-button type="primary" @click="emit('decide', true)">去看看</n-button>

--- a/lol-record-analysis-tauri/src/components/common/CloudSyncNoticeDialog.vue
+++ b/lol-record-analysis-tauri/src/components/common/CloudSyncNoticeDialog.vue
@@ -1,0 +1,37 @@
+<template>
+  <n-modal
+    :show="show"
+    preset="card"
+    title="新功能：备份与云同步"
+    style="max-width: 420px"
+    :mask-closable="false"
+  >
+    <n-space vertical size="large">
+      <n-text>
+        「我标记过的人」现在支持导出/导入备份文件，以及可选的跨设备云同步（默认关闭）。 可到 设置 →
+        数据与同步 里开启。
+      </n-text>
+      <n-space justify="end">
+        <n-button @click="emit('decide', false)">知道了</n-button>
+        <n-button type="primary" @click="emit('decide', true)">去看看</n-button>
+      </n-space>
+    </n-space>
+  </n-modal>
+</template>
+
+<script setup lang="ts">
+/**
+ * 云同步功能一次性告知弹窗（视觉组件）
+ *
+ * 只做"告知 + 导航"，不承担开启开关的职责——真正开启云同步必须经过设置页
+ * （数据与同步）里的风险告知弹窗，所以这里的"去看看"只是跳转过去，不在此处
+ * 触碰任何开关。是否已展示过、要不要跳转，均由父组件（Framework）编排与持久化。
+ *
+ * @property show - 是否展示
+ * @emits decide - 用户选择；true=跳转设置页，false=仅关闭。两种选择都视为"已告知"
+ */
+import { NModal, NSpace, NText, NButton } from 'naive-ui'
+
+defineProps<{ show: boolean }>()
+const emit = defineEmits<{ decide: [goto: boolean] }>()
+</script>

--- a/lol-record-analysis-tauri/src/composables/useGameState.ts
+++ b/lol-record-analysis-tauri/src/composables/useGameState.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, readonly, onMounted, onUnmounted } from 'vue'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import router from '../router'
@@ -48,6 +48,15 @@ interface SessionData {
 // 消费者 unmount 时清理。
 
 const isConnected = ref(false)
+
+/**
+ * LCU 连接状态的模块级只读引用。
+ *
+ * 供非组件上下文（如 cloudSync store）watch「连接建立」时机——值由本 composable
+ * 的单例监听器维护（主窗口 Framework 常驻挂载，监听始终在线），无需自建轮询。
+ */
+export const lcuConnected = readonly(isConnected)
+
 const currentPhase = ref<string | null>(null)
 const summoner = ref<GameStateEvent['summoner'] | null>(null)
 const reasonCode = ref<string | null>(null)

--- a/lol-record-analysis-tauri/src/main.ts
+++ b/lol-record-analysis-tauri/src/main.ts
@@ -5,6 +5,7 @@ import naive from 'naive-ui'
 import { createPinia } from 'pinia'
 import { useSettingsStore } from './pinia/setting'
 import { usePlayerNotesStore } from './pinia/playerNotes'
+import { useCloudSyncStore } from './pinia/cloudSync'
 import './global.css'
 import './styles/ai-report.css'
 
@@ -18,5 +19,7 @@ app.use(naive)
 useSettingsStore().initTheme()
 // 载入本地玩家备注（issue #67）
 usePlayerNotesStore().init()
+// 云同步：开关已开启时后台自动同步一次（issue 云同步）
+useCloudSyncStore().init()
 
 app.mount('#app')

--- a/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
@@ -166,6 +166,25 @@ describe('useCloudSyncStore', () => {
       expect(pushes.length).toBe(1)
     })
 
+    it('挂起防抖期间关闭开关,30s 后不再推送(隐私契约)', async () => {
+      vi.useFakeTimers()
+      mockGet.mockResolvedValue(undefined)
+      mockHappyInvoke()
+      const store = useCloudSyncStore()
+      const notesStore = usePlayerNotesStore()
+      await store.setEnabled(true)
+      await flushAsync()
+
+      await notesStore.setNote('a', { note: '1', label: 'normal', gameName: 'A', tagLine: '1' })
+      // 30s 防抖窗口内用户关掉开关：挂起的推送必须被取消
+      await store.setEnabled(false)
+      mockInvoke.mockClear()
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushAsync()
+      expect(mockInvoke).not.toHaveBeenCalled()
+    })
+
     it('未开启时 notes 变更不触发任何云端调用', async () => {
       vi.useFakeTimers()
       mockGet.mockResolvedValue(undefined)

--- a/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
@@ -3,8 +3,9 @@
  * @module pinia/cloudSync
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
+import type { Ref } from 'vue'
 
 vi.mock('@renderer/services/ipc', () => ({
   getConfigByIpc: vi.fn(),
@@ -15,20 +16,52 @@ vi.mock('@tauri-apps/api/event', () => ({
   emit: vi.fn(() => Promise.resolve()),
   listen: vi.fn(() => Promise.resolve(() => {}))
 }))
+// 主窗口判断依赖 window label，jsdom 无 Tauri runtime，默认扮演主窗口
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: vi.fn(() => ({ label: 'main' }))
+}))
+// LCU 连接状态用可写 ref 顶替，便于测试模拟「连接建立」时刻
+vi.mock('@renderer/composables/useGameState', async () => {
+  const { ref } = await import('vue')
+  return { lcuConnected: ref(false) }
+})
 
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { invoke } from '@tauri-apps/api/core'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { lcuConnected } from '@renderer/composables/useGameState'
 import { useCloudSyncStore } from '../cloudSync'
 import { usePlayerNotesStore } from '../playerNotes'
 
 const mockGet = vi.mocked(getConfigByIpc)
 const mockPut = vi.mocked(putConfigByIpc)
 const mockInvoke = vi.mocked(invoke)
+/** mock 后的 lcuConnected 实际是可写 ref，收窄类型便于测试赋值 */
+const mockConnected = lcuConnected as unknown as Ref<boolean>
+
+/** 让 pending 的 promise 链走完（fake timers 不冻结微任务，循环 await 即可放行） */
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+
+/** 常规成功路径的 invoke mock：无云端数据，pull 返回空 */
+function mockHappyInvoke(): void {
+  mockInvoke.mockImplementation(async cmd => {
+    if (cmd === 'get_my_summoner') return { puuid: 'me' }
+    if (cmd === 'cloud_pull_notes') return []
+    return undefined
+  })
+}
 
 describe('useCloudSyncStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockConnected.value = false
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('init 读取开关;未开启时不触发同步', async () => {
@@ -41,11 +74,7 @@ describe('useCloudSyncStore', () => {
 
   it('setEnabled(true) 持久化并触发一次同步', async () => {
     mockGet.mockResolvedValue(undefined)
-    mockInvoke.mockImplementation(async cmd => {
-      if (cmd === 'get_my_summoner') return { puuid: 'me' }
-      if (cmd === 'cloud_pull_notes') return []
-      return undefined
-    })
+    mockHappyInvoke()
     const store = useCloudSyncStore()
     await store.setEnabled(true)
     expect(mockPut).toHaveBeenCalledWith('cloudSyncEnabled', true)
@@ -83,5 +112,71 @@ describe('useCloudSyncStore', () => {
     await expect(store.syncNow()).rejects.toBeTruthy()
     expect(store.lastError).toContain('云端连接失败')
     expect(store.syncing).toBe(false)
+  })
+
+  it('详情窗口 init 只镜像开关,不触发同步(仅主窗口承担)', async () => {
+    vi.mocked(getCurrentWindow).mockReturnValueOnce({
+      label: 'match-detail-42'
+    } as ReturnType<typeof getCurrentWindow>)
+    mockGet.mockResolvedValue(true) // 开关已开启
+    mockHappyInvoke()
+    const store = useCloudSyncStore()
+    await store.init()
+    await flushAsync()
+    expect(store.enabled).toBe(true)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('启动同步失败后,LCU 连接建立时补触发一次', async () => {
+    mockGet.mockResolvedValue(true) // 开关已开启
+    mockInvoke.mockRejectedValue('LCU 未连接')
+    const store = useCloudSyncStore()
+    await store.init()
+    await flushAsync()
+    expect(store.lastSyncAt).toBeNull()
+    expect(store.lastError).toContain('LCU 未连接')
+
+    mockInvoke.mockReset()
+    mockHappyInvoke()
+    mockConnected.value = true
+    await vi.waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('cloud_push_notes', expect.anything())
+    )
+    await vi.waitFor(() => expect(store.lastSyncAt).not.toBeNull())
+  })
+
+  describe('防抖推送(fake timers)', () => {
+    it('开启后连续多次 setNote,30s 后只推送一次(timer 重置生效)', async () => {
+      vi.useFakeTimers()
+      mockGet.mockResolvedValue(undefined)
+      mockHappyInvoke()
+      const store = useCloudSyncStore()
+      const notesStore = usePlayerNotesStore()
+      await store.setEnabled(true)
+      await flushAsync() // 让 setEnabled 触发的立即同步先落定
+      mockInvoke.mockClear()
+
+      await notesStore.setNote('a', { note: '1', label: 'normal', gameName: 'A', tagLine: '1' })
+      await notesStore.setNote('b', { note: '2', label: 'normal', gameName: 'B', tagLine: '2' })
+      await notesStore.setNote('c', { note: '3', label: 'normal', gameName: 'C', tagLine: '3' })
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushAsync()
+      const pushes = mockInvoke.mock.calls.filter(c => c[0] === 'cloud_push_notes')
+      expect(pushes.length).toBe(1)
+    })
+
+    it('未开启时 notes 变更不触发任何云端调用', async () => {
+      vi.useFakeTimers()
+      mockGet.mockResolvedValue(undefined)
+      const store = useCloudSyncStore()
+      await store.init() // enabled=false,防抖 watch 未启动
+      const notesStore = usePlayerNotesStore()
+      await notesStore.setNote('a', { note: '1', label: 'normal', gameName: 'A', tagLine: '1' })
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushAsync()
+      expect(mockInvoke).not.toHaveBeenCalled()
+    })
   })
 })

--- a/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
@@ -105,6 +105,28 @@ describe('useCloudSyncStore', () => {
     expect(store.lastSyncAt).not.toBeNull()
   })
 
+  it('pull 回的畸形 payload（null/数组/字符串）被跳过,合法 payload 正常并入,push 照常', async () => {
+    mockGet.mockResolvedValue(undefined)
+    const notesStore = usePlayerNotesStore()
+    mockInvoke.mockImplementation(async cmd => {
+      if (cmd === 'get_my_summoner') return { puuid: 'me' }
+      if (cmd === 'cloud_pull_notes')
+        // 云端行任何人可插入:jsonb 列可存 null/数组/原始值,容器必须当不可信输入
+        return [
+          null,
+          [1, 2],
+          'str',
+          { p2: { note: 'ok', label: 'friendly', gameName: 'B', tagLine: '2', updatedAt: 5 } }
+        ]
+      return undefined
+    })
+    const store = useCloudSyncStore()
+    await expect(store.syncNow()).resolves.toBeUndefined()
+    expect(notesStore.getNote('p2')?.note).toBe('ok')
+    expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_push_notes')).toBe(true)
+    expect(store.lastError).toBeNull()
+  })
+
   it('同步失败记录 lastError,syncing 复位', async () => {
     mockGet.mockResolvedValue(undefined)
     mockInvoke.mockRejectedValue('云端连接失败: timeout')

--- a/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * useCloudSyncStore 单元测试
+ * @module pinia/cloudSync
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@renderer/services/ipc', () => ({
+  getConfigByIpc: vi.fn(),
+  putConfigByIpc: vi.fn(() => Promise.resolve())
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: vi.fn(() => Promise.resolve()),
+  listen: vi.fn(() => Promise.resolve(() => {}))
+}))
+
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { invoke } from '@tauri-apps/api/core'
+import { useCloudSyncStore } from '../cloudSync'
+import { usePlayerNotesStore } from '../playerNotes'
+
+const mockGet = vi.mocked(getConfigByIpc)
+const mockPut = vi.mocked(putConfigByIpc)
+const mockInvoke = vi.mocked(invoke)
+
+describe('useCloudSyncStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('init 读取开关;未开启时不触发同步', async () => {
+    mockGet.mockResolvedValue(undefined)
+    const store = useCloudSyncStore()
+    await store.init()
+    expect(store.enabled).toBe(false)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('setEnabled(true) 持久化并触发一次同步', async () => {
+    mockGet.mockResolvedValue(undefined)
+    mockInvoke.mockImplementation(async cmd => {
+      if (cmd === 'get_my_summoner') return { puuid: 'me' }
+      if (cmd === 'cloud_pull_notes') return []
+      return undefined
+    })
+    const store = useCloudSyncStore()
+    await store.setEnabled(true)
+    expect(mockPut).toHaveBeenCalledWith('cloudSyncEnabled', true)
+    await vi.waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('cloud_push_notes', expect.anything())
+    )
+  })
+
+  it('syncNow 拉取多设备 payload、合并进 notes、推送合并结果', async () => {
+    mockGet.mockResolvedValue(undefined)
+    const notesStore = usePlayerNotesStore()
+    await notesStore.setNote('p1', { note: 'local', label: 'normal', gameName: 'A', tagLine: '1' })
+    mockInvoke.mockImplementation(async cmd => {
+      if (cmd === 'get_my_summoner') return { puuid: 'me' }
+      if (cmd === 'cloud_pull_notes')
+        return [
+          { p2: { note: 'remote', label: 'friendly', gameName: 'B', tagLine: '2', updatedAt: 5 } }
+        ]
+      return undefined
+    })
+    const store = useCloudSyncStore()
+    await store.syncNow()
+    expect(notesStore.getNote('p2')?.note).toBe('remote')
+    const pushCall = mockInvoke.mock.calls.find(c => c[0] === 'cloud_push_notes')
+    expect(pushCall).toBeTruthy()
+    const payload = (pushCall![1] as { payload: Record<string, unknown> }).payload
+    expect(Object.keys(payload).sort()).toEqual(['p1', 'p2'])
+    expect(store.lastSyncAt).not.toBeNull()
+  })
+
+  it('同步失败记录 lastError,syncing 复位', async () => {
+    mockGet.mockResolvedValue(undefined)
+    mockInvoke.mockRejectedValue('云端连接失败: timeout')
+    const store = useCloudSyncStore()
+    await expect(store.syncNow()).rejects.toBeTruthy()
+    expect(store.lastError).toContain('云端连接失败')
+    expect(store.syncing).toBe(false)
+  })
+})

--- a/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
@@ -228,4 +228,45 @@ describe('usePlayerNotesStore', () => {
       ).rejects.toThrow()
     })
   })
+
+  describe('importNotes', () => {
+    it('合并传入表并落盘,返回统计', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p1', { note: 'local', label: 'normal', gameName: 'A', tagLine: '1' })
+      const localTs = store.getNote('p1')!.updatedAt
+
+      const stats = await store.importNotes({
+        p1: {
+          note: 'stale',
+          label: 'careful',
+          gameName: 'A',
+          tagLine: '1',
+          updatedAt: localTs - 1
+        },
+        p2: { note: 'new', label: 'friendly', gameName: 'B', tagLine: '2', updatedAt: 123 }
+      })
+
+      expect(stats).toEqual({ added: 1, replaced: 0, kept: 1, invalid: 0 })
+      expect(store.getNote('p1')!.note).toBe('local') // 本地更新,未被覆盖
+      expect(store.getNote('p2')!.note).toBe('new')
+    })
+
+    it('无实际变化时不落盘', async () => {
+      const store = usePlayerNotesStore()
+      mockPut.mockClear()
+      const stats = await store.importNotes({})
+      expect(stats.added + stats.replaced).toBe(0)
+      expect(mockPut).not.toHaveBeenCalled()
+    })
+
+    it('导入后 lastTs 不回退:再 setNote 的时间戳大于导入的最大 updatedAt', async () => {
+      const store = usePlayerNotesStore()
+      const future = Date.now() + 60_000
+      await store.importNotes({
+        p9: { note: 'x', label: 'normal', gameName: 'C', tagLine: '3', updatedAt: future }
+      })
+      await store.setNote('p10', { note: 'y', label: 'normal', gameName: 'D', tagLine: '4' })
+      expect(store.getNote('p10')!.updatedAt).toBeGreaterThan(future)
+    })
+  })
 })

--- a/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
@@ -234,6 +234,7 @@ describe('usePlayerNotesStore', () => {
       const store = usePlayerNotesStore()
       await store.setNote('p1', { note: 'local', label: 'normal', gameName: 'A', tagLine: '1' })
       const localTs = store.getNote('p1')!.updatedAt
+      mockPut.mockClear() // 排除 setNote 自身的落盘，确保断言命中的是 importNotes 的 persist
 
       const stats = await store.importNotes({
         p1: {
@@ -249,6 +250,11 @@ describe('usePlayerNotesStore', () => {
       expect(stats).toEqual({ added: 1, replaced: 0, kept: 1, invalid: 0 })
       expect(store.getNote('p1')!.note).toBe('local') // 本地更新,未被覆盖
       expect(store.getNote('p2')!.note).toBe('new')
+      // 正向落盘断言：合并结果（含新增的 p2）确实写盘了
+      expect(mockPut).toHaveBeenCalledWith(
+        'playerNotes',
+        expect.objectContaining({ p2: expect.any(Object) })
+      )
     })
 
     it('无实际变化时不落盘', async () => {

--- a/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
@@ -94,24 +94,104 @@ describe('usePlayerNotesStore', () => {
     })
   })
 
-  describe('removeNote', () => {
-    it('删除内存条目并落盘', async () => {
+  describe('removeNote（墓碑）', () => {
+    it('删除写墓碑而非物理删除：getNote/count/list 不可见，底层 map 留 deleted 条目', async () => {
       const store = usePlayerNotesStore()
-      await store.setNote('p', { note: 'x', label: 'normal', gameName: 'G', tagLine: 'T' })
+      await store.setNote('p', { note: 'x', label: 'careful', gameName: 'G', tagLine: 'T' })
       mockPut.mockClear()
 
       await store.removeNote('p')
 
+      // 对消费者透明：读不到、数不到、列不出
       expect(store.getNote('p')).toBeUndefined()
+      expect(store.count).toBe(0)
+      expect(store.list.length).toBe(0)
+      // 底层 map 保留墓碑（同步时随合并传播删除），内容字段已清空
+      const tomb = store.notes['p']
+      expect(tomb?.deleted).toBe(true)
+      expect(tomb?.note).toBe('')
+      expect(tomb?.encounters).toBeUndefined()
+      // 墓碑随整表落盘
       expect(mockPut).toHaveBeenCalledWith(
         'playerNotes',
-        expect.not.objectContaining({ p: expect.anything() })
+        expect.objectContaining({ p: expect.objectContaining({ deleted: true }) })
       )
     })
 
-    it('删除不存在的 puuid 不报错', async () => {
+    it('删除不存在的 puuid 不报错、不写墓碑', async () => {
       const store = usePlayerNotesStore()
+      mockPut.mockClear()
       await expect(store.removeNote('ghost')).resolves.not.toThrow()
+      expect(store.notes['ghost']).toBeUndefined()
+      expect(mockPut).not.toHaveBeenCalled()
+    })
+
+    it('墓碑传播：并入更旧的活备注时墓碑赢（kept），删除不被复活', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', { note: 'x', label: 'normal', gameName: 'G', tagLine: 'T' })
+      await store.removeNote('p')
+      const tombTs = store.notes['p'].updatedAt
+
+      // 模拟云端另一设备残留的旧活备注（updatedAt < 墓碑）
+      const stats = await store.importNotes({
+        p: { note: 'stale', label: 'careful', gameName: 'G', tagLine: 'T', updatedAt: tombTs - 1 }
+      })
+
+      expect(stats.kept).toBe(1)
+      expect(stats.added + stats.replaced).toBe(0)
+      expect(store.getNote('p')).toBeUndefined()
+      expect(store.notes['p'].deleted).toBe(true)
+    })
+
+    it('删除后重新标记：setNote 覆盖墓碑，getNote 恢复返回', async () => {
+      const store = usePlayerNotesStore()
+      await store.setNote('p', { note: 'x', label: 'normal', gameName: 'G', tagLine: 'T' })
+      await store.removeNote('p')
+
+      await store.setNote('p', { note: '回归', label: 'friendly', gameName: 'G', tagLine: 'T' })
+
+      expect(store.getNote('p')?.note).toBe('回归')
+      expect(store.notes['p'].deleted).toBeUndefined()
+      expect(store.count).toBe(1)
+    })
+  })
+
+  describe('墓碑 GC（loadFromConfig）', () => {
+    it('载入时清理超过 30 天的旧墓碑，保留新墓碑与活备注', async () => {
+      const now = Date.now()
+      const DAY = 24 * 60 * 60 * 1000
+      mockGet.mockResolvedValue({
+        oldTomb: {
+          note: '',
+          label: 'normal',
+          gameName: 'O',
+          tagLine: '1',
+          updatedAt: now - 31 * DAY,
+          deleted: true
+        },
+        freshTomb: {
+          note: '',
+          label: 'normal',
+          gameName: 'F',
+          tagLine: '2',
+          updatedAt: now - 1 * DAY,
+          deleted: true
+        },
+        live: {
+          note: '很老但没删',
+          label: 'careful',
+          gameName: 'L',
+          tagLine: '3',
+          updatedAt: now - 100 * DAY
+        }
+      })
+      const store = usePlayerNotesStore()
+      await store.init()
+
+      expect(store.notes['oldTomb']).toBeUndefined()
+      expect(store.notes['freshTomb']?.deleted).toBe(true)
+      // 活备注不受 TTL 影响，再老也保留
+      expect(store.getNote('live')?.note).toBe('很老但没删')
     })
   })
 

--- a/lol-record-analysis-tauri/src/pinia/cloudSync.ts
+++ b/lol-record-analysis-tauri/src/pinia/cloudSync.ts
@@ -152,6 +152,12 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
       const payloads = await invoke<PlayerNotesMap[]>('cloud_pull_notes', { puuid: me.puuid })
       const notesStore = usePlayerNotesStore()
       for (const payload of payloads) {
+        // 云端行任何人可插入（spec 接受的开放写入面），容器形状必须当不可信输入
+        // 过滤——jsonb 列可存 JSON null/数组/原始值，直接喂 importNotes 的
+        // Object.entries 会抛 TypeError，该 puuid 的同步从此永久失败（受害者
+        // 还删不掉毒行）。与 DataSync.vue 的 isBackupFile 容器校验对称；
+        // 条目级校验在 mergeNotesMaps 的 isValidNote，这里只管容器。
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) continue
         await notesStore.importNotes(payload)
       }
       await invoke('cloud_push_notes', { puuid: me.puuid, payload: notesStore.notes })

--- a/lol-record-analysis-tauri/src/pinia/cloudSync.ts
+++ b/lol-record-analysis-tauri/src/pinia/cloudSync.ts
@@ -1,30 +1,40 @@
 /**
- * 云同步编排 store
- *
- * 职责：开关状态 + 同步流程编排（取 puuid → 拉取 → 并入 notes store → 推送）。
- * 合并语义在 utils/mergePlayerNotes，网络在 Rust command，本 store 不碰两者细节。
- * 触发时机：app 启动（开关开时）、设置页手动、开关打开时、备注变更后防抖推送。
- *
+ * 云同步编排 store（职责与触发时机详见下方 store 定义处 JSDoc）
  * @module pinia/cloudSync
  */
 
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { CONFIG_KEYS } from '@renderer/services/configKeys'
+import { lcuConnected } from '@renderer/composables/useGameState'
 import { usePlayerNotesStore } from './playerNotes'
 import type { PlayerNotesMap } from '@renderer/types/domain/playerNote'
 
 /** 备注变更后自动推送的防抖窗口（毫秒） */
 const AUTO_PUSH_DEBOUNCE_MS = 30_000
 
+/** 防抖到期时若一次同步尚在途，延迟重试的间隔（毫秒） */
+const AUTO_PUSH_RETRY_MS = 5_000
+
+/**
+ * 是否为独立战绩详情窗口（label 形如 `match-detail-*`，见 detailWindow.ts）。
+ * 每个 WebviewWindow 都会执行 main.ts，同步职责只由主窗口承担——
+ * 否则开 N 个详情窗口就是 N 份 pull+push，一次备注广播会调度 N 个防抖同步。
+ */
+function isStandaloneDetailWindow(): boolean {
+  return getCurrentWindow().label.startsWith('match-detail-')
+}
+
 /**
  * 云同步编排 store
  *
  * 职责：开关状态 + 同步流程编排（取 puuid → 拉取 → 并入 notes store → 推送）。
  * 合并语义在 utils/mergePlayerNotes，网络在 Rust command，本 store 不碰两者细节。
- * 触发时机：app 启动（开关开时）、设置页手动、开关打开时、备注变更后防抖推送。
+ * 触发时机：app 启动（开关开时）、LCU 连接建立后补触发、设置页手动、
+ * 开关打开时、备注变更后防抖推送。同步流程只在主窗口跑（详情窗口只读开关）。
  *
  * 注意：云端拉取必须发生在 importNotes 之外——importNotes 的读-合-写临界区是
  * 同步的，往里插 await 会打开丢更新窗口。
@@ -41,10 +51,24 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
 
   let autoPushStarted = false
   let autoPushTimer: ReturnType<typeof setTimeout> | null = null
+  let connectionWatchStarted = false
+
+  /**
+   * 防抖到期后的推送执行体。
+   * 若此刻一次同步尚在途，5 秒后重试——否则 in-flight 同步在 importNotes 前
+   * 失败时，本次变更的推送会被 skip-when-syncing 永久搁浅。
+   */
+  function flushAutoPush(): void {
+    if (syncing.value) {
+      autoPushTimer = setTimeout(flushAutoPush, AUTO_PUSH_RETRY_MS)
+      return
+    }
+    syncNow().catch(() => {})
+  }
 
   /** 备注变更后延迟推送（合并短时间内的连续编辑，避免每次落盘都打云端） */
   function startAutoPush(): void {
-    if (autoPushStarted) return
+    if (autoPushStarted || isStandaloneDetailWindow()) return
     autoPushStarted = true
     const notesStore = usePlayerNotesStore()
     // notes 的写路径都是整体替换引用（setNote/removeNote/importNotes），浅 watch 足够
@@ -53,16 +77,32 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
       () => {
         if (!enabled.value) return
         if (autoPushTimer) clearTimeout(autoPushTimer)
-        autoPushTimer = setTimeout(() => {
-          if (!syncing.value) syncNow().catch(() => {})
-        }, AUTO_PUSH_DEBOUNCE_MS)
+        autoPushTimer = setTimeout(flushAutoPush, AUTO_PUSH_DEBOUNCE_MS)
       }
     )
   }
 
   /**
-   * 启动时初始化：读开关；已开启则后台同步一次（失败静默，不阻塞启动）。
-   * 由 main.ts 在 app 启动时调用。
+   * LCU 连接建立后补触发一次同步。
+   *
+   * init() 跑在 webview 启动时，此刻 LoL 客户端很可能还没开（先开工具后开游戏
+   * 是常态），启动同步会静默失败；这里 watch 连接状态，连上且本次启动尚未
+   * 成功同步过（lastSyncAt 为空）时补一次。无轮询——lcuConnected 由后端
+   * game-state-changed 事件驱动。
+   */
+  function startConnectionRetrigger(): void {
+    if (connectionWatchStarted) return
+    connectionWatchStarted = true
+    watch(lcuConnected, connected => {
+      if (connected && enabled.value && lastSyncAt.value === null) {
+        syncNow().catch(() => {})
+      }
+    })
+  }
+
+  /**
+   * 启动时初始化：读开关；主窗口且已开启则后台同步一次（失败静默，不阻塞启动）。
+   * 由 main.ts 在 app 启动时调用（每个窗口都会执行，但同步只在主窗口注册/触发）。
    */
   async function init(): Promise<void> {
     try {
@@ -70,6 +110,9 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     } catch {
       enabled.value = false
     }
+    // 详情窗口只镜像开关状态，不承担同步（见 isStandaloneDetailWindow）
+    if (isStandaloneDetailWindow()) return
+    startConnectionRetrigger()
     if (enabled.value) {
       startAutoPush()
       syncNow().catch(() => {})

--- a/lol-record-analysis-tauri/src/pinia/cloudSync.ts
+++ b/lol-record-analysis-tauri/src/pinia/cloudSync.ts
@@ -55,10 +55,12 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
 
   /**
    * 防抖到期后的推送执行体。
+   * 开关已被关掉时直接放弃——用户经风险弹窗明确关闭后，挂起的推送不能再发出。
    * 若此刻一次同步尚在途，5 秒后重试——否则 in-flight 同步在 importNotes 前
    * 失败时，本次变更的推送会被 skip-when-syncing 永久搁浅。
    */
   function flushAutoPush(): void {
+    if (!enabled.value) return
     if (syncing.value) {
       autoPushTimer = setTimeout(flushAutoPush, AUTO_PUSH_RETRY_MS)
       return
@@ -129,6 +131,10 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     if (v) {
       startAutoPush()
       syncNow().catch(() => {})
+    } else if (autoPushTimer) {
+      // 关闭开关时取消挂起的防抖推送，避免关掉后 timer 到点仍发出一次同步
+      clearTimeout(autoPushTimer)
+      autoPushTimer = null
     }
   }
 

--- a/lol-record-analysis-tauri/src/pinia/cloudSync.ts
+++ b/lol-record-analysis-tauri/src/pinia/cloudSync.ts
@@ -1,0 +1,119 @@
+/**
+ * 云同步编排 store
+ *
+ * 职责：开关状态 + 同步流程编排（取 puuid → 拉取 → 并入 notes store → 推送）。
+ * 合并语义在 utils/mergePlayerNotes，网络在 Rust command，本 store 不碰两者细节。
+ * 触发时机：app 启动（开关开时）、设置页手动、开关打开时、备注变更后防抖推送。
+ *
+ * @module pinia/cloudSync
+ */
+
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { CONFIG_KEYS } from '@renderer/services/configKeys'
+import { usePlayerNotesStore } from './playerNotes'
+import type { PlayerNotesMap } from '@renderer/types/domain/playerNote'
+
+/** 备注变更后自动推送的防抖窗口（毫秒） */
+const AUTO_PUSH_DEBOUNCE_MS = 30_000
+
+/**
+ * 云同步编排 store
+ *
+ * 职责：开关状态 + 同步流程编排（取 puuid → 拉取 → 并入 notes store → 推送）。
+ * 合并语义在 utils/mergePlayerNotes，网络在 Rust command，本 store 不碰两者细节。
+ * 触发时机：app 启动（开关开时）、设置页手动、开关打开时、备注变更后防抖推送。
+ *
+ * 注意：云端拉取必须发生在 importNotes 之外——importNotes 的读-合-写临界区是
+ * 同步的，往里插 await 会打开丢更新窗口。
+ */
+export const useCloudSyncStore = defineStore('cloudSync', () => {
+  /** 云同步开关（镜像 config，真实来源是 config.yaml） */
+  const enabled = ref(false)
+  /** 是否正在同步（防重入 + UI 转圈） */
+  const syncing = ref(false)
+  /** 最近一次成功同步时刻（毫秒），仅内存，重启清零 */
+  const lastSyncAt = ref<number | null>(null)
+  /** 最近一次失败信息，成功后清空 */
+  const lastError = ref<string | null>(null)
+
+  let autoPushStarted = false
+  let autoPushTimer: ReturnType<typeof setTimeout> | null = null
+
+  /** 备注变更后延迟推送（合并短时间内的连续编辑，避免每次落盘都打云端） */
+  function startAutoPush(): void {
+    if (autoPushStarted) return
+    autoPushStarted = true
+    const notesStore = usePlayerNotesStore()
+    // notes 的写路径都是整体替换引用（setNote/removeNote/importNotes），浅 watch 足够
+    watch(
+      () => notesStore.notes,
+      () => {
+        if (!enabled.value) return
+        if (autoPushTimer) clearTimeout(autoPushTimer)
+        autoPushTimer = setTimeout(() => {
+          if (!syncing.value) syncNow().catch(() => {})
+        }, AUTO_PUSH_DEBOUNCE_MS)
+      }
+    )
+  }
+
+  /**
+   * 启动时初始化：读开关；已开启则后台同步一次（失败静默，不阻塞启动）。
+   * 由 main.ts 在 app 启动时调用。
+   */
+  async function init(): Promise<void> {
+    try {
+      enabled.value = (await getConfigByIpc<boolean>(CONFIG_KEYS.cloudSyncEnabled)) === true
+    } catch {
+      enabled.value = false
+    }
+    if (enabled.value) {
+      startAutoPush()
+      syncNow().catch(() => {})
+    }
+  }
+
+  /**
+   * 切换云同步开关（风险告知弹窗的确认逻辑在设置页，进到这里视为已确认）。
+   * @param v - 开/关
+   */
+  async function setEnabled(v: boolean): Promise<void> {
+    enabled.value = v
+    await putConfigByIpc(CONFIG_KEYS.cloudSyncEnabled, v)
+    if (v) {
+      startAutoPush()
+      syncNow().catch(() => {})
+    }
+  }
+
+  /**
+   * 执行一次完整同步：当前召唤师 puuid → 拉取所有设备的行 → 逐份并入本地
+   * （updatedAt 新者赢）→ 把合并结果推回本设备的行。
+   * @throws 网络/LCU 未连接等失败，错误已记入 lastError
+   */
+  async function syncNow(): Promise<void> {
+    if (syncing.value) return
+    syncing.value = true
+    lastError.value = null
+    try {
+      const me = await invoke<{ puuid: string }>('get_my_summoner')
+      const payloads = await invoke<PlayerNotesMap[]>('cloud_pull_notes', { puuid: me.puuid })
+      const notesStore = usePlayerNotesStore()
+      for (const payload of payloads) {
+        await notesStore.importNotes(payload)
+      }
+      await invoke('cloud_push_notes', { puuid: me.puuid, payload: notesStore.notes })
+      lastSyncAt.value = Date.now()
+    } catch (e) {
+      lastError.value = String(e)
+      throw e
+    } finally {
+      syncing.value = false
+    }
+  }
+
+  return { enabled, syncing, lastSyncAt, lastError, init, setEnabled, syncNow }
+})

--- a/lol-record-analysis-tauri/src/pinia/playerNotes.ts
+++ b/lol-record-analysis-tauri/src/pinia/playerNotes.ts
@@ -162,16 +162,16 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
   }
 
   /**
-   * 批量并入外部备注表(手动导入 / 云端拉取共用),同 puuid 按 updatedAt 新者赢。
-   * 无实际变化(仅 kept/invalid)时不落盘、不广播。
+   * 批量并入外部备注表（手动导入 / 云端拉取共用），同 puuid 按 updatedAt 新者赢。
+   * 无实际变化（仅 kept/invalid）时不落盘、不广播。
    * @param incoming - 外部备注表
-   * @returns 合并统计,供 UI 反馈
+   * @returns 合并统计，供 UI 反馈
    */
   async function importNotes(incoming: PlayerNotesMap): Promise<MergeStats> {
     const { merged, stats } = mergeNotesMaps(notes.value, incoming)
     if (stats.added === 0 && stats.replaced === 0) return stats
     notes.value = merged
-    // 与 loadFromConfig 同理:把单调时钟顶到并入后的最大 updatedAt,防止后续写入回退
+    // 与 loadFromConfig 同理：把单调时钟顶到并入后的最大 updatedAt，防止后续写入回退
     for (const note of Object.values(merged)) {
       if (note.updatedAt > lastTs) lastTs = note.updatedAt
     }

--- a/lol-record-analysis-tauri/src/pinia/playerNotes.ts
+++ b/lol-record-analysis-tauri/src/pinia/playerNotes.ts
@@ -21,6 +21,16 @@ const NOTES_CHANGED_EVENT = 'player-notes-changed'
 /** 单个玩家最多保留的遇见记录条数（最近在前，超出截断） */
 const MAX_ENCOUNTERS = 20
 
+/**
+ * 墓碑保留时长：30 天。
+ *
+ * 墓碑（`deleted: true` 条目）的唯一使命是把"删除"随合并传播到云端与其他
+ * 设备，之后就是死重——不 GC 的话 map 只增不减。30 天窗口的取值权衡：
+ * 太短则长期离线的设备错过删除传播（回线后其旧活备注会复活该条目）；
+ * 太长则墓碑堆积。30 天足以覆盖绝大多数设备的回线周期。
+ */
+const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
 /** 时间字符串转毫秒，无效值归零（用于遇见记录排序） */
 function toTimestamp(date: string): number {
   const t = new Date(date).getTime()
@@ -68,21 +78,34 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
     return lastTs
   }
 
-  /** 备注总数 */
-  const count = computed(() => Object.keys(notes.value).length)
+  /** 备注总数（不含墓碑——已删除条目对消费者视同不存在） */
+  const count = computed(() => Object.values(notes.value).filter(n => !n.deleted).length)
 
-  /** 列表视图：按更新时间倒序的 `{ puuid, ...note }` 数组，供设置页表格使用 */
+  /** 列表视图：按更新时间倒序的 `{ puuid, ...note }` 数组（不含墓碑），供设置页表格使用 */
   const list = computed(() =>
     Object.entries(notes.value)
+      .filter(([, note]) => !note.deleted)
       .map(([puuid, note]) => ({ puuid, ...note }))
       .sort((a, b) => b.updatedAt - a.updatedAt)
   )
 
-  /** 从 config 读取备注到内存（不注册监听，供 init 与跨窗口事件复用） */
+  /**
+   * 从 config 读取备注到内存（不注册监听，供 init 与跨窗口事件复用）。
+   *
+   * 载入时顺带做墓碑 GC：`deleted` 且超过 {@link TOMBSTONE_TTL_MS} 的条目
+   * 不再进内存（防 map 无限增长）。只过滤不落盘——下次任何写操作的整表
+   * persist 会自然把瘦身结果带到盘上，启动路径不多打一次 IPC 写。
+   */
   async function loadFromConfig(): Promise<void> {
     try {
       const saved = await getConfigByIpc<PlayerNotesMap>(STORAGE_KEY)
-      notes.value = saved && typeof saved === 'object' ? saved : {}
+      const loaded = saved && typeof saved === 'object' ? saved : {}
+      const expireBefore = Date.now() - TOMBSTONE_TTL_MS
+      notes.value = Object.fromEntries(
+        Object.entries(loaded).filter(
+          ([, note]) => !(note.deleted && note.updatedAt < expireBefore)
+        )
+      )
       // 跨窗口 / 重载后保持单调时钟不回退：把 lastTs 顶到已有最大 updatedAt。
       // 否则 reload 后 lastTs 归 0，下次保存可能生成比现有更小的时间戳，
       // 破坏列表"最近更新优先"的排序。
@@ -117,10 +140,11 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
   /**
    * 读取某玩家的备注
    * @param puuid - 玩家唯一标识
-   * @returns 备注，不存在返回 undefined
+   * @returns 备注；不存在或已删除（墓碑）返回 undefined，墓碑对消费者透明
    */
   function getNote(puuid: string): PlayerNote | undefined {
-    return notes.value[puuid]
+    const note = notes.value[puuid]
+    return note && !note.deleted ? note : undefined
   }
 
   /**
@@ -150,20 +174,39 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
   }
 
   /**
-   * 删除某玩家的备注，并整体落盘。不存在时静默返回。
+   * 删除某玩家的备注，并整体落盘。不存在（或已是墓碑）时静默返回。
+   *
+   * 不做物理删除而是写墓碑：直接 delete key 的话，云同步 pull 回的旧数据
+   * （本机上次推送的、或其他设备的行）里还有这条，合并会把它当"新增"复活，
+   * push 又推回云端——删除永远传播不出去。墓碑带上新 updatedAt，在
+   * "新者赢"合并里压过所有旧活备注，删除得以跨设备生效；之后若用户重新
+   * 标记同一玩家，新 setNote 的 updatedAt 更新，又会自然覆盖墓碑。
+   * 内容字段清空（note 空串、encounters 丢弃——隐私 + 瘦身），仅保留
+   * gameName/tagLine 便于调试排查。
    * @param puuid - 玩家唯一标识
    */
   async function removeNote(puuid: string): Promise<void> {
-    if (!(puuid in notes.value)) return
-    const next = { ...notes.value }
-    delete next[puuid]
-    notes.value = next
+    const existing = notes.value[puuid]
+    if (!existing || existing.deleted) return
+    notes.value = {
+      ...notes.value,
+      [puuid]: {
+        note: '',
+        label: 'normal',
+        gameName: existing.gameName,
+        tagLine: existing.tagLine,
+        updatedAt: nextTs(),
+        deleted: true
+      }
+    }
     await persist()
   }
 
   /**
    * 批量并入外部备注表（手动导入 / 云端拉取共用），同 puuid 按 updatedAt 新者赢。
    * 无实际变化（仅 kept/invalid）时不落盘、不广播。
+   * 墓碑就是普通条目，走同一套"新者赢"——较新的墓碑压过旧活备注（删除传播），
+   * 较新的活备注压过旧墓碑（删除后重新标记），无需特判。
    * @param incoming - 外部备注表
    * @returns 合并统计，供 UI 反馈
    */

--- a/lol-record-analysis-tauri/src/pinia/playerNotes.ts
+++ b/lol-record-analysis-tauri/src/pinia/playerNotes.ts
@@ -4,6 +4,7 @@ import { emit, listen } from '@tauri-apps/api/event'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import type { NoteLabel, PlayerNote, PlayerNotesMap } from '@renderer/types/domain/playerNote'
 import type { OneGamePlayer } from '@renderer/types/domain/analysis'
+import { mergeNotesMaps, type MergeStats } from '@renderer/utils/mergePlayerNotes'
 
 /** 持久化 key，复用 config 系统，无需新增 Rust command */
 const STORAGE_KEY = 'playerNotes'
@@ -161,6 +162,24 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
   }
 
   /**
+   * 批量并入外部备注表(手动导入 / 云端拉取共用),同 puuid 按 updatedAt 新者赢。
+   * 无实际变化(仅 kept/invalid)时不落盘、不广播。
+   * @param incoming - 外部备注表
+   * @returns 合并统计,供 UI 反馈
+   */
+  async function importNotes(incoming: PlayerNotesMap): Promise<MergeStats> {
+    const { merged, stats } = mergeNotesMaps(notes.value, incoming)
+    if (stats.added === 0 && stats.replaced === 0) return stats
+    notes.value = merged
+    // 与 loadFromConfig 同理:把单调时钟顶到并入后的最大 updatedAt,防止后续写入回退
+    for (const note of Object.values(merged)) {
+      if (note.updatedAt > lastTs) lastTs = note.updatedAt
+    }
+    await persist()
+    return stats
+  }
+
+  /**
    * 整表落盘，并广播变更通知其他窗口重载。
    * 落盘失败时**重新抛出**——否则 setNote/removeNote 即使写盘失败也会 resolve，
    * 上层 try/catch 永远进不去，用户看到"已保存/已删除"却实际未持久化。
@@ -176,5 +195,5 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
     emit(NOTES_CHANGED_EVENT).catch(() => {})
   }
 
-  return { notes, count, list, init, getNote, setNote, removeNote }
+  return { notes, count, list, init, getNote, setNote, removeNote, importNotes }
 })

--- a/lol-record-analysis-tauri/src/router/index.ts
+++ b/lol-record-analysis-tauri/src/router/index.ts
@@ -61,6 +61,12 @@ const routes: Array<RouteRecordRaw> = [
         meta: { title: '我标记过的人' }
       },
       {
+        path: '/Settings/DataSync',
+        name: 'DataSync',
+        component: () => import('@renderer/views/settings/DataSync.vue'),
+        meta: { title: '数据与同步' }
+      },
+      {
         path: '/Settings/About',
         name: 'About',
         component: () => import('@renderer/views/settings/About.vue'),

--- a/lol-record-analysis-tauri/src/services/configKeys.ts
+++ b/lol-record-analysis-tauri/src/services/configKeys.ts
@@ -21,6 +21,10 @@ export const CONFIG_KEYS = {
   dashscopeApiKey: 'dashscopeApiKey',
   /** 玩家备注是否随 AI 分析请求发送到云端模型（默认开） */
   aiUsePlayerNotes: 'aiUsePlayerNotes',
+  /** 云同步开关（默认关，开启需经风险告知弹窗） */
+  cloudSyncEnabled: 'cloudSyncEnabled',
+  /** 是否已向用户介绍过云同步功能（首次启动一次性弹窗用） */
+  cloudSyncNoticeShown: 'cloudSyncNoticeShown',
   /**
    * 游戏安装根目录（免 WeGame 一键启动用）。
    *

--- a/lol-record-analysis-tauri/src/types/domain/playerNote.ts
+++ b/lol-record-analysis-tauri/src/types/domain/playerNote.ts
@@ -29,6 +29,11 @@ export type NoteLabel = 'friendly' | 'normal' | 'careful' | 'blacklist'
  * @property updatedAt - 最后更新时间（毫秒时间戳）
  * @property encounters - 遇见记录（在哪些对局里标记/碰到过 ta），按 gameId 去重、
  *   最近在前，复刻"遇见过"效果。复用 {@link OneGamePlayer} 以便直接用 MettingPlayersCard 渲染。
+ * @property deleted - 墓碑：删除标记。物理删除会被云同步的合并"复活"（云端/其他
+ *   设备仍持有旧活备注，合并时被当成新增并回），所以删除改写成墓碑条目——
+ *   随"updatedAt 新者赢"的合并自然传播，使删除在多设备间生效。墓碑的内容
+ *   字段已清空（note 空串、encounters 丢弃），仅保留 gameName/tagLine 便于调试。
+ *   store 的 getNote/count/list 对墓碑透明（视同不存在）。
  */
 export interface PlayerNote {
   note: string
@@ -37,6 +42,7 @@ export interface PlayerNote {
   tagLine: string
   updatedAt: number
   encounters?: OneGamePlayer[]
+  deleted?: true
 }
 
 /**

--- a/lol-record-analysis-tauri/src/utils/__tests__/mergePlayerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/utils/__tests__/mergePlayerNotes.spec.ts
@@ -31,10 +31,48 @@ describe('mergeNotesMaps', () => {
   })
 
   it('非法条目跳过并计入 invalid,不污染结果', () => {
-    const bad = { p2: null, p3: 'str', p4: { note: 'no-ts', label: 'normal' } } as unknown as PlayerNotesMap
+    const bad = {
+      p2: null,
+      p3: 'str',
+      p4: { note: 'no-ts', label: 'normal' }
+    } as unknown as PlayerNotesMap
     const { merged, stats } = mergeNotesMaps({}, bad)
     expect(Object.keys(merged)).toHaveLength(0)
     expect(stats.invalid).toBe(3)
+  })
+
+  it('NaN updatedAt 计入 invalid(非有限时间戳一旦并入将永远无法被替换)', () => {
+    const { merged, stats } = mergeNotesMaps({}, { p1: note(NaN) })
+    expect(Object.keys(merged)).toHaveLength(0)
+    expect(stats.invalid).toBe(1)
+  })
+
+  it('toString 等原型链键的合法 note 正常 added', () => {
+    const { merged, stats } = mergeNotesMaps({}, { toString: note(100, 'proto-key') })
+    expect(stats).toEqual({ added: 1, replaced: 0, kept: 0, invalid: 0 })
+    expect(merged.toString).toEqual(note(100, 'proto-key'))
+  })
+
+  it('__proto__ 键计入 invalid 且不污染 Object.prototype', () => {
+    const incoming = JSON.parse(`{"__proto__": ${JSON.stringify(note(100))}}`) as PlayerNotesMap
+    const { merged, stats } = mergeNotesMaps({}, incoming)
+    expect(stats.invalid).toBe(1)
+    expect(Object.keys(merged)).toHaveLength(0)
+    expect(({} as Record<string, unknown>).note).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('note')
+  })
+
+  it('混合合法+非法条目,invalid 不影响 added/replaced 计数', () => {
+    const incoming = {
+      p1: note(200, 'newer'),
+      p2: note(100, 'fresh'),
+      p3: null,
+      p4: note(NaN)
+    } as unknown as PlayerNotesMap
+    const { merged, stats } = mergeNotesMaps({ p1: note(100, 'old') }, incoming)
+    expect(stats).toEqual({ added: 1, replaced: 1, kept: 0, invalid: 2 })
+    expect(merged.p1.note).toBe('newer')
+    expect(merged.p2.note).toBe('fresh')
   })
 
   it('不修改入参(纯函数)', () => {

--- a/lol-record-analysis-tauri/src/utils/__tests__/mergePlayerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/utils/__tests__/mergePlayerNotes.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { mergeNotesMaps } from '../mergePlayerNotes'
+import type { PlayerNotesMap } from '@renderer/types/domain/playerNote'
+
+function note(updatedAt: number, text = 'x'): PlayerNotesMap[string] {
+  return { note: text, label: 'normal', gameName: 'A', tagLine: '1', updatedAt }
+}
+
+describe('mergeNotesMaps', () => {
+  it('新 puuid 直接加入,计入 added', () => {
+    const { merged, stats } = mergeNotesMaps({}, { p1: note(100) })
+    expect(merged.p1.updatedAt).toBe(100)
+    expect(stats).toEqual({ added: 1, replaced: 0, kept: 0, invalid: 0 })
+  })
+
+  it('同 puuid 时间戳新者赢', () => {
+    const { merged, stats } = mergeNotesMaps({ p1: note(100, 'old') }, { p1: note(200, 'new') })
+    expect(merged.p1.note).toBe('new')
+    expect(stats.replaced).toBe(1)
+  })
+
+  it('同 puuid 传入更旧则保留本地,计入 kept', () => {
+    const { merged, stats } = mergeNotesMaps({ p1: note(200, 'local') }, { p1: note(100, 'stale') })
+    expect(merged.p1.note).toBe('local')
+    expect(stats.kept).toBe(1)
+  })
+
+  it('时间戳相等保留本地(避免无谓覆盖)', () => {
+    const { stats } = mergeNotesMaps({ p1: note(100, 'local') }, { p1: note(100, 'remote') })
+    expect(stats.kept).toBe(1)
+  })
+
+  it('非法条目跳过并计入 invalid,不污染结果', () => {
+    const bad = { p2: null, p3: 'str', p4: { note: 'no-ts', label: 'normal' } } as unknown as PlayerNotesMap
+    const { merged, stats } = mergeNotesMaps({}, bad)
+    expect(Object.keys(merged)).toHaveLength(0)
+    expect(stats.invalid).toBe(3)
+  })
+
+  it('不修改入参(纯函数)', () => {
+    const base = { p1: note(100) }
+    mergeNotesMaps(base, { p2: note(50) })
+    expect(Object.keys(base)).toEqual(['p1'])
+  })
+})

--- a/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
+++ b/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
@@ -1,0 +1,58 @@
+/**
+ * 玩家备注合并(云同步 / 手动导入共用)
+ *
+ * 纯函数:同 puuid 按 `updatedAt` 新者赢,相等保留本地;非法条目跳过。
+ *
+ * @module utils/mergePlayerNotes
+ */
+import type { PlayerNote, PlayerNotesMap } from '@renderer/types/domain/playerNote'
+
+/** 合并统计,供导入/同步完成后的 UI 反馈 */
+export interface MergeStats {
+  /** 本地原本没有、新增的条数 */
+  added: number
+  /** 传入更新、覆盖本地的条数 */
+  replaced: number
+  /** 本地更新(或同龄)、保持不变的条数 */
+  kept: number
+  /** 结构非法被跳过的条数 */
+  invalid: number
+}
+
+/** 最低限度的结构校验:对象 + 数值 updatedAt + 字符串 label(防导入损坏文件) */
+function isValidNote(v: unknown): v is PlayerNote {
+  if (!v || typeof v !== 'object') return false
+  const n = v as Partial<PlayerNote>
+  return typeof n.updatedAt === 'number' && typeof n.label === 'string'
+}
+
+/**
+ * 合并两张备注表,不修改入参。
+ * @param base - 本地表(冲突时的"守方")
+ * @param incoming - 传入表(导入文件 / 云端拉取)
+ * @returns 合并结果与统计
+ */
+export function mergeNotesMaps(
+  base: PlayerNotesMap,
+  incoming: PlayerNotesMap
+): { merged: PlayerNotesMap; stats: MergeStats } {
+  const merged: PlayerNotesMap = { ...base }
+  const stats: MergeStats = { added: 0, replaced: 0, kept: 0, invalid: 0 }
+  for (const [puuid, note] of Object.entries(incoming)) {
+    if (!isValidNote(note)) {
+      stats.invalid++
+      continue
+    }
+    const existing = merged[puuid]
+    if (!existing) {
+      merged[puuid] = note
+      stats.added++
+    } else if (note.updatedAt > existing.updatedAt) {
+      merged[puuid] = note
+      stats.replaced++
+    } else {
+      stats.kept++
+    }
+  }
+  return { merged, stats }
+}

--- a/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
+++ b/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
@@ -19,11 +19,15 @@ export interface MergeStats {
   invalid: number
 }
 
-/** 最低限度的结构校验:对象 + 数值 updatedAt + 字符串 label(防导入损坏文件) */
+/**
+ * 最低限度的结构校验:对象 + 有限数值 updatedAt + 字符串 label(防导入损坏文件)。
+ * 用 `Number.isFinite` 而非 `typeof === 'number'`:NaN 与任何数比较恒 false,
+ * 一旦并入就永远无法被更新的时间戳替换。
+ */
 function isValidNote(v: unknown): v is PlayerNote {
   if (!v || typeof v !== 'object') return false
   const n = v as Partial<PlayerNote>
-  return typeof n.updatedAt === 'number' && typeof n.label === 'string'
+  return Number.isFinite(n.updatedAt) && typeof n.label === 'string'
 }
 
 /**
@@ -43,7 +47,15 @@ export function mergeNotesMaps(
       stats.invalid++
       continue
     }
-    const existing = merged[puuid]
+    // `__proto__` 是保留键:普通对象字面量上 `merged['__proto__'] = note` 走原型
+    // setter,不会成为自有属性,直接拒绝(不可信输入不该有这种 puuid)。
+    if (puuid === '__proto__') {
+      stats.invalid++
+      continue
+    }
+    // 用 Object.hasOwn 判断存在性:`toString` 等键会命中原型链继承属性,
+    // 直接真值判断会把新条目误判为已存在而静默丢弃。
+    const existing = Object.hasOwn(merged, puuid) ? merged[puuid] : undefined
     if (!existing) {
       merged[puuid] = note
       stats.added++

--- a/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
+++ b/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
@@ -15,7 +15,7 @@ export interface MergeStats {
   replaced: number
   /** 本地更新(或同龄)、保持不变的条数 */
   kept: number
-  /** 结构非法被跳过的条数 */
+  /** 结构非法或键不安全、被跳过的条数 */
   invalid: number
 }
 
@@ -53,9 +53,10 @@ export function mergeNotesMaps(
       stats.invalid++
       continue
     }
-    // 用 Object.hasOwn 判断存在性:`toString` 等键会命中原型链继承属性,
+    // 用 hasOwnProperty 判断存在性:`toString` 等键会命中原型链继承属性,
     // 直接真值判断会把新条目误判为已存在而静默丢弃。
-    const existing = Object.hasOwn(merged, puuid) ? merged[puuid] : undefined
+    // (不用 Object.hasOwn:那是 ES2022 API,项目 tsconfig target/lib 是 ES2020。)
+    const existing = Object.prototype.hasOwnProperty.call(merged, puuid) ? merged[puuid] : undefined
     if (!existing) {
       merged[puuid] = note
       stats.added++

--- a/lol-record-analysis-tauri/src/views/Settings.vue
+++ b/lol-record-analysis-tauri/src/views/Settings.vue
@@ -41,7 +41,8 @@ import {
   AlertCircleOutline,
   SettingsOutline,
   PricetagOutline,
-  BookmarksOutline
+  BookmarksOutline,
+  CloudOutline
 } from '@vicons/ionicons5'
 
 const collapsed = ref(false)
@@ -81,6 +82,11 @@ const menuOptions = [
     label: '我标记过的人',
     key: 'PlayerNotes',
     icon: renderIcon(BookmarksOutline)
+  },
+  {
+    label: '数据与同步',
+    key: 'DataSync',
+    icon: renderIcon(CloudOutline)
   },
   // {
   //     label: 'AI能力',

--- a/lol-record-analysis-tauri/src/views/settings/DataSync.vue
+++ b/lol-record-analysis-tauri/src/views/settings/DataSync.vue
@@ -1,0 +1,217 @@
+<template>
+  <n-space vertical :size="12">
+    <!-- 手动备份 -->
+    <n-card title="手动备份" size="small">
+      <n-space vertical>
+        <n-text :depth="3" style="font-size: 12px">
+          把「我标记过的人」导出为 JSON 文件，或从备份文件导入（同一玩家按更新时间新者保留）。
+        </n-text>
+        <n-space>
+          <n-button size="small" :disabled="notesStore.count === 0" @click="handleExport">
+            导出备注（{{ notesStore.count }} 条）
+          </n-button>
+          <n-button size="small" @click="handleImport">从文件导入</n-button>
+        </n-space>
+      </n-space>
+    </n-card>
+
+    <!-- 云同步 -->
+    <n-card title="云同步" size="small">
+      <n-space vertical>
+        <n-space align="center" justify="space-between">
+          <n-space vertical :size="4">
+            <n-text>跨设备同步玩家备注</n-text>
+            <n-text :depth="3" style="font-size: 12px">
+              按当前登录的召唤师（puuid）存取，明文存储于第三方云端，开启前请阅读风险说明。
+            </n-text>
+          </n-space>
+          <n-switch :value="cloudStore.enabled" @update:value="handleToggle" />
+        </n-space>
+
+        <n-space v-if="cloudStore.enabled" align="center">
+          <n-button
+            size="small"
+            :loading="cloudStore.syncing"
+            :disabled="cloudStore.syncing"
+            @click="handleSyncNow"
+          >
+            立即同步
+          </n-button>
+          <n-text :depth="3" style="font-size: 12px">{{ syncStatusText }}</n-text>
+        </n-space>
+      </n-space>
+    </n-card>
+
+    <!-- 风险告知弹窗：开启云同步前必经，勾选确认才放行 -->
+    <n-modal
+      :show="showRiskModal"
+      preset="card"
+      title="开启云同步前，请了解以下风险"
+      style="max-width: 480px"
+      :mask-closable="false"
+      @update:show="cancelRisk"
+    >
+      <n-space vertical size="large">
+        <ol class="risk-list">
+          <li>你的备注将<b>明文</b>存储在第三方云端（Supabase / AWS 海外节点）。</li>
+          <li>
+            数据按你的召唤师标识（puuid）存取，而 puuid 对局内队友、对手及战绩网站均可见——
+            <b>任何知道你 puuid 的人理论上都能查询到你同步的备注</b>。
+          </li>
+          <li>本功能无身份验证，数据存在被他人覆盖或污染的残余风险。</li>
+          <li>请<b>不要</b>在备注中写入任何隐私或敏感信息。</li>
+        </ol>
+        <n-checkbox v-model:checked="riskAcknowledged">我已阅读并了解上述风险</n-checkbox>
+        <n-space justify="end">
+          <n-button @click="cancelRisk">取消</n-button>
+          <n-button type="primary" :disabled="!riskAcknowledged" @click="confirmRisk">
+            开启云同步
+          </n-button>
+        </n-space>
+      </n-space>
+    </n-modal>
+  </n-space>
+</template>
+
+<script setup lang="ts">
+/**
+ * 设置页·数据与同步分区
+ *
+ * 手动导入导出（JSON 文件，经系统对话框）+ 云同步开关（开启必经风险告知）。
+ * 同步编排在 pinia/cloudSync，合并语义在 utils/mergePlayerNotes，本组件只做交互。
+ */
+import { ref, computed } from 'vue'
+import { useMessage } from 'naive-ui'
+import { save, open } from '@tauri-apps/plugin-dialog'
+import { invoke } from '@tauri-apps/api/core'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import { useCloudSyncStore } from '@renderer/pinia/cloudSync'
+import type { PlayerNotesMap } from '@renderer/types/domain/playerNote'
+
+/** 导出文件格式版本，导入时校验；后续扩展同步内容时递增并做兼容分支 */
+const BACKUP_VERSION = 1
+
+const message = useMessage()
+const notesStore = usePlayerNotesStore()
+const cloudStore = useCloudSyncStore()
+
+const showRiskModal = ref(false)
+const riskAcknowledged = ref(false)
+
+const syncStatusText = computed(() => {
+  if (cloudStore.syncing) return '同步中…'
+  if (cloudStore.lastError) return `上次同步失败：${cloudStore.lastError}`
+  if (cloudStore.lastSyncAt)
+    return `上次同步：${new Date(cloudStore.lastSyncAt).toLocaleTimeString()}`
+  return '本次启动尚未同步'
+})
+
+/** 导出：系统保存对话框选路径 → Rust 写文件 */
+async function handleExport(): Promise<void> {
+  const path = await save({
+    defaultPath: `rank-analysis-notes-${new Date().toISOString().slice(0, 10)}.json`,
+    filters: [{ name: 'JSON', extensions: ['json'] }]
+  })
+  if (!path) return
+  const content = JSON.stringify(
+    {
+      version: BACKUP_VERSION,
+      type: 'rank-analysis-backup',
+      exportedAt: Date.now(),
+      playerNotes: notesStore.notes
+    },
+    null,
+    2
+  )
+  try {
+    await invoke('save_text_file', { path, content })
+    message.success(`已导出 ${notesStore.count} 条备注`)
+  } catch (e) {
+    message.error(String(e))
+  }
+}
+
+/**
+ * 导入：系统打开对话框选文件 → Rust 读文件 → 校验格式 → 并入 store。
+ * 校验要点：parse 结果必须是「普通对象」（排除 null / 数组 / 原始值），
+ * 否则 importNotes 的 Object.entries 会拿到垃圾数据。
+ */
+async function handleImport(): Promise<void> {
+  const path = await open({ multiple: false, filters: [{ name: 'JSON', extensions: ['json'] }] })
+  if (!path || Array.isArray(path)) return
+  let parsed: unknown
+  try {
+    const content = await invoke<string>('read_text_file', { path })
+    parsed = JSON.parse(content)
+  } catch {
+    message.error('文件读取失败或不是合法 JSON')
+    return
+  }
+  if (!isBackupFile(parsed)) {
+    message.error('不是本应用导出的备份文件')
+    return
+  }
+  try {
+    const stats = await notesStore.importNotes(parsed.playerNotes)
+    message.success(
+      `导入完成：新增 ${stats.added}，更新 ${stats.replaced}，保留本地 ${stats.kept}` +
+        (stats.invalid ? `，跳过损坏 ${stats.invalid}` : '')
+    )
+  } catch (e) {
+    message.error(`导入失败：${String(e)}`)
+  }
+}
+
+/** 备份文件结构校验：version 匹配且 playerNotes 是普通对象（非 null/数组） */
+function isBackupFile(v: unknown): v is { version: number; playerNotes: PlayerNotesMap } {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return false
+  const b = v as { version?: unknown; playerNotes?: unknown }
+  return (
+    b.version === BACKUP_VERSION &&
+    typeof b.playerNotes === 'object' &&
+    b.playerNotes !== null &&
+    !Array.isArray(b.playerNotes)
+  )
+}
+
+/** 开关交互：开=先过风险弹窗；关=直接关 */
+function handleToggle(v: boolean): void {
+  if (v) {
+    riskAcknowledged.value = false
+    showRiskModal.value = true
+  } else {
+    cloudStore.setEnabled(false).catch(() => message.error('保存失败'))
+  }
+}
+
+function cancelRisk(): void {
+  showRiskModal.value = false
+}
+
+async function confirmRisk(): Promise<void> {
+  showRiskModal.value = false
+  try {
+    await cloudStore.setEnabled(true)
+    message.success('云同步已开启，正在后台同步')
+  } catch {
+    message.error('保存失败')
+  }
+}
+
+async function handleSyncNow(): Promise<void> {
+  try {
+    await cloudStore.syncNow()
+    message.success('同步完成')
+  } catch {
+    message.error(cloudStore.lastError ?? '同步失败')
+  }
+}
+</script>
+
+<style scoped>
+.risk-list {
+  margin: 0;
+  padding-left: 1.2em;
+  line-height: 1.8;
+}
+</style>

--- a/lol-record-analysis-tauri/src/views/settings/DataSync.vue
+++ b/lol-record-analysis-tauri/src/views/settings/DataSync.vue
@@ -139,12 +139,19 @@ async function handleExport(): Promise<void> {
 async function handleImport(): Promise<void> {
   const path = await open({ multiple: false, filters: [{ name: 'JSON', extensions: ['json'] }] })
   if (!path || Array.isArray(path)) return
+  // 读文件与 parse 分开 catch：Rust 侧的「文件过大」「仅支持 .json」等文案需原样透传
+  let content: string
+  try {
+    content = await invoke<string>('read_text_file', { path })
+  } catch (e) {
+    message.error(String(e))
+    return
+  }
   let parsed: unknown
   try {
-    const content = await invoke<string>('read_text_file', { path })
     parsed = JSON.parse(content)
   } catch {
-    message.error('文件读取失败或不是合法 JSON')
+    message.error('文件内容不是合法 JSON')
     return
   }
   if (!isBackupFile(parsed)) {
@@ -162,11 +169,14 @@ async function handleImport(): Promise<void> {
   }
 }
 
-/** 备份文件结构校验：version 匹配且 playerNotes 是普通对象（非 null/数组） */
-function isBackupFile(v: unknown): v is { version: number; playerNotes: PlayerNotesMap } {
+/** 备份文件结构校验：type 标记 + version 匹配且 playerNotes 是普通对象（非 null/数组） */
+function isBackupFile(
+  v: unknown
+): v is { version: number; type: 'rank-analysis-backup'; playerNotes: PlayerNotesMap } {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return false
-  const b = v as { version?: unknown; playerNotes?: unknown }
+  const b = v as { version?: unknown; type?: unknown; playerNotes?: unknown }
   return (
+    b.type === 'rank-analysis-backup' &&
     b.version === BACKUP_VERSION &&
     typeof b.playerNotes === 'object' &&
     b.playerNotes !== null &&


### PR DESCRIPTION
## Summary
- 玩家备注支持导出/导入 JSON 备份(同一玩家按 updatedAt 新者赢合并,损坏条目计数跳过)
- 可选 Supabase 云同步(默认关):匿名账号写入溯源、按 puuid 寻址、每设备一行、客户端跨行合并;仅主窗口同步,LCU 连接建立后补触发,备注变更 30s 防抖推送,关闭开关即取消挂起推送
- 开启云同步必经风险告知弹窗(明文存储海外节点/puuid 可被他人查询/无身份验证有覆盖污染风险/勿存敏感信息),勾选确认才放行
- 首次启动一次性功能告知(避让错误上报同意弹窗,新用户下次启动再弹)
- Rust 端防御:备份文件命令强制 .json 扩展名 + 读取 10MB 上限;puuid 字符集校验防 PostgREST query 注入

## 设计决策(为什么无身份验证)
调研确认 Riot 生态下"无感 + 服务器可验证身份"不可兼得(可验证 token 只能走 RSO OAuth 审批流程;本地提取的 entitlements token 属官方政策灰色地带)。本功能选择"无感"一侧:puuid 只作数据寻址不作身份凭证,风险经弹窗充分披露,残余风险限定在"个人备注可被知晓 puuid 者读取/污染",不外溢。

## 已知后续事项(不阻塞本 PR)
- [ ] `ensure_session` 对刷新失败一律弃号重注册——弱网会积累孤儿匿名账号,建议改为仅 4xx 弃号、5xx/网络错误向上返回
- [ ] 仓库级安全根因(与本 PR 无关但相关):AI 面板 v-html 渲染 LLM 输出无 sanitize、CSP 为 null——值得单开 issue
- [ ] cloudSync 防抖 5s 重试分支无单测覆盖
- [ ] 墓碑 GC 在开启云同步时会被 pull 弹回(本设备云端行仍含过期墓碑),实际仅对纯本地用户生效;真修需 push 时同步剪枝过期墓碑。正确性无损,仅磁盘 map 缓慢增长
- [ ] 导出按钮文案计数不含墓碑,导出文件实际条目数可能略多(行为正确:备份需携带墓碑传播删除)

## Test plan
- [x] 前端门禁(prettier/eslint/vue-tsc/vitest 45 files·484 tests)本地全绿
- [ ] Windows CI(cargo fmt/clippy -Dwarnings/cargo test)通过
- [ ] Windows 真机手动清单:导出→导入往返、开启同步→风险弹窗→云端出行、改备注 30s 内云端更新、断网降级不崩、双设备合并
- [x] Supabase 云端冒烟(匿名注册/upsert 201/匿名读/更新路径 200/RLS owner-only 删除)已实测通过

https://claude.ai/code/session_011NwERmn3y2C3HBkpmYthLq
