### PR TITLE
fix(ui): 自动弹窗关闭 auto-focus——消除打开时按钮上的幻影焦点环

### DIFF
--- a/lol-record-analysis-tauri/src/components/common/CloudConfigPullDialog.vue
+++ b/lol-record-analysis-tauri/src/components/common/CloudConfigPullDialog.vue
@@ -6,6 +6,7 @@
     style="max-width: 420px"
     :mask-closable="false"
     :close-on-esc="false"
+    :auto-focus="false"
   >
     <n-space vertical size="large">
       <n-space vertical :size="4">

--- a/lol-record-analysis-tauri/src/components/common/CloudSyncNoticeDialog.vue
+++ b/lol-record-analysis-tauri/src/components/common/CloudSyncNoticeDialog.vue
@@ -6,6 +6,7 @@
     style="max-width: 420px"
     :mask-closable="false"
     :close-on-esc="false"
+    :auto-focus="false"
   >
     <n-space vertical size="large">
       <!-- 两句拆成两个 n-text：避免单个长文本节点被 prettier 折行后，

--- a/lol-record-analysis-tauri/src/components/common/ErrorReportingConsentDialog.vue
+++ b/lol-record-analysis-tauri/src/components/common/ErrorReportingConsentDialog.vue
@@ -3,6 +3,7 @@
     :show="show"
     :mask-closable="false"
     :close-on-esc="false"
+    :auto-focus="false"
     transform-origin="center"
     @update:show="$emit('update:show', $event)"
   >

--- a/lol-record-analysis-tauri/src/components/common/__tests__/autoFocusDialogs.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/autoFocusDialogs.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * 自动弹出类弹窗的焦点行为回归测试
+ *
+ * 背景：全局 `:focus-visible` 是 JB 风格 2px 实心绿焦点环（global.css），本意是
+ * 键盘导航时才出现。但 n-modal 默认 `auto-focus` 会在弹窗打开时把焦点程序化地
+ * 移到第一个按钮上；应用启动后无任何指针交互时，Chromium 会让这种程序化聚焦
+ * 命中 `:focus-visible`，导致弹窗一打开按钮就带一圈绿色外边框（用户报障）。
+ *
+ * 因此约定：**启动时自动弹出的告知/确认弹窗必须显式关闭 auto-focus**。
+ */
+import { describe, it, expect } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import { NModal } from 'naive-ui'
+import CloudSyncNoticeDialog from '../CloudSyncNoticeDialog.vue'
+import CloudConfigPullDialog from '../CloudConfigPullDialog.vue'
+import ErrorReportingConsentDialog from '../ErrorReportingConsentDialog.vue'
+
+describe('auto-popup dialogs disable modal auto-focus', () => {
+  it.each([
+    ['CloudSyncNoticeDialog', CloudSyncNoticeDialog, { show: true }],
+    ['CloudConfigPullDialog', CloudConfigPullDialog, { show: true, updatedAt: 0 }],
+    ['ErrorReportingConsentDialog', ErrorReportingConsentDialog, { show: true }]
+  ] as const)('%s passes auto-focus=false to n-modal', (_name, component, props) => {
+    const wrapper = shallowMount(component, { props })
+    const modal = wrapper.findComponent(NModal)
+    expect(modal.exists()).toBe(true)
+    expect(modal.props('autoFocus')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- 根因：n-modal 默认 `auto-focus` 在弹窗打开时把焦点程序化移到第一个按钮；启动后无指针交互时 Chromium 让程序化聚焦命中 `:focus-visible`，全局 JB 风格 2px 实心绿焦点环（global.css）就套在"知道了"按钮上，看起来像一圈异常的绿色外边框
- 对三个启动时自动弹出的弹窗显式 `:auto-focus="false"`：CloudSyncNoticeDialog / CloudConfigPullDialog / ErrorReportingConsentDialog
- 新增回归测试 `autoFocusDialogs.spec.ts` 锁定"自动弹窗必须关 auto-focus"的约定

## Test plan
- [x] `npm run check` passes（0 errors）
- [x] `npm run test` passes（510 tests，含新增 3 个）
- [x] Manual: Windows 真机重置 `cloudSyncNoticeShown` 后复现弹窗——修复前 activeElement 为"知道了"且 outline 为 2px 实心绿；修复后焦点留在 body、outline none，绿环消失