### PR TITLE
fix(ui): 筛选框/输入框圆角回到 8px 档，保留按钮 4px 描边体系

### DIFF
--- a/lol-record-analysis-tauri/src/theme/overrides.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.ts
@@ -63,7 +63,8 @@ export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides {
       borderColor: glassBorder
     },
     Input: {
-      borderRadius: radiusControl,
+      // 输入/筛选类控件用 8px 档:比 JB 的 4px 控件档更圆润(用户口味),按钮仍走 4px
+      borderRadius: radiusMd,
       color: glassMid,
       border: `1px solid ${glassBorder}`,
       borderFocus: `1px solid ${primary}`,
@@ -86,7 +87,7 @@ export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides {
       textColorPressed: textPrimary
     },
     Select: {
-      borderRadius: radiusControl
+      borderRadius: radiusMd
     },
     Pagination: {
       itemBorderRadius: radiusControl


### PR DESCRIPTION
## Summary
- #97 把 Select/Input 圆角压到了 JB 的 4px 控件档，实际观感偏方（用户反馈筛选框不如原来圆润）
- Select 与 Input（含 InputNumber）圆角回到 `--radius-md`(8px)，与改造前一致
- 按钮/分页保持 4px 描边体系、浮层保持 8px 不变

## Test plan
- [x] lint / typecheck / overrides 单测通过
- [x] CDP 截图验证：战绩页筛选框圆角恢复圆润，与搜索框/卡片风格协调
