### PR TITLE
refactor(ui): 巡检收尾——语义色 alpha 收编 color-mix + 5 处观感/一致性修复

### DIFF
--- a/lol-record-analysis-tauri/src/components/Header.vue
+++ b/lol-record-analysis-tauri/src/components/Header.vue
@@ -225,9 +225,9 @@ const closeWindow = (): void => {
   width: 22px;
   height: 22px;
   border-radius: var(--radius-sm);
-  background: rgba(61, 155, 122, 0.18);
-  border: 1px solid rgba(61, 155, 122, 0.28);
-  box-shadow: 0 0 10px rgba(61, 155, 122, 0.18);
+  background: color-mix(in srgb, var(--semantic-win) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--semantic-win) 28%, transparent);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--semantic-win) 18%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -273,12 +273,8 @@ const closeWindow = (): void => {
 
 /* 聚焦时整框发光 */
 .header-center:focus-within .header-search :deep(.n-input-wrapper) {
-  box-shadow: 0 0 0 2px rgba(61, 155, 122, 0.2);
-  border-color: rgba(61, 155, 122, 0.35) !important;
-}
-
-.theme-light .header-center:focus-within .header-search :deep(.n-input-wrapper) {
-  box-shadow: 0 0 0 2px rgba(45, 138, 108, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--semantic-win) 20%, transparent);
+  border-color: color-mix(in srgb, var(--semantic-win) 35%, transparent) !important;
 }
 
 /* 前缀：大区下拉触发器（小号文字 + 箭头，hover 淡底） */
@@ -382,7 +378,7 @@ const closeWindow = (): void => {
 }
 
 .close-btn:hover {
-  background-color: rgba(196, 92, 92, 0.75);
+  background-color: color-mix(in srgb, var(--semantic-loss) 75%, transparent);
   color: white;
 }
 

--- a/lol-record-analysis-tauri/src/components/LoadingComponent.vue
+++ b/lol-record-analysis-tauri/src/components/LoadingComponent.vue
@@ -64,9 +64,9 @@ defineProps<{ hint?: string }>()
   border-radius: 50%;
   border: 2px solid transparent;
   border-top-color: var(--semantic-win);
-  border-right-color: rgba(61, 155, 122, 0.35);
+  border-right-color: color-mix(in srgb, var(--semantic-win) 35%, transparent);
   animation: loading-spin 1.2s cubic-bezier(0.6, 0.2, 0.4, 0.9) infinite;
-  filter: drop-shadow(0 0 6px rgba(61, 155, 122, 0.4));
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--semantic-win) 40%, transparent));
 }
 
 .loading-center {
@@ -75,8 +75,8 @@ defineProps<{ hint?: string }>()
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: rgba(61, 155, 122, 0.08);
-  border: 1px solid rgba(61, 155, 122, 0.2);
+  background: color-mix(in srgb, var(--semantic-win) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--semantic-win) 20%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -112,11 +112,11 @@ defineProps<{ hint?: string }>()
   border-radius: var(--radius-pill);
   background: linear-gradient(
     90deg,
-    rgba(61, 155, 122, 0) 0%,
-    rgba(61, 155, 122, 0.5) 40%,
-    rgba(61, 155, 122, 0.7) 50%,
-    rgba(61, 155, 122, 0.5) 60%,
-    rgba(61, 155, 122, 0) 100%
+    color-mix(in srgb, var(--semantic-win) 0%, transparent) 0%,
+    color-mix(in srgb, var(--semantic-win) 50%, transparent) 40%,
+    color-mix(in srgb, var(--semantic-win) 70%, transparent) 50%,
+    color-mix(in srgb, var(--semantic-win) 50%, transparent) 60%,
+    color-mix(in srgb, var(--semantic-win) 0%, transparent) 100%
   );
   background-size: 200% 100%;
   animation: shimmer 1.8s ease-in-out infinite;
@@ -142,23 +142,18 @@ defineProps<{ hint?: string }>()
 
 /* 亮色主题 */
 .theme-light .loading-ring {
-  border-right-color: rgba(45, 138, 108, 0.3);
-  filter: drop-shadow(0 0 5px rgba(45, 138, 108, 0.35));
-}
-
-.theme-light .loading-center {
-  background: rgba(45, 138, 108, 0.08);
-  border-color: rgba(45, 138, 108, 0.2);
+  border-right-color: color-mix(in srgb, var(--semantic-win) 30%, transparent);
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--semantic-win) 35%, transparent));
 }
 
 .theme-light .loading-shimmer-bar {
   background: linear-gradient(
     90deg,
-    rgba(45, 138, 108, 0) 0%,
-    rgba(45, 138, 108, 0.4) 40%,
-    rgba(45, 138, 108, 0.6) 50%,
-    rgba(45, 138, 108, 0.4) 60%,
-    rgba(45, 138, 108, 0) 100%
+    color-mix(in srgb, var(--semantic-win) 0%, transparent) 0%,
+    color-mix(in srgb, var(--semantic-win) 40%, transparent) 40%,
+    color-mix(in srgb, var(--semantic-win) 60%, transparent) 50%,
+    color-mix(in srgb, var(--semantic-win) 40%, transparent) 60%,
+    color-mix(in srgb, var(--semantic-win) 0%, transparent) 100%
   );
   background-size: 200% 100%;
 }

