### PR TITLE
fix(launcher): 自动清除腾讯登录客户端注册的 LOL 开机自启项

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/Cargo.lock
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.lock
@@ -2731,6 +2731,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "winapi",
+ "winreg",
 ]
 
 [[package]]

--- a/lol-record-analysis-tauri/src-tauri/Cargo.toml
+++ b/lol-record-analysis-tauri/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ winapi = { version = "0.3.9", features = [
     "winuser",
 ] } # 用于 Windows api，用于获取lol进程信息
 log = "0.4.0"
+winreg = "0.55" # 清理腾讯登录客户端注册的 LOL 开机自启项（command/launcher.rs）
 env_logger = "0.11"
 base64 = "0.21"
 tauri-plugin-http = "2"

--- a/lol-record-analysis-tauri/src-tauri/src/command/launcher.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/launcher.rs
@@ -98,6 +98,85 @@ pub async fn remember_install_root() {
     }
 }
 
+/// 开机自启 Run 键的注册表子路径（HKLM 与 HKCU 共用）。
+const RUN_KEY_PATH: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+
+/// 判断 Run 键中某条值的数据是否指向腾讯登录客户端的开机自启程序。
+///
+/// 登录客户端（`Launcher\Client.exe`）被拉起后，会以管理员权限把
+/// `<安装根>\Launcher\startup_runner.exe` 注册为开机自启（值名形如 `Client_26`，
+/// 随版本变化），导致每次开机自动弹出 LOL 登录窗。这里按「文件名 + 父目录名」
+/// 双重匹配定位，与值名、安装盘符无关，也不会误删其他软件的自启项。
+fn is_login_client_autostart(data: &str) -> bool {
+    let path = Path::new(data.trim().trim_matches('"'));
+    let name_is = |name: Option<&std::ffi::OsStr>, expect: &str| {
+        name.is_some_and(|n| n.eq_ignore_ascii_case(expect))
+    };
+    name_is(path.file_name(), "startup_runner.exe")
+        && name_is(path.parent().and_then(Path::file_name), "Launcher")
+}
+
+/// 清理腾讯登录客户端注册的 LOL 开机自启项。
+///
+/// 免 WeGame 直接拉起 `Launcher\Client.exe` 后（经 WeGame 启动亦可能发生），它会
+/// 把 `startup_runner.exe` 写入机器级 Run 键（实测在 HKLM 的 32 位视图，即
+/// `WOW6432Node`），使 LOL 每次开机自启。本函数扫描 HKLM（64/32 位视图）与 HKCU
+/// 的 Run 键，删除所有指向 `Launcher\startup_runner.exe` 的值。
+///
+/// 删除 HKLM 值需要管理员权限。国服客户端本身以管理员运行，本工具要连上它时
+/// 已经提权，故在「已连接/刚断开」时机调用基本必然成功；无权限时记日志静默
+/// 跳过，待下次提权运行时再清。
+pub fn purge_login_client_autostart() {
+    use winreg::enums::{
+        HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_QUERY_VALUE, KEY_SET_VALUE, KEY_WOW64_32KEY,
+        KEY_WOW64_64KEY,
+    };
+    use winreg::types::FromRegValue;
+    use winreg::RegKey;
+
+    // HKLM 需分别查 64/32 位视图（后者即 WOW6432Node）；HKCU 的 Run 键不受
+    // WOW64 重定向影响，查一次即可。
+    let views = [
+        (HKEY_LOCAL_MACHINE, KEY_WOW64_64KEY),
+        (HKEY_LOCAL_MACHINE, KEY_WOW64_32KEY),
+        (HKEY_CURRENT_USER, 0),
+    ];
+    for (hive, view) in views {
+        // 先只读枚举定位目标值名，再以写权限打开删除：普通权限下多数情况
+        // 无目标值，避免无谓的 HKLM 写权限请求失败刷日志。
+        let Ok(key) =
+            RegKey::predef(hive).open_subkey_with_flags(RUN_KEY_PATH, KEY_QUERY_VALUE | view)
+        else {
+            continue;
+        };
+        let targets: Vec<String> = key
+            .enum_values()
+            .filter_map(Result::ok)
+            .filter(|(_, value)| {
+                String::from_reg_value(value).is_ok_and(|data| is_login_client_autostart(&data))
+            })
+            .map(|(name, _)| name)
+            .collect();
+        if targets.is_empty() {
+            continue;
+        }
+        let writable =
+            match RegKey::predef(hive).open_subkey_with_flags(RUN_KEY_PATH, KEY_SET_VALUE | view) {
+                Ok(k) => k,
+                Err(e) => {
+                    log::info!("发现 LOL 开机自启项但当前无权限清理（需管理员）: {}", e);
+                    continue;
+                }
+            };
+        for name in targets {
+            match writable.delete_value(&name) {
+                Ok(()) => log::info!("已移除腾讯登录客户端注册的 LOL 开机自启项（{}）", name),
+                Err(e) => log::warn!("移除 LOL 开机自启项 {} 失败: {}", name, e),
+            }
+        }
+    }
+}
+
 /// 免 WeGame 一键启动国服英雄联盟。
 ///
 /// 发现安装根目录后，直接 spawn `Launcher\Client.exe`（回退 `TCLS\Client.exe`）。
