### PR TITLE
refactor: session 渐进推送 + Moka try_get_with 缓存一致性

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -653,91 +653,144 @@ async fn process_subteam_parallel(
     subteam_id: i32,
     seq: u64,
 ) -> Result<(), String> {
-    let futures = players.iter().map(|player| async move {
-        if player.puuid.is_empty() {
-            return SessionSummoner {
-                champion_id: player.champion_id,
-                champion_key: format!("champion_{}", player.champion_id),
-                is_loading: false,
-                ..Default::default()
-            };
-        }
+    #[derive(Serialize)]
+    struct PlayerUpdate {
+        #[serde(rename = "subteamId")]
+        subteam_id: i32,
+        index: usize,
+        total: usize,
+        player: SessionSummoner,
+    }
 
-        let count = crate::config::get_config("matchHistoryCount")
-            .await
-            .ok()
-            .as_ref()
-            .and_then(crate::config::extract_int)
-            .map(|n| n as i32)
-            .unwrap_or(4);
-        let puuid = player.puuid.clone();
-        // 选人早期 champion_id 为 0 表示未选定，此时按「未知」处理而非「英雄 0」
-        let champion_id = Some(player.champion_id).filter(|&id| id > 0);
+    let total = players.len();
 
-        let (summoner, match_history, rank) = tokio::join!(
-            async {
-                Summoner::get_summoner_by_puuid(&puuid)
-                    .await
-                    .unwrap_or_default()
-            },
-            async {
-                match MatchHistory::get_match_history_by_puuid(&puuid, 0, count - 1).await {
-                    Ok(mut mh) => {
+    let futures = players
+        .iter()
+        .enumerate()
+        .map(|(index, player)| async move {
+            if player.puuid.is_empty() {
+                return SessionSummoner {
+                    champion_id: player.champion_id,
+                    champion_key: format!("champion_{}", player.champion_id),
+                    is_loading: false,
+                    ..Default::default()
+                };
+            }
+
+            let count = crate::config::get_config("matchHistoryCount")
+                .await
+                .ok()
+                .as_ref()
+                .and_then(crate::config::extract_int)
+                .map(|n| n as i32)
+                .unwrap_or(4);
+            let puuid = player.puuid.clone();
+            let champion_id = Some(player.champion_id).filter(|&id| id > 0);
+
+            let (summoner, match_history, rank) = tokio::join!(
+                async {
+                    Summoner::get_summoner_by_puuid(&puuid)
+                        .await
+                        .unwrap_or_default()
+                },
+                async {
+                    let mut result = if let Some(mut mh) =
+                        MatchHistory::try_get_cached_slice(&puuid, 0, count - 1).await
+                    {
                         mh.enrich_info_cn().ok();
                         mh
+                    } else {
+                        let puuid_for_cache = puuid.clone();
+                        tokio::spawn(async move {
+                            MatchHistory::fill_cache(&puuid_for_cache).await;
+                        });
+                        match MatchHistory::get_by_puuid(&puuid, 0, count - 1).await {
+                            Ok(mut mh) => {
+                                mh.enrich_info_cn().ok();
+                                mh
+                            }
+                            Err(_) => MatchHistory::default(),
+                        }
+                    };
+                    if result.games.games.len() > count as usize {
+                        result.games.games.truncate(count as usize);
                     }
-                    Err(_) => MatchHistory::default(),
+                    result
+                },
+                async {
+                    match Rank::get_rank_by_puuid(&puuid).await {
+                        Ok(mut r) => {
+                            r.enrich_cn_info();
+                            r
+                        }
+                        Err(_) => Rank::default(),
+                    }
                 }
-            },
-            async {
-                match Rank::get_rank_by_puuid(&puuid).await {
-                    Ok(mut r) => {
-                        r.enrich_cn_info();
-                        r
-                    }
-                    Err(_) => Rank::default(),
+            );
+
+            // 先推送基础数据（无 user_tag），让 UI 尽早渲染玩家战绩卡片
+            if is_latest_task(&SESSION_TASK_SEQ, seq) {
+                let basic = SessionSummoner {
+                    champion_id: player.champion_id,
+                    champion_key: format!("champion_{}", player.champion_id),
+                    summoner: summoner.clone(),
+                    match_history: match_history.clone(),
+                    user_tag: UserTag::default(),
+                    rank: rank.clone(),
+                    meet_games: Vec::new(),
+                    pre_group_markers: PreGroupMarker::default(),
+                    is_loading: false,
+                };
+                let update = PlayerUpdate {
+                    subteam_id,
+                    index,
+                    total,
+                    player: basic,
+                };
+                if let Err(e) = app_handle.emit("session-player-update", &update) {
+                    log::error!("Failed to emit player update event: {}", e);
                 }
             }
-        );
 
-        let user_tag = crate::command::user_tag::get_user_tag_by_puuid(&puuid, mode, champion_id)
-            .await
-            .unwrap_or_else(|_| UserTag {
-                recent_data: crate::command::user_tag::RecentData {
-                    kda: 0.0,
-                    kills: 0.0,
-                    deaths: 0.0,
-                    assists: 0.0,
-                    select_mode: mode,
-                    select_mode_cn: QUEUE_ID_TO_CN
-                        .get(&(mode as u32))
-                        .unwrap_or(&"未知模式")
-                        .to_string(),
-                    select_wins: 0,
-                    select_losses: 0,
-                    group_rate: 0,
-                    average_gold: 0,
-                    gold_rate: 0,
-                    average_damage_dealt_to_champions: 0,
-                    damage_dealt_to_champions_rate: 0,
-                    friend_and_dispute: Default::default(),
-                    one_game_players_map: None,
-                },
-                tag: Vec::new(),
-            });
+            let user_tag =
+                crate::command::user_tag::get_user_tag_by_puuid(&puuid, mode, champion_id)
+                    .await
+                    .unwrap_or_else(|_| UserTag {
+                        recent_data: crate::command::user_tag::RecentData {
+                            kda: 0.0,
+                            kills: 0.0,
+                            deaths: 0.0,
+                            assists: 0.0,
+                            select_mode: mode,
+                            select_mode_cn: QUEUE_ID_TO_CN
+                                .get(&(mode as u32))
+                                .unwrap_or(&"未知模式")
+                                .to_string(),
+                            select_wins: 0,
+                            select_losses: 0,
+                            group_rate: 0,
+                            average_gold: 0,
+                            gold_rate: 0,
+                            average_damage_dealt_to_champions: 0,
+                            damage_dealt_to_champions_rate: 0,
+                            friend_and_dispute: Default::default(),
+                            one_game_players_map: None,
+                        },
+                        tag: Vec::new(),
+                    });
 
-        SessionSummoner {
-            champion_id: player.champion_id,
-            champion_key: format!("champion_{}", player.champion_id),
-            summoner,
-            match_history,
-            user_tag,
-            rank,
-            meet_games: Vec::new(),
-            pre_group_markers: PreGroupMarker::default(),
-            is_loading: false,
-        }
-    });
+            SessionSummoner {
+                champion_id: player.champion_id,
+                champion_key: format!("champion_{}", player.champion_id),
+                summoner,
+                match_history,
+                user_tag,
+                rank,
+                meet_games: Vec::new(),
+                pre_group_markers: PreGroupMarker::default(),
+                is_loading: false,
+            }
+        });
 
     let fetched_players = futures::future::join_all(futures).await;
 
@@ -749,15 +802,6 @@ async fn process_subteam_parallel(
 
         if !emit_allowed {
             continue;
-        }
-
-        #[derive(Serialize)]
-        struct PlayerUpdate {
-            #[serde(rename = "subteamId")]
-            subteam_id: i32,
-            index: usize,
-            total: usize,
-            player: SessionSummoner,
         }
 
         let update = PlayerUpdate {

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
@@ -130,9 +130,15 @@ static MATCH_HISTORY_CACHE: LazyLock<Cache<String, MatchHistory>> = LazyLock::ne
         .build()
 });
 
+const MAX_CACHE_END: i32 = 49;
+
 impl MatchHistory {
     /// 内部：按 PUUID 与索引范围请求 LCU 对局列表。
-    async fn get_by_puuid(puuid: &str, begin_index: i32, end_index: i32) -> Result<Self, String> {
+    pub(crate) async fn get_by_puuid(
+        puuid: &str,
+        begin_index: i32,
+        end_index: i32,
+    ) -> Result<Self, String> {
         let uri = format!(
             "lol-match-history/v1/products/lol/{}/matches?begIndex={}&endIndex={}",
             puuid, begin_index, end_index
@@ -153,7 +159,7 @@ impl MatchHistory {
         Ok(match_history)
     }
 
-    /// 按 PUUID 与索引范围获取对局记录；在 0..=49 范围内使用缓存。
+    /// 按 PUUID 与索引范围获取对局记录；首次访问时缓存完整 50 场（0-49），后续命中后切片返回。
     pub async fn get_match_history_by_puuid(
         puuid: &str,
         beg_index: i32,
@@ -165,59 +171,80 @@ impl MatchHistory {
             beg_index,
             end_index
         );
-        let max_cache_end_index = 49;
 
-        // 参数验证
         if beg_index < 0 || end_index < 0 {
             return Err("索引不能为负数".to_string());
         }
-
-        // 允许 beg_index == end_index：matchHistoryCount=1 时请求区间为 (0, 0)，表示单场
         if beg_index > end_index {
             return Err("开始索引不能大于结束索引".to_string());
         }
 
-        // 如果没有用户缓存，且在缓存范围内，则获取缓存
-        if !MATCH_HISTORY_CACHE.contains_key(puuid) && end_index <= max_cache_end_index {
-            let cache = MatchHistory::get_by_puuid(puuid, 0, max_cache_end_index).await?;
-            MATCH_HISTORY_CACHE.insert(puuid.to_string(), cache).await;
+        if end_index > MAX_CACHE_END {
+            return MatchHistory::get_by_puuid(puuid, beg_index, end_index).await;
         }
 
-        let res = if end_index <= max_cache_end_index {
-            let history = MATCH_HISTORY_CACHE
-                .get(puuid)
-                .await
-                .ok_or_else(|| format!("未找到缓存的比赛历史: {}", puuid))?
-                .clone();
+        let history = MATCH_HISTORY_CACHE
+            .try_get_with(puuid.to_string(), async {
+                MatchHistory::get_by_puuid(puuid, 0, MAX_CACHE_END).await
+            })
+            .await
+            .map_err(|e| e.to_string())?;
 
-            let beg = beg_index as usize;
-            let end = end_index as usize;
-            let total_games = history.games.games.len();
+        let total_games = history.games.games.len();
+        let beg = beg_index as usize;
+        let end = end_index as usize;
 
-            if beg >= total_games {
-                return Err(format!(
-                    "开始索引 {} 超出范围，总游戏数 {}",
-                    beg, total_games
-                ));
-            }
+        if end >= total_games {
+            return MatchHistory::get_by_puuid(puuid, beg_index, end_index).await;
+        }
+        if beg >= total_games {
+            return Err(format!(
+                "开始索引 {} 超出范围，总游戏数 {}",
+                beg, total_games
+            ));
+        }
 
-            let actual_end = std::cmp::min(end + 1, total_games);
+        let actual_end = std::cmp::min(end + 1, total_games);
+        if beg >= actual_end {
+            return Err(format!("有效范围为空：{} >= {}", beg, actual_end));
+        }
 
-            if beg >= actual_end {
-                return Err(format!("有效范围为空：{} >= {}", beg, actual_end));
-            }
+        Ok(MatchHistory {
+            games: GamesWrapper {
+                games: history.games.games[beg..actual_end].to_vec(),
+            },
+            ..history
+        })
+    }
 
-            MatchHistory {
-                games: GamesWrapper {
-                    games: history.games.games[beg..actual_end].to_vec(),
-                },
-                ..history
-            }
-        } else {
-            MatchHistory::get_by_puuid(puuid, beg_index, end_index).await?
-        };
+    /// 纯读缓存并切片，不触发 LCU 请求。命中则返回切片后的数据，未命中或数据不足返回 None。
+    pub async fn try_get_cached_slice(puuid: &str, beg: i32, end: i32) -> Option<MatchHistory> {
+        let cached = MATCH_HISTORY_CACHE.get(puuid).await?;
+        let total = cached.games.games.len();
+        let b = beg as usize;
+        let e = end as usize;
+        if e >= total {
+            return None;
+        }
+        let actual_end = std::cmp::min(e + 1, total);
+        if b >= actual_end {
+            return None;
+        }
+        Some(MatchHistory {
+            games: GamesWrapper {
+                games: cached.games.games[b..actual_end].to_vec(),
+            },
+            ..cached
+        })
+    }
 
-        Ok(res)
+    /// 异步补全缓存：用 try_get_with 保证并发下只有一个线程拉 0-49。
+    pub async fn fill_cache(puuid: &str) {
+        let _ = MATCH_HISTORY_CACHE
+            .try_get_with(puuid.to_string(), async {
+                MatchHistory::get_by_puuid(puuid, 0, MAX_CACHE_END).await
+            })
+            .await;
     }
 
     /// 为每条对局拉取详情（game_detail）并写入。


### PR DESCRIPTION
## 动机

对局页每次拉取全部 10 个玩家的 50 场对战记录（0-49），
但 UI 实际只展示 matchHistoryCount 配置的场数（默认 4 场）。
50 场预加载数据量大、耗时长，且并发请求易触发 LCU API throttle，
导致玩家的历史战绩列表早已加载好，却要等待50场预加载之后才渲染到UI

## 改动概要

### session.rs
- 逐玩家两阶段推送：基础数据（summoner + 战绩 + 段位）立即 emit 到 UI，user_tag 计算完成后再次 emit 完整数据
- 战绩获取优先查缓存（try_get_cached_slice），miss 时直发小范围 + spawn 后台补全
- 发送 UI 前截断战绩列表，兜底 LCU 返回超量数据

### match_history.rs
- get_match_history_by_puuid 用 try_get_with 替代手写 contains_key + insert + get 链，并发安全
- 新增 try_get_cached_slice：纯读缓存 + 切片，不触发 LCU 请求
- 新增 fill_cache：后台异步补全 0-49，try_get_with 保证唯一执行
- get_by_puuid 改为 pub(crate)，供 session 直调用



## Benchmark

| 场景 | 改动前（从进入选人界面到UI显示所有队友的战绩） | 改动后 |
|------|--------|--------|
| 5 玩家小队冷启动 | ~25s | ~3.5s |

测试环境：matchHistoryCount=10，5v5 对局，10 个不同玩家