### PR TITLE
fix(record): 模式筛选人机选项去重——人机按难度显示,过滤按中文名分组匹配

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/config.rs
@@ -157,6 +157,12 @@ pub struct GameModeOption {
 /// # 返回值
 ///
 /// 游戏模式选项列表，第一项为「全部」（ID 为 0），其余按 ID 排序
+///
+/// # 去重规则
+///
+/// 多个队列 ID 共用同一中文名（如新旧人机队列同难度、430/490 均为「匹配」），
+/// 选项按中文名去重，保留最小 ID 作为代表；
+/// 过滤对局时经 `queue_ids_same_group` 按中文名分组匹配
 #[tauri::command]
 pub fn get_game_modes() -> Vec<GameModeOption> {
     let mut options = vec![GameModeOption {
@@ -174,7 +180,32 @@ pub fn get_game_modes() -> Vec<GameModeOption> {
         .collect();
 
     modes.sort_by_key(|k| k.value);
+    let mut seen = std::collections::HashSet::new();
+    modes.retain(|m| seen.insert(m.label.clone()));
     options.extend(modes);
 
     options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 模式选项不应出现重复中文名（人机有 6 个队列 ID、匹配有 2 个）
+    #[test]
+    fn game_modes_should_have_unique_labels() {
+        let options = get_game_modes();
+        let mut labels: Vec<&str> = options.iter().map(|o| o.label.as_str()).collect();
+        let total = labels.len();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), total, "模式选项存在重复中文名");
+    }
+
+    #[test]
+    fn game_modes_should_start_with_all_option() {
+        let options = get_game_modes();
+        assert_eq!(options[0].label, "全部");
+        assert_eq!(options[0].value, 0);
+    }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command/match_history.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/match_history.rs
@@ -248,10 +248,15 @@ pub async fn get_filter_match_history_by_name(
 ///
 /// # 匹配逻辑
 ///
-/// - 队列匹配: `filter_queue_id <= 0` 或 `game.queue_id == filter_queue_id`
+/// - 队列匹配: `filter_queue_id <= 0` 或与对局队列属于同一模式分组
+///   （多个队列 ID 共用同一中文名，如新旧人机队列同难度，按分组而非精确 ID 匹配）
 /// - 英雄匹配: `filter_champion_id <= 0` 或参与者中使用了指定英雄
 fn game_matches_filters(game: &Game, filter_queue_id: i32, filter_champion_id: i32) -> bool {
-    let queue_matches = filter_queue_id <= 0 || game.queue_id == filter_queue_id;
+    let queue_matches = filter_queue_id <= 0
+        || crate::constant::game::queue_ids_same_group(
+            game.queue_id as u32,
+            filter_queue_id as u32,
+        );
     let champion_matches = filter_champion_id <= 0
         || game
             .participants

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag.rs
@@ -590,7 +590,10 @@ fn count_gold_and_group_and_damage_dealt_to_champions(
     let mut all_damage_dealt_to_champions = 1;
 
     for game in &match_history.games.games {
-        if mode != 0 && game.queue_id != mode {
+        // 模式筛选按中文名分组匹配（如「人机(入门)」对应新旧 830/870 两个队列 ID）
+        if mode != 0
+            && !crate::constant::game::queue_ids_same_group(game.queue_id as u32, mode as u32)
+        {
             continue;
         }
 
@@ -653,7 +656,10 @@ fn count_win_and_loss(match_history: &MatchHistory, mode: i32) -> (i32, i32) {
     let mut select_losses = 0;
 
     for game in &match_history.games.games {
-        if mode == 0 || game.queue_id == mode {
+        // 模式筛选按中文名分组匹配（如「人机(入门)」对应新旧 830/870 两个队列 ID）
+        if mode == 0
+            || crate::constant::game::queue_ids_same_group(game.queue_id as u32, mode as u32)
+        {
             if game.participants[0].stats.win {
                 select_wins += 1;
             } else {
@@ -682,7 +688,10 @@ fn count_kda(match_history: &MatchHistory, mode: i32) -> (f64, f64, f64) {
     let mut assists = 0;
 
     for game in &match_history.games.games {
-        if mode != 0 && game.queue_id != mode {
+        // 模式筛选按中文名分组匹配（如「人机(入门)」对应新旧 830/870 两个队列 ID）
+        if mode != 0
+            && !crate::constant::game::queue_ids_same_group(game.queue_id as u32, mode as u32)
+        {
             continue;
         }
 

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -659,7 +659,10 @@ fn match_filter(game: &crate::lcu::api::match_history::Game, filter: &MatchFilte
     let p = &game.participants[0];
 
     match filter {
-        MatchFilter::Queue { ids } => ids.contains(&game.queue_id),
+        // 队列按中文名分组匹配（如「人机(入门)」对应新旧 830/870 两个 ID，选项去重后只存代表 ID）
+        MatchFilter::Queue { ids } => ids.iter().any(|id| {
+            crate::constant::game::queue_ids_same_group(game.queue_id as u32, *id as u32)
+        }),
         MatchFilter::Champion { ids } => ids.contains(&p.champion_id),
         MatchFilter::Stat { metric, op, value } => {
             let v = extract_game_metric(game, metric);

--- a/lol-record-analysis-tauri/src-tauri/src/constant/game.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/constant/game.rs
@@ -85,12 +85,15 @@ pub static QUEUE_ID_TO_CN: phf::Map<u32, &'static str> = phf_map! {
     480u32 => "快速匹配",
     490u32 => "匹配",
     700u32 => "冠军杯赛",
-    830u32 => "人机",
-    840u32 => "人机",
-    850u32 => "人机",
-    870u32 => "人机",
-    880u32 => "人机",
-    890u32 => "人机",
+    // 人机（合作对抗 AI）：830/840/850 为旧版队列（7.19 版本弃用，仅存在于老战绩），
+    // 870/880/890 为现行 ID，难度一一对应（入门/新手/一般）；
+    // 旧队列不单独标注，缺省共用同难度中文名，筛选经 queue_ids_same_group 按名称分组匹配
+    830u32 => "人机(入门)",
+    840u32 => "人机(新手)",
+    850u32 => "人机(一般)",
+    870u32 => "人机(入门)",
+    880u32 => "人机(新手)",
+    890u32 => "人机(一般)",
     900u32 => "无限乱斗",
     1700u32 => "斗魂竞技场",
     1900u32 => "无限火力",
@@ -387,4 +390,51 @@ pub fn get_queue_type_to_cn(key: &str) -> Option<&'static str> {
 
 pub fn get_queue_id_to_cn(key: u32) -> Option<&'static str> {
     QUEUE_ID_TO_CN.get(&key).copied()
+}
+
+/// 判断两个队列 ID 是否属于同一模式分组（ID 相同，或中文名相同）。
+///
+/// 多个队列 ID 会共用同一中文名（如新旧人机队列同难度：830/870 均为「人机(入门)」、
+/// 430/490 均为「匹配」）。模式筛选的下拉选项按中文名去重后只保留一个代表 ID，
+/// 过滤对局时必须按中文名分组匹配，否则只能命中代表 ID 对应的那一个队列。
+pub fn queue_ids_same_group(a: u32, b: u32) -> bool {
+    if a == b {
+        return true;
+    }
+    match (QUEUE_ID_TO_CN.get(&a), QUEUE_ID_TO_CN.get(&b)) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_id_should_match() {
+        assert!(queue_ids_same_group(420, 420));
+    }
+
+    #[test]
+    fn bot_queues_same_difficulty_should_be_same_group() {
+        // 新旧两代人机队列同难度中文名相同，应视为同组
+        assert!(queue_ids_same_group(830, 870)); // 入门
+        assert!(queue_ids_same_group(840, 880)); // 新手
+        assert!(queue_ids_same_group(850, 890)); // 一般
+    }
+
+    #[test]
+    fn different_modes_should_not_match() {
+        assert!(!queue_ids_same_group(420, 440));
+        assert!(!queue_ids_same_group(830, 420));
+        // 不同难度的人机不属于同组
+        assert!(!queue_ids_same_group(840, 890));
+    }
+
+    #[test]
+    fn unknown_ids_should_only_match_exactly() {
+        assert!(!queue_ids_same_group(999999, 830));
+        assert!(queue_ids_same_group(999999, 999999));
+    }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/match_history.rs
@@ -546,7 +546,7 @@ mod queue_name_tests {
     #[test]
     fn newly_mapped_queue_ids_resolve() {
         assert_eq!(resolve_queue_name_cn(480, "CLASSIC"), "快速匹配");
-        assert_eq!(resolve_queue_name_cn(870, "CLASSIC"), "人机");
+        assert_eq!(resolve_queue_name_cn(870, "CLASSIC"), "人机(入门)");
         // 真机实测：训练模式 queueId=3140 / gameMode=PRACTICETOOL（此前显示"未知"）
         assert_eq!(resolve_queue_name_cn(3140, "PRACTICETOOL"), "训练模式");
         assert_eq!(resolve_queue_name_cn(99999, "PRACTICETOOL"), "训练模式");


### PR DESCRIPTION
QUEUE_ID_TO_CN 收录了新旧两代共 6 个人机队列 ID(830-890,均译"人机"), 而 get_game_modes 把每个表条目都转成下拉选项,导致模式筛选出现 6 个重复
的"人机"(430/490 也产生 2 个重复的"匹配")。

- 人机按难度细分中文名:人机(入门)/人机(新手)/人机(一般),旧队列 (830/840/850,7.19 弃用)缺省共用同难度名称
- get_game_modes 按中文名去重,保留最小 ID 作为代表
- 新增 queue_ids_same_group:ID 相同或中文名相同视为同组;战绩筛选、 近期数据统计(胜负/KDA/参团率)、自定义标签队列条件共 5 处过滤点 由精确 ID 匹配改为分组匹配,选任一难度可同时命中新旧队列的对局