@@ -190,5 +269,34 @@ mod tests {
         assert_eq!(candidates[1].parent().unwrap().file_name().unwrap(), "TCLS");
         // 保持在安装根目录之下
         assert!(candidates[0].starts_with(root));
+    }
+
+    #[test]
+    fn login_client_autostart_matches_launcher_startup_runner() {
+        // 实测被注册的形态（HKLM\...\Run\Client_26）
+        assert!(is_login_client_autostart(
+            r"C:\WeGameApps\英雄联盟\Launcher\startup_runner.exe"
+        ));
+        // 自定义安装盘符/路径、带引号、大小写差异均应命中
+        assert!(is_login_client_autostart(
+            r#""D:\Games\LOL\launcher\Startup_Runner.EXE""#
+        ));
+    }
+
+    #[test]
+    fn login_client_autostart_ignores_unrelated_entries() {
+        // 其他软件的自启项不能误删
+        assert!(!is_login_client_autostart(
+            r"C:\Program Files\Tencent\QQNT\QQ.exe"
+        ));
+        // 文件名相同但不在 Launcher 目录下（防止碰瓷同名 exe）
+        assert!(!is_login_client_autostart(
+            r"C:\SomeApp\bin\startup_runner.exe"
+        ));
+        // 父目录对但文件名不对
+        assert!(!is_login_client_autostart(
+            r"C:\WeGameApps\英雄联盟\Launcher\Client.exe"
+        ));
+        assert!(!is_login_client_autostart(""));
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/game_state_monitor.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/game_state_monitor.rs
@@ -186,6 +186,9 @@ impl GameStateMonitor {
             // 之后即便游戏关闭也能免 WeGame 一键启动（见 command::launcher）。
             tokio::spawn(async {
                 crate::command::launcher::remember_install_root().await;
+                // 顺手清除登录客户端注册的 LOL 开机自启项：能连上国服客户端说明
+                // 本工具已提权，此刻删 HKLM 值必然有权限（见 command::launcher）。
+                crate::command::launcher::purge_login_client_autostart();
             });
 
             // 维度标签：把当前登录大区（HN1/TJ100…）挂到 Sentry 全局 scope，
@@ -219,6 +222,14 @@ impl GameStateMonitor {
                         log::error!("获取 LCU 认证信息失败: {}", e);
                     }
                 }
+            });
+        }
+
+        // 刚断开（之前连接，现在断开）：客户端退出时可能重新注册了 LOL 开机
+        // 自启，再清一次，避免"最后一局退出后残留自启项"。
+        if !new_state.connected && self.last_state.connected {
+            tokio::spawn(async {
+                crate::command::launcher::purge_login_client_autostart();
             });
         }
 


### PR DESCRIPTION
免 WeGame 直接拉起 Launcher\Client.exe 后，它会以管理员权限把
Launcher\startup_runner.exe 写入 HKLM 机器级 Run 键（值名如 Client_26）， 导致每次开机自动弹出 LOL 登录窗。

在 game_state_monitor 的「已连接/刚断开」转变时扫描 HKLM（64/32 位视图） 与 HKCU 的 Run 键，删除指向 Launcher\startup_runner.exe 的值；连上国服 客户端时本工具必已提权，删除 HKLM 值必然有权限，无权限时记日志跳过。
按「文件名 + 父目录名」双重匹配，不会误删其他软件的自启项。