### PR TITLE
feat(opgg): OP.GG 英雄数据层(T级/胜率/克制)拉取与缓存

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ wrangler.toml
 *.DS_Store
 
 config.yaml
+opgg_cache_*.json
 
 app.log.*

--- a/lol-record-analysis-tauri/src-tauri/src/command.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command.rs
@@ -45,6 +45,7 @@ pub mod fandom;
 pub mod info;
 pub mod launcher;
 pub mod match_history;
+pub mod opgg;
 pub mod rank;
 pub mod rule_config;
 pub mod session;

--- a/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
@@ -36,11 +36,30 @@ pub struct OpggStatus {
     pub champion_count: usize,
 }
 
+/// 当前 unix 秒；系统时钟异常时返回 0。
 fn now_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+/// 校验模式是否在白名单（"ranked"/"aram"）内。
+///
+/// # 参数
+/// - `mode`: 待校验的模式字符串
+///
+/// # 错误
+/// 不在白名单时返回 Err，消息附带合法取值提示。
+fn validate_mode(mode: &str) -> Result<(), String> {
+    if VALID_MODES.contains(&mode) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid opgg mode: {} (expected ranked|aram)",
+            mode
+        ))
+    }
 }
 
 /// 从快照生成状态对象。
@@ -103,9 +122,7 @@ where
     F: FnOnce(String) -> Fut,
     Fut: std::future::Future<Output = Result<OpggSnapshot, String>>,
 {
-    if !VALID_MODES.contains(&mode) {
-        return Err(format!("invalid opgg mode: {}", mode));
-    }
+    validate_mode(mode)?;
 
     // 1. 内存 fresh
     if let Some(snap) = mem_cache.get(mode).await {
@@ -184,7 +201,8 @@ pub async fn update_opgg_data(
 
 /// 查询单英雄元数据（T级/胜率等）。position 传 LCU 命名（TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY）。
 ///
-/// 快照不存在（从未成功拉取）时返回 Ok(None) 而非 Err——数据缺失是常态降级路径。
+/// 非法模式（不在 ranked/aram 白名单）返回 Err；数据未拉取仍是 Ok(None)——
+/// 数据缺失是常态降级路径，不应与参数错误混淆。
 #[tauri::command]
 pub async fn get_champion_meta(
     mode: String,
@@ -192,6 +210,7 @@ pub async fn get_champion_meta(
     position: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<Option<ChampionMeta>, String> {
+    validate_mode(&mode)?;
     match state.opgg_cache.get(&mode).await {
         Some(snap) => Ok(select_meta(&snap, champion_id, position.as_deref())),
         None => Ok(None),
@@ -199,24 +218,30 @@ pub async fn get_champion_meta(
 }
 
 /// 批量查询多个英雄的对线克制数据（服务本局 10 英雄一次取齐）。
+///
+/// 非法模式返回 Err；数据未拉取仍是 Ok(空 map)。
 #[tauri::command]
 pub async fn get_lane_counters(
     mode: String,
     champion_ids: Vec<i32>,
     state: State<'_, AppState>,
 ) -> Result<HashMap<i32, Vec<LaneCounter>>, String> {
+    validate_mode(&mode)?;
     match state.opgg_cache.get(&mode).await {
         Some(snap) => Ok(collect_counters(&snap, &champion_ids)),
         None => Ok(HashMap::new()),
     }
 }
 
-/// 查询某模式的数据状态；从未成功拉取过返回 Ok(None)。
+/// 查询某模式的数据状态。
+///
+/// 非法模式返回 Err；从未成功拉取过仍是 Ok(None)。
 #[tauri::command]
 pub async fn get_opgg_status(
     mode: String,
     state: State<'_, AppState>,
 ) -> Result<Option<OpggStatus>, String> {
+    validate_mode(&mode)?;
     let now = now_secs();
     match state.opgg_cache.get(&mode).await {
         Some(snap) => {
@@ -302,6 +327,16 @@ mod tests {
         assert_eq!(s.champion_count, 1);
     }
 
+    #[test]
+    fn validate_mode_should_accept_whitelisted_and_reject_others() {
+        assert!(validate_mode("ranked").is_ok());
+        assert!(validate_mode("aram").is_ok());
+
+        let err = validate_mode("urf").unwrap_err();
+        assert!(err.contains("invalid opgg mode"));
+        assert!(err.contains("expected ranked|aram"));
+    }
+
     // ---- ensure_snapshot_impl（降级链编排）----
 
     use crate::opgg::cache::TTL_SECS;
@@ -361,6 +396,39 @@ mod tests {
         );
         assert!(!stale);
         assert_eq!(snap.fetched_at, NOW - 100);
+    }
+
+    #[tokio::test]
+    async fn ensure_should_promote_fresh_disk_without_fetching() {
+        let cache_map = mem_cache();
+
+        let fetch_called = AtomicBool::new(false);
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            NOW,
+            |_m| {
+                fetch_called.store(true, Ordering::SeqCst);
+                async { Err::<OpggSnapshot, String>("should not fetch".into()) }
+            },
+            |_mode| Some(snapshot_at(NOW - 100)),
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !fetch_called.load(Ordering::SeqCst),
+            "磁盘 fresh 不应触发拉取"
+        );
+        assert!(!stale);
+        assert_eq!(snap.fetched_at, NOW - 100);
+        // 磁盘命中应回填内存，后续查询命令可复用
+        let cached = cache_map
+            .get("ranked")
+            .await
+            .expect("磁盘 fresh 应写入内存");
+        assert_eq!(cached.fetched_at, NOW - 100);
     }
 
     #[tokio::test]

--- a/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
@@ -1,0 +1,272 @@
+//! # OP.GG 命令模块
+//!
+//! 暴露 OP.GG 英雄数据给前端：更新快照、查英雄元数据、批量查对线克制、查数据状态。
+//!
+//! ## 降级链
+//!
+//! `ensure_opgg_snapshot`：内存 fresh → 磁盘 fresh → HTTP 拉取 →
+//! 过期缓存（标 `stale=true`）→ 全无则 Err。数据缺失不应阻塞任何上层功能，
+//! 前端拿到 Err/None 时隐藏相关 UI、AI prompt 跳过版本情报块即可。
+
+use crate::opgg::data::{ChampionMeta, LaneCounter, OpggSnapshot};
+use crate::opgg::{api, cache};
+use crate::state::AppState;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::State;
+
+/// 允许的模式白名单。
+const VALID_MODES: [&str; 2] = ["ranked", "aram"];
+
+/// OP.GG 数据状态（供设置页与对局页横幅展示）。
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OpggStatus {
+    /// 模式
+    pub mode: String,
+    /// patch 版本号
+    pub patch: String,
+    /// 拉取时间（unix 秒）
+    pub fetched_at: i64,
+    /// 是否过期数据（拉取失败降级）
+    pub stale: bool,
+    /// 覆盖英雄数
+    pub champion_count: usize,
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// 从快照生成状态对象。
+fn snapshot_status(snap: &OpggSnapshot, stale: bool) -> OpggStatus {
+    OpggStatus {
+        mode: snap.mode.clone(),
+        patch: snap.patch.clone(),
+        fetched_at: snap.fetched_at,
+        stale,
+        champion_count: snap.champions.len(),
+    }
+}
+
+/// 查某英雄的元数据：指定分路精确命中 → 回退主分路 → None。
+fn select_meta(
+    snap: &OpggSnapshot,
+    champion_id: i32,
+    position: Option<&str>,
+) -> Option<ChampionMeta> {
+    let metas = snap.champions.get(&champion_id)?;
+    if let Some(pos) = position {
+        if let Some(m) = metas.iter().find(|m| m.position == pos) {
+            return Some(m.clone());
+        }
+    }
+    metas
+        .iter()
+        .find(|m| m.is_main_position)
+        .or_else(|| metas.first())
+        .cloned()
+}
+
+/// 批量收集指定英雄的克制数据（快照中没有的英雄直接缺席结果）。
+fn collect_counters(snap: &OpggSnapshot, champion_ids: &[i32]) -> HashMap<i32, Vec<LaneCounter>> {
+    champion_ids
+        .iter()
+        .filter_map(|id| snap.counters.get(id).map(|v| (*id, v.clone())))
+        .collect()
+}
+
+/// 获取某模式快照的核心编排（命令层与启动预热共用）。
+///
+/// # 返回值
+/// `(快照, stale)`：stale=true 表示拉取失败、返回的是过期缓存。
+pub async fn ensure_opgg_snapshot(
+    state: &AppState,
+    mode: &str,
+) -> Result<(Arc<OpggSnapshot>, bool), String> {
+    if !VALID_MODES.contains(&mode) {
+        return Err(format!("invalid opgg mode: {}", mode));
+    }
+    let now = now_secs();
+
+    // 1. 内存 fresh
+    if let Some(snap) = state.opgg_cache.get(mode).await {
+        if cache::is_fresh(&snap, now) {
+            return Ok((snap, false));
+        }
+    }
+
+    // 2. 磁盘 fresh（跨重启复用）
+    if let Some(disk) = cache::load(mode) {
+        if cache::is_fresh(&disk, now) {
+            let arc = Arc::new(disk);
+            state.opgg_cache.insert(mode.to_string(), arc.clone()).await;
+            return Ok((arc, false));
+        }
+    }
+
+    // 3. HTTP 拉取
+    match api::fetch_mode(mode).await {
+        Ok(snap) => {
+            if let Err(e) = cache::save(&snap) {
+                log::warn!("OP.GG cache save failed: {}", e);
+            }
+            let arc = Arc::new(snap);
+            state.opgg_cache.insert(mode.to_string(), arc.clone()).await;
+            Ok((arc, false))
+        }
+        Err(e) => {
+            // 4. 过期缓存降级（内存优先，其次磁盘）
+            log::warn!(
+                "OP.GG fetch {} failed, falling back to stale cache: {}",
+                mode,
+                e
+            );
+            if let Some(snap) = state.opgg_cache.get(mode).await {
+                return Ok((snap, true));
+            }
+            if let Some(disk) = cache::load(mode) {
+                let arc = Arc::new(disk);
+                state.opgg_cache.insert(mode.to_string(), arc.clone()).await;
+                return Ok((arc, true));
+            }
+            Err(e)
+        }
+    }
+}
+
+/// 更新（或确保）某模式的 OP.GG 数据，返回数据状态。
+#[tauri::command]
+pub async fn update_opgg_data(
+    mode: String,
+    state: State<'_, AppState>,
+) -> Result<OpggStatus, String> {
+    let (snap, stale) = ensure_opgg_snapshot(&state, &mode).await?;
+    Ok(snapshot_status(&snap, stale))
+}
+
+/// 查询单英雄元数据（T级/胜率等）。position 传 LCU 命名（TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY）。
+///
+/// 快照不存在（从未成功拉取）时返回 Ok(None) 而非 Err——数据缺失是常态降级路径。
+#[tauri::command]
+pub async fn get_champion_meta(
+    mode: String,
+    champion_id: i32,
+    position: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<Option<ChampionMeta>, String> {
+    match state.opgg_cache.get(&mode).await {
+        Some(snap) => Ok(select_meta(&snap, champion_id, position.as_deref())),
+        None => Ok(None),
+    }
+}
+
+/// 批量查询多个英雄的对线克制数据（服务本局 10 英雄一次取齐）。
+#[tauri::command]
+pub async fn get_lane_counters(
+    mode: String,
+    champion_ids: Vec<i32>,
+    state: State<'_, AppState>,
+) -> Result<HashMap<i32, Vec<LaneCounter>>, String> {
+    match state.opgg_cache.get(&mode).await {
+        Some(snap) => Ok(collect_counters(&snap, &champion_ids)),
+        None => Ok(HashMap::new()),
+    }
+}
+
+/// 查询某模式的数据状态；从未成功拉取过返回 Ok(None)。
+#[tauri::command]
+pub async fn get_opgg_status(
+    mode: String,
+    state: State<'_, AppState>,
+) -> Result<Option<OpggStatus>, String> {
+    let now = now_secs();
+    match state.opgg_cache.get(&mode).await {
+        Some(snap) => {
+            let stale = !cache::is_fresh(&snap, now);
+            Ok(Some(snapshot_status(&snap, stale)))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::opgg::data::{ChampionMeta, LaneCounter, OpggSnapshot};
+    use std::collections::HashMap;
+
+    fn meta(champion_id: i32, position: &str, is_main: bool) -> ChampionMeta {
+        ChampionMeta {
+            champion_id,
+            position: position.into(),
+            tier: 1,
+            rank: 1,
+            win_rate: 0.52,
+            pick_rate: 0.1,
+            ban_rate: 0.05,
+            role_rate: 0.8,
+            is_main_position: is_main,
+        }
+    }
+
+    fn snapshot() -> OpggSnapshot {
+        let mut champions = HashMap::new();
+        champions.insert(86, vec![meta(86, "TOP", true), meta(86, "MIDDLE", false)]);
+        let mut counters = HashMap::new();
+        counters.insert(
+            86,
+            vec![LaneCounter {
+                opponent_id: 10,
+                position: "TOP".into(),
+                subject_win_rate: 0.447,
+                play: 4710,
+            }],
+        );
+        OpggSnapshot {
+            mode: "ranked".into(),
+            patch: "16.13".into(),
+            fetched_at: 1_752_000_000,
+            champions,
+            counters,
+        }
+    }
+
+    #[test]
+    fn select_meta_should_prefer_exact_position_then_main() {
+        let snap = snapshot();
+        // 指定分路精确命中
+        let m = select_meta(&snap, 86, Some("MIDDLE")).unwrap();
+        assert_eq!(m.position, "MIDDLE");
+        // 指定分路无数据 → 回退主分路
+        let m = select_meta(&snap, 86, Some("UTILITY")).unwrap();
+        assert_eq!(m.position, "TOP");
+        // 不指定分路 → 主分路
+        let m = select_meta(&snap, 86, None).unwrap();
+        assert_eq!(m.position, "TOP");
+        // 未知英雄 → None
+        assert!(select_meta(&snap, 12345, None).is_none());
+    }
+
+    #[test]
+    fn collect_counters_should_only_include_requested_ids() {
+        let snap = snapshot();
+        let got = collect_counters(&snap, &[86, 999]);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[&86][0].opponent_id, 10);
+    }
+
+    #[test]
+    fn status_should_reflect_snapshot() {
+        let s = snapshot_status(&snapshot(), true);
+        assert_eq!(s.mode, "ranked");
+        assert_eq!(s.patch, "16.13");
+        assert!(s.stale);
+        assert_eq!(s.champion_count, 1);
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
@@ -81,43 +81,56 @@ fn collect_counters(snap: &OpggSnapshot, champion_ids: &[i32]) -> HashMap<i32, V
         .collect()
 }
 
-/// 获取某模式快照的核心编排（命令层与启动预热共用）。
+/// 降级链编排的可注入实现（供单测注入假 fetch / 假磁盘）。
 ///
-/// # 返回值
-/// `(快照, stale)`：stale=true 表示拉取失败、返回的是过期缓存。
-pub async fn ensure_opgg_snapshot(
-    state: &AppState,
+/// 与 [`ensure_opgg_snapshot`] 行为完全一致，仅把外部效应
+/// （HTTP 拉取、磁盘读写、当前时间）参数化。
+///
+/// # 参数
+/// - `mem_cache`: 内存缓存（无 TTL，保留最后已知快照供降级）
+/// - `now`: 当前 unix 秒（新鲜度判定基准）
+/// - `fetch`: HTTP 拉取（生产为 `api::fetch_mode`）
+/// - `disk_load` / `disk_save`: 磁盘缓存读写（生产为 `cache::load` / `cache::save`）
+async fn ensure_snapshot_impl<F, Fut>(
+    mem_cache: &moka::future::Cache<String, Arc<OpggSnapshot>>,
     mode: &str,
-) -> Result<(Arc<OpggSnapshot>, bool), String> {
+    now: i64,
+    fetch: F,
+    disk_load: impl Fn(&str) -> Option<OpggSnapshot>,
+    disk_save: impl Fn(&OpggSnapshot) -> Result<(), String>,
+) -> Result<(Arc<OpggSnapshot>, bool), String>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = Result<OpggSnapshot, String>>,
+{
     if !VALID_MODES.contains(&mode) {
         return Err(format!("invalid opgg mode: {}", mode));
     }
-    let now = now_secs();
 
     // 1. 内存 fresh
-    if let Some(snap) = state.opgg_cache.get(mode).await {
+    if let Some(snap) = mem_cache.get(mode).await {
         if cache::is_fresh(&snap, now) {
             return Ok((snap, false));
         }
     }
 
     // 2. 磁盘 fresh（跨重启复用）
-    if let Some(disk) = cache::load(mode) {
+    if let Some(disk) = disk_load(mode) {
         if cache::is_fresh(&disk, now) {
             let arc = Arc::new(disk);
-            state.opgg_cache.insert(mode.to_string(), arc.clone()).await;
+            mem_cache.insert(mode.to_string(), arc.clone()).await;
             return Ok((arc, false));
         }
     }
 
     // 3. HTTP 拉取
-    match api::fetch_mode(mode).await {
+    match fetch(mode.to_string()).await {
         Ok(snap) => {
-            if let Err(e) = cache::save(&snap) {
+            if let Err(e) = disk_save(&snap) {
                 log::warn!("OP.GG cache save failed: {}", e);
             }
             let arc = Arc::new(snap);
-            state.opgg_cache.insert(mode.to_string(), arc.clone()).await;
+            mem_cache.insert(mode.to_string(), arc.clone()).await;
             Ok((arc, false))
         }
         Err(e) => {
@@ -127,17 +140,36 @@ pub async fn ensure_opgg_snapshot(
                 mode,
                 e
             );
-            if let Some(snap) = state.opgg_cache.get(mode).await {
+            if let Some(snap) = mem_cache.get(mode).await {
                 return Ok((snap, true));
             }
-            if let Some(disk) = cache::load(mode) {
+            if let Some(disk) = disk_load(mode) {
                 let arc = Arc::new(disk);
-                state.opgg_cache.insert(mode.to_string(), arc.clone()).await;
+                mem_cache.insert(mode.to_string(), arc.clone()).await;
                 return Ok((arc, true));
             }
             Err(e)
         }
     }
+}
+
+/// 获取某模式快照的核心编排（命令层与启动预热共用）。
+///
+/// # 返回值
+/// `(快照, stale)`：stale=true 表示拉取失败、返回的是过期缓存。
+pub async fn ensure_opgg_snapshot(
+    state: &AppState,
+    mode: &str,
+) -> Result<(Arc<OpggSnapshot>, bool), String> {
+    ensure_snapshot_impl(
+        &state.opgg_cache,
+        mode,
+        now_secs(),
+        |m| async move { api::fetch_mode(&m).await },
+        cache::load,
+        cache::save,
+    )
+    .await
 }
 
 /// 更新（或确保）某模式的 OP.GG 数据，返回数据状态。
@@ -268,5 +300,177 @@ mod tests {
         assert_eq!(s.patch, "16.13");
         assert!(s.stale);
         assert_eq!(s.champion_count, 1);
+    }
+
+    // ---- ensure_snapshot_impl（降级链编排）----
+
+    use crate::opgg::cache::TTL_SECS;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// 测试基准时刻。
+    const NOW: i64 = 2_000_000_000;
+
+    /// 指定拉取时刻的快照（内容复用 [`snapshot`]）。
+    fn snapshot_at(fetched_at: i64) -> OpggSnapshot {
+        OpggSnapshot {
+            fetched_at,
+            ..snapshot()
+        }
+    }
+
+    /// 空内存缓存（与 `AppState::opgg_cache` 同构：无 TTL）。
+    fn mem_cache() -> moka::future::Cache<String, Arc<OpggSnapshot>> {
+        moka::future::Cache::builder().build()
+    }
+
+    /// 恒不命中的磁盘读。
+    fn disk_none(_mode: &str) -> Option<OpggSnapshot> {
+        None
+    }
+
+    /// 恒成功的磁盘写。
+    fn disk_save_ok(_snap: &OpggSnapshot) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ensure_should_return_fresh_memory_without_fetching() {
+        let cache_map = mem_cache();
+        cache_map
+            .insert("ranked".into(), Arc::new(snapshot_at(NOW - 100)))
+            .await;
+
+        let fetch_called = AtomicBool::new(false);
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            NOW,
+            |_m| {
+                fetch_called.store(true, Ordering::SeqCst);
+                async { Err::<OpggSnapshot, String>("should not fetch".into()) }
+            },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !fetch_called.load(Ordering::SeqCst),
+            "内存 fresh 不应触发拉取"
+        );
+        assert!(!stale);
+        assert_eq!(snap.fetched_at, NOW - 100);
+    }
+
+    #[tokio::test]
+    async fn ensure_should_fetch_and_cache_on_success() {
+        let cache_map = mem_cache();
+        let saved = AtomicBool::new(false);
+
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            NOW,
+            |_m| async { Ok(snapshot_at(NOW)) },
+            disk_none,
+            |_s| {
+                saved.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!stale);
+        assert_eq!(snap.fetched_at, NOW);
+        assert!(saved.load(Ordering::SeqCst), "拉取成功应落盘");
+        let cached = cache_map.get("ranked").await.expect("拉取成功应写入内存");
+        assert_eq!(cached.fetched_at, NOW);
+    }
+
+    #[tokio::test]
+    async fn ensure_should_fall_back_to_stale_memory_on_fetch_failure() {
+        let cache_map = mem_cache();
+        // 过期快照仍留在内存（opgg_cache 无 TTL 的意义所在）
+        cache_map
+            .insert("ranked".into(), Arc::new(snapshot_at(NOW - TTL_SECS - 100)))
+            .await;
+
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            NOW,
+            |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(stale, "拉取失败回退过期内存应标 stale");
+        assert_eq!(snap.fetched_at, NOW - TTL_SECS - 100);
+    }
+
+    #[tokio::test]
+    async fn ensure_should_fall_back_to_stale_disk_on_fetch_failure() {
+        let cache_map = mem_cache();
+
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            NOW,
+            |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
+            |_mode| Some(snapshot_at(NOW - TTL_SECS - 100)),
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(stale, "拉取失败回退过期磁盘应标 stale");
+        assert_eq!(snap.fetched_at, NOW - TTL_SECS - 100);
+        // 降级结果也应写入内存，后续查询命令可用
+        assert!(cache_map.get("ranked").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn ensure_should_err_when_fetch_fails_and_no_cache_anywhere() {
+        let cache_map = mem_cache();
+
+        let err = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            NOW,
+            |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, "network down");
+    }
+
+    #[tokio::test]
+    async fn ensure_should_reject_invalid_mode() {
+        let cache_map = mem_cache();
+
+        let fetch_called = AtomicBool::new(false);
+        let err = ensure_snapshot_impl(
+            &cache_map,
+            "urf",
+            NOW,
+            |_m| {
+                fetch_called.store(true, Ordering::SeqCst);
+                async { Err::<OpggSnapshot, String>("should not fetch".into()) }
+            },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.contains("invalid opgg mode"));
+        assert!(!fetch_called.load(Ordering::SeqCst));
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lib.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lib.rs
@@ -6,5 +6,6 @@ pub mod fandom;
 pub mod game_state_monitor;
 pub mod lcu;
 pub mod observability;
+pub mod opgg;
 pub mod rule_engine;
 pub mod state;

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -147,6 +147,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::session::get_session_data,
             command::fandom::update_fandom_data,
             command::fandom::get_aram_balance,
+            command::opgg::update_opgg_data,
+            command::opgg::get_champion_meta,
+            command::opgg::get_lane_counters,
+            command::opgg::get_opgg_status,
             command::system::relaunch_as_admin,
             command::system::get_device_id,
             command::launcher::launch_league,
@@ -193,6 +197,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         });
 
         // 启动自动化系统
+        let warm_handle = app.handle().clone();
         tauri::async_runtime::spawn(async move {
             log::info!("Starting automation system...");
             tokio::spawn(async {
@@ -201,6 +206,25 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
             // Initialize asset caches
             asset_api::init().await;
+
+            // OP.GG 数据预热：失败仅告警，不阻塞启动（对局页/AI 会按需再触发）。
+            let opgg_state = warm_handle.state::<AppState>();
+            for mode in ["ranked", "aram"] {
+                match lol_record_analysis_app_lib::command::opgg::ensure_opgg_snapshot(
+                    &opgg_state,
+                    mode,
+                )
+                .await
+                {
+                    Ok((snap, stale)) => log::info!(
+                        "OP.GG warmup {}: patch {}, stale={}",
+                        mode,
+                        snap.patch,
+                        stale
+                    ),
+                    Err(e) => log::warn!("OP.GG warmup {} failed: {}", mode, e),
+                }
+            }
         });
 
         // 启动游戏状态监听器

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
@@ -1,0 +1,226 @@
+//! OP.GG 内部 API 客户端：响应解析（HTTP 拉取见 `fetch_mode`，Task 3 添加）。
+
+use crate::opgg::data::{normalize_position, ChampionMeta, LaneCounter, OpggSnapshot};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// OP.GG 原始响应（只解出需要的字段，其余忽略；可空字段全部 Option 容错）。
+#[derive(Deserialize)]
+struct RawResponse {
+    data: Vec<RawChampion>,
+    meta: RawMeta,
+}
+
+#[derive(Deserialize)]
+struct RawMeta {
+    version: String,
+}
+
+#[derive(Deserialize)]
+struct RawChampion {
+    id: i32,
+    average_stats: Option<RawStats>,
+    positions: Option<Vec<RawPosition>>,
+}
+
+#[derive(Deserialize)]
+struct RawStats {
+    win_rate: Option<f64>,
+    pick_rate: Option<f64>,
+    ban_rate: Option<f64>,
+    role_rate: Option<f64>,
+    tier: Option<i32>,
+    rank: Option<i32>,
+    tier_data: Option<RawTierData>,
+}
+
+#[derive(Deserialize)]
+struct RawTierData {
+    tier: Option<i32>,
+    rank: Option<i32>,
+}
+
+#[derive(Deserialize)]
+struct RawPosition {
+    name: String,
+    stats: Option<RawStats>,
+    counters: Option<Vec<RawCounter>>,
+}
+
+#[derive(Deserialize)]
+struct RawCounter {
+    champion_id: i32,
+    play: i64,
+    win: i64,
+}
+
+/// 把 OP.GG 响应体解析为 [`OpggSnapshot`]。
+///
+/// # 参数
+/// - `mode`: "ranked" | "aram"（写入快照，不参与解析分支——分路有无由数据自身决定）
+/// - `body`: 响应体 JSON 字符串
+/// - `fetched_at`: 拉取时间（unix 秒），由调用方注入以便测试
+///
+/// # 容错
+/// - `positions` 为 null（aram）→ 用 `average_stats` 生成单条 position="" 的记录
+/// - `ban_rate`/`tier` 等为 null → 取 0
+/// - 单个英雄缺 `average_stats` 且无 positions → 跳过该英雄
+pub fn parse_snapshot(mode: &str, body: &str, fetched_at: i64) -> Result<OpggSnapshot, String> {
+    let raw: RawResponse =
+        serde_json::from_str(body).map_err(|e| format!("OP.GG response parse error: {}", e))?;
+
+    let mut champions: HashMap<i32, Vec<ChampionMeta>> = HashMap::new();
+    let mut counters: HashMap<i32, Vec<LaneCounter>> = HashMap::new();
+
+    for champ in &raw.data {
+        match &champ.positions {
+            Some(positions) if !positions.is_empty() => {
+                // 有分路数据（ranked）：每分路一条，role_rate 最高者为主分路
+                let main_idx = positions
+                    .iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| {
+                        let ra = a.stats.as_ref().and_then(|s| s.role_rate).unwrap_or(0.0);
+                        let rb = b.stats.as_ref().and_then(|s| s.role_rate).unwrap_or(0.0);
+                        ra.partial_cmp(&rb).unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+
+                for (i, pos) in positions.iter().enumerate() {
+                    let position = normalize_position(&pos.name);
+                    let stats = match &pos.stats {
+                        Some(s) => s,
+                        None => continue,
+                    };
+                    let tier_data = stats.tier_data.as_ref();
+                    champions.entry(champ.id).or_default().push(ChampionMeta {
+                        champion_id: champ.id,
+                        position: position.clone(),
+                        tier: tier_data.and_then(|t| t.tier).or(stats.tier).unwrap_or(0),
+                        rank: tier_data.and_then(|t| t.rank).or(stats.rank).unwrap_or(0),
+                        win_rate: stats.win_rate.unwrap_or(0.0),
+                        pick_rate: stats.pick_rate.unwrap_or(0.0),
+                        ban_rate: stats.ban_rate.unwrap_or(0.0),
+                        role_rate: stats.role_rate.unwrap_or(0.0),
+                        is_main_position: i == main_idx,
+                    });
+
+                    for c in pos.counters.iter().flatten() {
+                        if c.play <= 0 {
+                            continue;
+                        }
+                        counters.entry(champ.id).or_default().push(LaneCounter {
+                            opponent_id: c.champion_id,
+                            position: position.clone(),
+                            subject_win_rate: c.win as f64 / c.play as f64,
+                            play: c.play,
+                        });
+                    }
+                }
+            }
+            _ => {
+                // 无分路数据（aram）：用 average_stats 生成单条记录
+                let stats = match &champ.average_stats {
+                    Some(s) => s,
+                    None => continue,
+                };
+                champions.entry(champ.id).or_default().push(ChampionMeta {
+                    champion_id: champ.id,
+                    position: String::new(),
+                    tier: stats.tier.unwrap_or(0),
+                    rank: stats.rank.unwrap_or(0),
+                    win_rate: stats.win_rate.unwrap_or(0.0),
+                    pick_rate: stats.pick_rate.unwrap_or(0.0),
+                    ban_rate: stats.ban_rate.unwrap_or(0.0),
+                    role_rate: 1.0,
+                    is_main_position: true,
+                });
+            }
+        }
+    }
+
+    if champions.is_empty() {
+        return Err("OP.GG response contained no champion data".to_string());
+    }
+
+    Ok(OpggSnapshot {
+        mode: mode.to_string(),
+        patch: raw.meta.version,
+        fetched_at,
+        champions,
+        counters,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RANKED_FIXTURE: &str = include_str!("fixtures/ranked_sample.json");
+    const ARAM_FIXTURE: &str = include_str!("fixtures/aram_sample.json");
+
+    #[test]
+    fn should_parse_ranked_snapshot_with_positions_and_counters() {
+        let snap = parse_snapshot("ranked", RANKED_FIXTURE, 1_752_000_000).unwrap();
+        assert_eq!(snap.mode, "ranked");
+        assert_eq!(snap.patch, "16.13");
+        assert_eq!(snap.fetched_at, 1_752_000_000);
+
+        // 盖伦：单分路 TOP，T1
+        let garen = &snap.champions[&86];
+        assert_eq!(garen.len(), 1);
+        assert_eq!(garen[0].position, "TOP");
+        assert_eq!(garen[0].tier, 1);
+        assert!((garen[0].win_rate - 0.517991).abs() < 1e-6);
+        assert!(garen[0].is_main_position);
+
+        // 盖伦 counters：3 条，win/play 即对位胜率
+        let garen_counters = &snap.counters[&86];
+        assert_eq!(garen_counters.len(), 3);
+        assert_eq!(garen_counters[0].opponent_id, 10);
+        assert_eq!(garen_counters[0].position, "TOP");
+        assert!((garen_counters[0].subject_win_rate - 2107.0 / 4710.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn should_normalize_positions_and_mark_main_by_role_rate() {
+        let snap = parse_snapshot("ranked", RANKED_FIXTURE, 0).unwrap();
+        let c = &snap.champions[&999];
+        assert_eq!(c.len(), 2);
+        // OP.GG 命名 → LCU 命名
+        let mid = c.iter().find(|m| m.position == "MIDDLE").unwrap();
+        let adc = c.iter().find(|m| m.position == "BOTTOM").unwrap();
+        // role_rate 最高的是主分路
+        assert!(mid.is_main_position);
+        assert!(!adc.is_main_position);
+        assert_eq!(mid.tier, 2);
+    }
+
+    #[test]
+    fn should_parse_aram_with_null_positions_and_null_ban_rate() {
+        let snap = parse_snapshot("aram", ARAM_FIXTURE, 0).unwrap();
+        let c = &snap.champions[&1];
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].position, ""); // 无分路模式
+        assert_eq!(c[0].tier, 2);
+        assert_eq!(c[0].ban_rate, 0.0); // null → 0.0
+        assert!(c[0].is_main_position);
+        assert!(snap.counters.is_empty()); // aram 无 counter
+    }
+
+    #[test]
+    fn should_reject_malformed_body() {
+        assert!(parse_snapshot("ranked", "not json", 0).is_err());
+        assert!(parse_snapshot("ranked", r#"{"foo": 1}"#, 0).is_err());
+    }
+
+    #[test]
+    fn should_normalize_opgg_position_names() {
+        assert_eq!(crate::opgg::data::normalize_position("MID"), "MIDDLE");
+        assert_eq!(crate::opgg::data::normalize_position("ADC"), "BOTTOM");
+        assert_eq!(crate::opgg::data::normalize_position("SUPPORT"), "UTILITY");
+        assert_eq!(crate::opgg::data::normalize_position("TOP"), "TOP");
+        assert_eq!(crate::opgg::data::normalize_position("JUNGLE"), "JUNGLE");
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
@@ -1,8 +1,16 @@
 //! OP.GG 内部 API 客户端：响应解析（HTTP 拉取见 `fetch_mode`，Task 3 添加）。
 
 use crate::opgg::data::{normalize_position, ChampionMeta, LaneCounter, OpggSnapshot};
+use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const BASE_URL: &str = "https://lol-api-champion.op.gg/api/global/champions";
+/// ranked 数据取 emerald+ 分段（样本大且贴近排位主流生态）。
+const RANKED_TIER_PARAM: &str = "tier=emerald_plus";
+/// 与 fandom::api 一致的浏览器 UA——OP.GG 对无 UA 请求可能拒绝。
+const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
 
 /// OP.GG 原始响应（只解出需要的字段，其余忽略；可空字段全部 Option 容错）。
 #[derive(Deserialize)]
@@ -52,6 +60,53 @@ struct RawCounter {
     champion_id: i32,
     play: i64,
     win: i64,
+}
+
+/// 拼接某模式的请求 URL（仅 ranked 需要 tier 参数）。
+pub fn mode_url(mode: &str) -> String {
+    if mode == "ranked" {
+        format!("{}/{}?{}", BASE_URL, mode, RANKED_TIER_PARAM)
+    } else {
+        format!("{}/{}", BASE_URL, mode)
+    }
+}
+
+/// 拉取并解析某模式的完整快照。
+///
+/// # 参数
+/// - `mode`: "ranked" | "aram"
+///
+/// # 错误
+/// 网络失败、非 2xx、响应解析失败时返回 Err；调用方负责降级到缓存。
+pub async fn fetch_mode(mode: &str) -> Result<OpggSnapshot, String> {
+    let url = mode_url(mode);
+    log::info!("Fetching OP.GG data: {}", url);
+
+    let client = Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client.get(&url).send().await.map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("OP.GG returned status {}", resp.status()));
+    }
+    let body = resp.text().await.map_err(|e| e.to_string())?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_secs() as i64;
+
+    let snap = parse_snapshot(mode, &body, now)?;
+    log::info!(
+        "OP.GG {} snapshot: patch {}, {} champions",
+        mode,
+        snap.patch,
+        snap.champions.len()
+    );
+    Ok(snap)
 }
 
 /// 把 OP.GG 响应体解析为 [`OpggSnapshot`]。
@@ -222,5 +277,27 @@ mod tests {
         assert_eq!(crate::opgg::data::normalize_position("SUPPORT"), "UTILITY");
         assert_eq!(crate::opgg::data::normalize_position("TOP"), "TOP");
         assert_eq!(crate::opgg::data::normalize_position("JUNGLE"), "JUNGLE");
+    }
+
+    #[test]
+    fn mode_url_should_add_tier_param_only_for_ranked() {
+        assert_eq!(
+            mode_url("ranked"),
+            "https://lol-api-champion.op.gg/api/global/champions/ranked?tier=emerald_plus"
+        );
+        assert_eq!(
+            mode_url("aram"),
+            "https://lol-api-champion.op.gg/api/global/champions/aram"
+        );
+    }
+
+    /// 真实网络冒烟测试：默认忽略，本机联调时 `cargo test opgg -- --ignored` 手动跑。
+    #[tokio::test]
+    #[ignore]
+    async fn live_fetch_ranked_should_return_snapshot() {
+        let snap = fetch_mode("ranked").await.expect("live fetch");
+        assert!(!snap.patch.is_empty());
+        assert!(snap.champions.len() > 100);
+        assert!(!snap.counters.is_empty());
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
@@ -9,7 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const BASE_URL: &str = "https://lol-api-champion.op.gg/api/global/champions";
 /// ranked 数据取 emerald+ 分段（样本大且贴近排位主流生态）。
 const RANKED_TIER_PARAM: &str = "tier=emerald_plus";
-/// 与 fandom::api 一致的浏览器 UA——OP.GG 对无 UA 请求可能拒绝。
+/// 同 fandom::api 风格的浏览器 UA——OP.GG 对无 UA 请求可能拒绝。
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
 
 /// OP.GG 原始响应（只解出需要的字段，其余忽略；可空字段全部 Option 容错）。

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
@@ -1,0 +1,103 @@
+//! OP.GG 快照磁盘缓存。
+//!
+//! 按模式一个 JSON 文件（`opgg_cache_ranked.json` / `opgg_cache_aram.json`），
+//! 工作目录相对路径——与 `config.yaml` 相同的存储约定。
+//! 一个 patch 内数据基本不变，TTL 取 12 小时。
+
+use crate::opgg::data::OpggSnapshot;
+use std::path::{Path, PathBuf};
+
+/// 快照有效期：12 小时（秒）。
+pub const TTL_SECS: i64 = 12 * 60 * 60;
+
+/// 快照是否仍新鲜（`now - fetched_at < TTL_SECS`）。
+pub fn is_fresh(snapshot: &OpggSnapshot, now: i64) -> bool {
+    now - snapshot.fetched_at < TTL_SECS
+}
+
+/// 某模式的默认缓存文件路径（工作目录相对）。
+pub fn default_path(mode: &str) -> PathBuf {
+    PathBuf::from(format!("opgg_cache_{}.json", mode))
+}
+
+/// 序列化快照写入指定路径。
+pub fn save_to_path(snapshot: &OpggSnapshot, path: &Path) -> Result<(), String> {
+    let json = serde_json::to_string(snapshot).map_err(|e| e.to_string())?;
+    std::fs::write(path, json).map_err(|e| format!("write {}: {}", path.display(), e))
+}
+
+/// 从指定路径读取快照；文件缺失或损坏返回 None（缓存问题不阻塞主流程）。
+pub fn load_from_path(path: &Path) -> Option<OpggSnapshot> {
+    let content = std::fs::read_to_string(path).ok()?;
+    match serde_json::from_str(&content) {
+        Ok(snap) => Some(snap),
+        Err(e) => {
+            log::warn!("OP.GG cache corrupt at {}: {}", path.display(), e);
+            None
+        }
+    }
+}
+
+/// 写入默认路径。
+pub fn save(snapshot: &OpggSnapshot) -> Result<(), String> {
+    save_to_path(snapshot, &default_path(&snapshot.mode))
+}
+
+/// 从默认路径读取。
+pub fn load(mode: &str) -> Option<OpggSnapshot> {
+    load_from_path(&default_path(mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::opgg::data::OpggSnapshot;
+    use std::collections::HashMap;
+
+    fn snap(fetched_at: i64) -> OpggSnapshot {
+        OpggSnapshot {
+            mode: "ranked".into(),
+            patch: "16.13".into(),
+            fetched_at,
+            champions: HashMap::new(),
+            counters: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn should_round_trip_snapshot_via_disk() {
+        let path = std::env::temp_dir().join("opgg_cache_test_roundtrip.json");
+        let original = snap(1_752_000_000);
+        save_to_path(&original, &path).unwrap();
+        let loaded = load_from_path(&path).expect("should load");
+        assert_eq!(loaded.patch, "16.13");
+        assert_eq!(loaded.fetched_at, 1_752_000_000);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn should_return_none_for_missing_or_corrupt_file() {
+        let missing = std::env::temp_dir().join("opgg_cache_test_missing.json");
+        let _ = std::fs::remove_file(&missing);
+        assert!(load_from_path(&missing).is_none());
+
+        let corrupt = std::env::temp_dir().join("opgg_cache_test_corrupt.json");
+        std::fs::write(&corrupt, "not json").unwrap();
+        assert!(load_from_path(&corrupt).is_none());
+        let _ = std::fs::remove_file(&corrupt);
+    }
+
+    #[test]
+    fn should_judge_freshness_by_ttl() {
+        let now = 1_752_000_000;
+        assert!(is_fresh(&snap(now - TTL_SECS + 1), now));
+        assert!(!is_fresh(&snap(now - TTL_SECS), now));
+        assert!(!is_fresh(&snap(now - TTL_SECS - 1), now));
+    }
+
+    #[test]
+    fn default_path_should_be_mode_scoped_relative_file() {
+        assert_eq!(default_path("ranked").to_str().unwrap(), "opgg_cache_ranked.json");
+        assert_eq!(default_path("aram").to_str().unwrap(), "opgg_cache_aram.json");
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
@@ -97,7 +97,13 @@ mod tests {
 
     #[test]
     fn default_path_should_be_mode_scoped_relative_file() {
-        assert_eq!(default_path("ranked").to_str().unwrap(), "opgg_cache_ranked.json");
-        assert_eq!(default_path("aram").to_str().unwrap(), "opgg_cache_aram.json");
+        assert_eq!(
+            default_path("ranked").to_str().unwrap(),
+            "opgg_cache_ranked.json"
+        );
+        assert_eq!(
+            default_path("aram").to_str().unwrap(),
+            "opgg_cache_aram.json"
+        );
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/data.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/data.rs
@@ -1,0 +1,76 @@
+//! OP.GG 数据结构定义：英雄元数据、对线克制、模式快照。
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// 单英雄在某一分路的统计元数据。
+///
+/// 数据来自 OP.GG（外服，emerald+ 分段），`tier` 为 1~5（1 最强），
+/// aram 等无分路模式下 `position` 为空字符串。
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChampionMeta {
+    /// 英雄 ID
+    pub champion_id: i32,
+    /// 分路（LCU 命名：TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY；无分路模式为 ""）
+    pub position: String,
+    /// T 级（1~5，1 最强；无数据为 0）
+    pub tier: i32,
+    /// 同分路排名（无数据为 0）
+    pub rank: i32,
+    /// 胜率（0~1）
+    pub win_rate: f64,
+    /// 登场率（0~1）
+    pub pick_rate: f64,
+    /// Ban 率（0~1，源数据缺失时为 0）
+    pub ban_rate: f64,
+    /// 该英雄玩此分路的占比（0~1，无分路模式为 1.0）
+    pub role_rate: f64,
+    /// 是否该英雄的主分路（role_rate 最高者）
+    pub is_main_position: bool,
+}
+
+/// 对线克制关系：本英雄面对 `opponent_id` 时的对线胜率。
+///
+/// OP.GG 每分路仅给出最难打的 top3 对手，`subject_win_rate` 通常 <0.5。
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LaneCounter {
+    /// 对手英雄 ID
+    pub opponent_id: i32,
+    /// 分路（LCU 命名）
+    pub position: String,
+    /// 本英雄对该对手的对线胜率（0~1）
+    pub subject_win_rate: f64,
+    /// 样本对局数
+    pub play: i64,
+}
+
+/// 某一模式的完整数据快照，内存与磁盘缓存的最小单元。
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OpggSnapshot {
+    /// 模式："ranked" | "aram"
+    pub mode: String,
+    /// patch 版本号（OP.GG meta.version，如 "16.13"）
+    pub patch: String,
+    /// 拉取时间（unix 秒）
+    pub fetched_at: i64,
+    /// 英雄 ID → 各分路元数据
+    pub champions: HashMap<i32, Vec<ChampionMeta>>,
+    /// 英雄 ID → 被克制列表（仅有分路的模式）
+    pub counters: HashMap<i32, Vec<LaneCounter>>,
+}
+
+/// 把 OP.GG 分路命名转成 LCU 命名，未知值原样返回。
+///
+/// 对齐 `session.rs` 排序用的 TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY 词汇，
+/// 让前端与信号引擎只面对一套分路词汇。
+pub fn normalize_position(opgg_name: &str) -> String {
+    match opgg_name {
+        "MID" => "MIDDLE".to_string(),
+        "ADC" => "BOTTOM".to_string(),
+        "SUPPORT" => "UTILITY".to_string(),
+        other => other.to_string(),
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/aram_sample.json
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/aram_sample.json
@@ -1,0 +1,21 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "is_rotation": false,
+      "is_rip": false,
+      "average_stats": {
+        "play": 96224, "win_rate": 0.522313, "pick_rate": 0.0594868,
+        "ban_rate": null, "kda": 2.882699, "tier": 2, "rank": 36,
+        "tier_data": { "tier": 2, "rank": 36, "rank_prev": 36, "rank_prev_patch": 39 }
+      },
+      "positions": null
+    }
+  ],
+  "meta": {
+    "version": "16.13",
+    "cached_at": "2026-07-11 18:06:42",
+    "match_count": 16175700,
+    "analyzed_at": "2026-07-11T18:06:42+09:00"
+  }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/ranked_sample.json
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/ranked_sample.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "id": 86,
+      "is_rotation": false,
+      "is_rip": false,
+      "average_stats": {
+        "play": 280051, "win_rate": 0.517106, "pick_rate": 0.0871455,
+        "ban_rate": 0.068954, "kda": 1.84497, "tier": 1, "rank": 7,
+        "tier_data": { "tier": 1, "rank": 7, "rank_prev": 7, "rank_prev_patch": 7 }
+      },
+      "positions": [
+        {
+          "name": "TOP",
+          "stats": {
+            "play": 259070, "win_rate": 0.517991, "pick_rate": 0.0815533,
+            "role_rate": 0.925081, "ban_rate": 0.0689323, "kda": 1.823866,
+            "tier_data": { "tier": 1, "rank": 1, "rank_prev": 1, "rank_prev_patch": 1 }
+          },
+          "counters": [
+            { "champion_id": 10, "play": 4710, "win": 2107 },
+            { "champion_id": 133, "play": 1158, "win": 531 },
+            { "champion_id": 23, "play": 4468, "win": 2080 }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 999,
+      "is_rotation": false,
+      "is_rip": false,
+      "average_stats": {
+        "play": 100000, "win_rate": 0.5, "pick_rate": 0.05,
+        "ban_rate": 0.01, "kda": 2.0, "tier": 3, "rank": 60,
+        "tier_data": { "tier": 3, "rank": 60, "rank_prev": 60, "rank_prev_patch": 60 }
+      },
+      "positions": [
+        {
+          "name": "MID",
+          "stats": {
+            "play": 70000, "win_rate": 0.51, "pick_rate": 0.04,
+            "role_rate": 0.7, "ban_rate": 0.01, "kda": 2.1,
+            "tier_data": { "tier": 2, "rank": 20, "rank_prev": 20, "rank_prev_patch": 20 }
+          },
+          "counters": [ { "champion_id": 86, "play": 2000, "win": 900 } ]
+        },
+        {
+          "name": "ADC",
+          "stats": {
+            "play": 30000, "win_rate": 0.49, "pick_rate": 0.01,
+            "role_rate": 0.3, "ban_rate": 0.01, "kda": 1.9,
+            "tier_data": { "tier": 4, "rank": 50, "rank_prev": 50, "rank_prev_patch": 50 }
+          },
+          "counters": []
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "version": "16.13",
+    "cached_at": "2026-07-11 17:48:44",
+    "match_count": 32136034,
+    "analyzed_at": "2026-07-11T17:48:44+09:00"
+  }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/mod.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/mod.rs
@@ -8,5 +8,5 @@
 //! [`crate::command::opgg`]。
 
 pub mod api;
-// pub mod cache; // Task 2 放开
+pub mod cache;
 pub mod data;

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/mod.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/mod.rs
@@ -1,0 +1,12 @@
+//! # OP.GG 数据模块
+//!
+//! 拉取 OP.GG 内部 API 的英雄统计数据（T级/胜率/Ban率/对线克制），
+//! 为对局页展示与 AI prompt 的【版本情报】【对线克制】块提供数据源。
+//!
+//! 架构与 [`crate::fandom`] 同构：`api` 负责拉取解析，`data` 定义结构，
+//! `cache` 负责磁盘持久化（按模式一个 JSON 文件），命令层见
+//! [`crate::command::opgg`]。
+
+pub mod api;
+// pub mod cache; // Task 2 放开
+pub mod data;

--- a/lol-record-analysis-tauri/src-tauri/src/state.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/state.rs
@@ -77,6 +77,12 @@ pub struct AppState {
     /// 缓存键为英雄 ID，值为平衡数据。
     /// 使用 2 小时的 TTL（生存时间）自动过期数据。
     pub fandom_cache: Cache<i32, AramBalanceData>,
+
+    /// OP.GG 快照内存缓存。
+    ///
+    /// 键为模式（"ranked" / "aram"），值为完整快照。TTL 12 小时，
+    /// 与磁盘缓存（`opgg::cache`）互为补充：内存快、磁盘跨重启。
+    pub opgg_cache: Cache<String, std::sync::Arc<crate::opgg::data::OpggSnapshot>>,
 }
 
 impl Default for AppState {
@@ -99,6 +105,9 @@ impl Default for AppState {
             http_port: OnceLock::new(),
             fandom_cache: Cache::builder()
                 .time_to_live(Duration::from_secs(2 * 60 * 60))
+                .build(),
+            opgg_cache: Cache::builder()
+                .time_to_live(Duration::from_secs(12 * 60 * 60))
                 .build(),
         }
     }

--- a/lol-record-analysis-tauri/src-tauri/src/state.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/state.rs
@@ -99,6 +99,7 @@ impl Default for AppState {
     ///
     /// - `http_port`: 未初始化的 `OnceLock`
     /// - `fandom_cache`: 2 小时 TTL 的 Moka 缓存
+    /// - `opgg_cache`: 无 TTL 的 Moka 缓存（理由见字段文档）
     ///
     /// # 示例
     ///

--- a/lol-record-analysis-tauri/src-tauri/src/state.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/state.rs
@@ -80,8 +80,15 @@ pub struct AppState {
 
     /// OP.GG 快照内存缓存。
     ///
-    /// 键为模式（"ranked" / "aram"），值为完整快照。TTL 12 小时，
-    /// 与磁盘缓存（`opgg::cache`）互为补充：内存快、磁盘跨重启。
+    /// 键为模式（"ranked" / "aram"），值为完整快照，与磁盘缓存
+    /// （`opgg::cache`）互为补充：内存快、磁盘跨重启。
+    ///
+    /// # 为什么不设 TTL
+    ///
+    /// 内存须保留"最后已知快照"供拉取失败时降级（`ensure_opgg_snapshot`
+    /// 的过期缓存回退分支）。若设 moka TTL，条目一到期即被驱逐，降级分支
+    /// 永远拿不到数据。新鲜度由 `opgg::cache::is_fresh` 单独裁决；键至多
+    /// 2 个（"ranked"/"aram"），无内存压力。
     pub opgg_cache: Cache<String, std::sync::Arc<crate::opgg::data::OpggSnapshot>>,
 }
 
@@ -106,9 +113,7 @@ impl Default for AppState {
             fandom_cache: Cache::builder()
                 .time_to_live(Duration::from_secs(2 * 60 * 60))
                 .build(),
-            opgg_cache: Cache::builder()
-                .time_to_live(Duration::from_secs(12 * 60 * 60))
-                .build(),
+            opgg_cache: Cache::builder().build(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- 新增 Rust `opgg` 模块：OP.GG 内部 API 拉取 + 解析（ranked/aram，容忍 aram 的 null positions/ban_rate），仿 fandom 模块架构
- 磁盘(12h TTL)+内存(moka)双层缓存；降级链：内存 fresh → 磁盘 fresh → HTTP → 过期缓存标 stale → Err（编排函数已依赖注入化并有 7 项分支单测）
- 4 个 Tauri 命令：`update_opgg_data` / `get_champion_meta` / `get_lane_counters` / `get_opgg_status`；启动预热 ranked+aram，失败仅告警
- 上游设计：`docs/superpowers/specs/2026-07-11-ai-analysis-iteration-design.md` §4.1（AI 分析迭代 · 计划 1/4）

## 与 spec 文本的两处已裁决偏差
- 磁盘缓存用**工作目录相对路径**（与 config.yaml 同约定）而非 spec 写的 app data 目录；按模式（非 patch）一个文件，避免跨版本文件堆积
- `get_lane_counters` 返回 `HashMap<championId, Vec<LaneCounter>>`（批量取本局 10 英雄更顺手）而非 spec 的扁平 Vec
- 另：内存 moka 缓存**无 TTL**（计划原文的 12h 内存 TTL 会使过期降级成死代码，审查中发现并修复）——`opgg::cache::is_fresh` 是唯一新鲜度权威

## 后续计划（计划 4 前端接入）须知
- 只读命令对未拉取模式返回 `Ok(None)`/空 map；**刷新须显式调 `update_opgg_data`**（无周期自刷新），数据新旧由 `get_opgg_status.stale` 表达

## Test plan
- [x] `npm run check` passes（prettier/eslint/vue-tsc/cargo fmt/clippy -Dwarnings）
- [x] `cargo test` passes（209/209，含 opgg 解析 5 + 缓存 4 + URL 1 + 命令层 11）
- [x] `cargo test opgg -- --ignored` live 冒烟通过（真实接口 173 英雄）
- [x] Manual: dev 真机经 MCP bridge 验证 4 命令（状态/元数据/克制/非法模式 Err）+ 磁盘缓存文件生成 + 二次启动缓存命中零 HTTP