--- a/lol-record-analysis-tauri/src/components/SideNavigation.vue
+++ b/lol-record-analysis-tauri/src/components/SideNavigation.vue
@@ -191,10 +191,16 @@ const goGaming = () => {
 }
 
 .nav-item--active {
-  background: rgba(61, 155, 122, 0.14);
+  background: color-mix(in srgb, var(--semantic-win) 14%, transparent);
   color: var(--semantic-win);
-  border-color: rgba(61, 155, 122, 0.2);
-  box-shadow: 0 0 12px rgba(61, 155, 122, 0.15);
+  border-color: color-mix(in srgb, var(--semantic-win) 20%, transparent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--semantic-win) 15%, transparent);
+}
+
+/* 键盘聚焦时让位给全局 focus ring，激活态描边/辉光暂时退场，避免双环 */
+.nav-item--active:focus-visible {
+  border-color: transparent;
+  box-shadow: none;
 }
 
 /* Active indicator — INSIDE the button, NOT bleeding outside */
@@ -208,7 +214,7 @@ const goGaming = () => {
   height: 18px;
   background: var(--win-bar-gradient);
   border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
-  box-shadow: 0 0 8px rgba(61, 155, 122, 0.4);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--semantic-win) 40%, transparent);
 }
 
 .nav-item-label {
@@ -255,12 +261,12 @@ const goGaming = () => {
 }
 
 .status-icon-btn--on {
-  background: rgba(61, 155, 122, 0.12);
+  background: color-mix(in srgb, var(--semantic-win) 12%, transparent);
   color: var(--semantic-win);
 }
 
 .status-icon-btn--blue {
-  background: rgba(56, 189, 248, 0.1);
+  background: color-mix(in srgb, var(--accent-sky) 10%, transparent);
   color: var(--accent-sky);
 }
 
@@ -276,13 +282,13 @@ const goGaming = () => {
 
 .status-dot--green {
   background: var(--semantic-win-bright);
-  box-shadow: 0 0 5px rgba(74, 222, 128, 0.6);
+  box-shadow: 0 0 5px color-mix(in srgb, var(--semantic-win-bright) 60%, transparent);
   animation: dot-pulse 2s ease-in-out infinite;
 }
 
 .status-dot--blue {
   background: var(--accent-sky);
-  box-shadow: 0 0 5px rgba(56, 189, 248, 0.5);
+  box-shadow: 0 0 5px color-mix(in srgb, var(--accent-sky) 50%, transparent);
   animation: dot-pulse 2s ease-in-out infinite;
 }
 
@@ -301,29 +307,29 @@ const goGaming = () => {
 }
 
 .theme-light .nav-item--active {
-  background: rgba(45, 138, 108, 0.12);
-  border-color: rgba(45, 138, 108, 0.18);
+  background: color-mix(in srgb, var(--semantic-win) 12%, transparent);
+  border-color: color-mix(in srgb, var(--semantic-win) 18%, transparent);
+}
+
+.theme-light .nav-item--active:focus-visible {
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .theme-light .nav-item--active::before {
-  background: linear-gradient(180deg, #0d9668, #2d8a6c);
-  box-shadow: 0 0 6px rgba(45, 138, 108, 0.3);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--semantic-win) 30%, transparent);
 }
 
 .theme-light .status-icon-btn--on {
-  background: rgba(45, 138, 108, 0.1);
-}
-
-.theme-light .status-icon-btn--blue {
-  background: rgba(2, 132, 199, 0.1);
+  background: color-mix(in srgb, var(--semantic-win) 10%, transparent);
 }
 
 .theme-light .status-dot--green {
   background: var(--semantic-win);
-  box-shadow: 0 0 4px rgba(13, 150, 104, 0.4);
+  box-shadow: 0 0 4px color-mix(in srgb, var(--semantic-win-bright) 40%, transparent);
 }
 
 .theme-light .status-dot--blue {
-  box-shadow: 0 0 4px rgba(2, 132, 199, 0.35);
+  box-shadow: 0 0 4px color-mix(in srgb, var(--accent-sky) 35%, transparent);
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/common/PlayerNoteBadge.vue
+++ b/lol-record-analysis-tauri/src/components/common/PlayerNoteBadge.vue
@@ -218,7 +218,7 @@ async function onDelete() {
 
 .note-add-icon {
   font-size: var(--font-size-base);
-  color: var(--text-quaternary, var(--text-tertiary));
+  color: var(--text-tertiary);
   opacity: 0.55;
   transition: opacity var(--dur-fast, 0.15s) var(--ease-expo, ease);
 }

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
@@ -124,9 +124,11 @@ const selectWinRate = computed(() => winRate(props.recent.selectWins, props.rece
   width: 240px;
   z-index: 100;
   background: var(--bg-elevated);
-  /* 半透明 win 色描边，强调激活态；alpha 自定义保留 rgba */
-  border-color: rgba(61, 155, 122, 0.25);
-  box-shadow: var(--shadow-lg);
+  border-color: color-mix(in srgb, var(--semantic-win) 25%, transparent);
+  /* 外圈 2px 底色"暗缝"把浮层从下方内容里切出来，再叠常规投影 */
+  box-shadow:
+    0 0 0 2px var(--bg-base),
+    var(--shadow-lg);
 }
 
 .stats-header {

--- a/lol-record-analysis-tauri/src/components/record/MatchHistory.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchHistory.vue
@@ -84,7 +84,7 @@
             <n-button
               size="tiny"
               @click="nextPage"
-              :disabled="page == 5 || isRequestingMatchHostory"
+              :disabled="page == 5 || isRequestingMatchHostory || noMoreMatches"
             >
               <template #icon>
                 <n-icon>
@@ -192,6 +192,14 @@ const games = computed<Game[]>(() => matchHistory.value?.games?.games ?? [])
 
 /** 是否启用了任何筛选条件（用于区分"无数据"与"筛选无结果"） */
 const hasFilter = computed(() => filterChampionId.value > 0 || filterQueueId.value > 0)
+
+/**
+ * 已到最后一页：无筛选时每页固定请求 10 条，不满 10 条即无下页；
+ * 筛选分页按命中数续推，只能以"当前页为空"兜底判断。
+ */
+const noMoreMatches = computed(() =>
+  hasFilter.value ? games.value.length === 0 : games.value.length < 10
+)
 
 async function openDetail(game: Game) {
   await openMatchDetailWindow(game)


### PR DESCRIPTION
UI 截图巡检（#97 后）发现的 5 个优化点，一次收尾：

## Summary
- **语义色 alpha 收编**：SideNavigation / Header / LoadingComponent 中约 30 处 `rgba(61,155,122,x)` 类写法全部改为 `color-mix(in srgb, var(--semantic-win) N%, transparent)`，明暗主题自动联动；顺带删除 4 条替换后与深色完全重复的 `.theme-light` 冗余规则
- **对局页「近期数据」展开浮层分层**：外圈加 2px `--bg-base` 暗缝 + 常规投影，不再与下方玩家的收起面板糊在一起（JB 暗缝分层手法）
- **战绩分页**：无筛选每页固定 10 条，不满 10 条即最后一页，禁用「下一页」；筛选态以当前页为空兜底
- **幽灵 token**：PlayerNoteBadge 中不存在的 `--text-quaternary` 引用改为实际生效的 `--text-tertiary`（视觉零变化）
- **侧边栏双环**：激活项键盘聚焦时暂时收起描边/辉光，让位给全局 focus ring（明暗两套）

## Test plan
- [x] lint（0 errors）/ typecheck / vitest 491 全过
- [ ] Manual：对局页展开「近期数据」看分层效果；战绩不满一页时确认「下一页」禁用；Tab 键盘导航侧边栏看单环
