### PR TITLE
feat(app): 顶栏关闭游戏按钮；未连接时可访问设置页

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/launcher.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/launcher.rs
@@ -206,6 +206,54 @@ pub async fn launch_league() -> Result<(), String> {
     Ok(())
 }
 
+/// 关闭客户端兜底强杀的进程链，先杀渲染层（Ux）再杀主进程。
+///
+/// 刻意不含对局进程 `League of Legends.exe`：对局中强退会被判定为逃跑
+/// （掉胜点 + 排队惩罚），代价远超「客户端没关干净」，故只关客户端本体。
+const CLIENT_PROCESS_CHAIN: [&str; 2] = ["LeagueClientUx.exe", "LeagueClient.exe"];
+
+/// LCU 空 JSON 请求体（`process-control` 退出端点不需要参数）。
+#[derive(serde::Serialize)]
+struct EmptyJsonBody {}
+
+/// 关闭正在运行的英雄联盟客户端。
+///
+/// 优先走 LCU 的 `POST /process-control/v1/process/quit` 让客户端优雅退出
+/// （等同于点客户端右上角关闭，客户端自行收尾并带走整条进程链）；LCU 不可用
+/// 或请求失败（客户端卡死等）时，兜底按进程名强杀
+/// `LeagueClientUx.exe` / `LeagueClient.exe`。
+///
+/// # 返回值
+///
+/// - `Ok(())`: 已发出优雅退出指令，或已强制结束至少一个客户端进程
+/// - `Err(String)`: 两条路径都失败（通常是客户端本就没在运行）
+#[tauri::command]
+pub async fn close_league() -> Result<(), String> {
+    crate::observability::track_feature("close_league");
+
+    let graceful = crate::lcu::util::http::lcu_post::<serde_json::Value, _>(
+        "process-control/v1/process/quit",
+        &EmptyJsonBody {},
+    )
+    .await;
+    if graceful.is_ok() {
+        log::info!("已通过 LCU 优雅退出游戏客户端");
+        return Ok(());
+    }
+
+    // LCU 打不通时按进程名强杀兜底；单个进程名失败不影响其余
+    let killed: u32 = CLIENT_PROCESS_CHAIN
+        .iter()
+        .map(|name| crate::lcu::util::token::kill_processes_by_name(name).unwrap_or(0))
+        .sum();
+    if killed > 0 {
+        log::info!("已强制结束 {} 个游戏客户端进程", killed);
+        Ok(())
+    } else {
+        Err("未检测到正在运行的游戏客户端。".to_string())
+    }
+}
+
 /// 启动目标 exe（工作目录设为其所在目录），需要提权时自动弹 UAC。
 ///
 /// **必须用 `ShellExecuteW` 而非 `std::process::Command`**：国服 `Launcher\Client.exe`

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
@@ -13,12 +13,12 @@ use std::sync::LazyLock;
 use winapi::shared::minwindef::{DWORD, FALSE};
 use winapi::shared::ntdef::UNICODE_STRING;
 use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
-use winapi::um::processthreadsapi::OpenProcess;
+use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess};
 use winapi::um::tlhelp32::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
 use winapi::um::winbase::QueryFullProcessImageNameW;
-use winapi::um::winnt::{HANDLE, PROCESS_QUERY_LIMITED_INFORMATION};
+use winapi::um::winnt::{HANDLE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE};
 
 /// `Windows` `ERROR_ACCESS_DENIED`：`OpenProcess` 对更高完整性级别（如以管理员
 /// 身份运行的客户端）的进程会返回此错误。
@@ -110,6 +110,50 @@ fn get_process_pid_by_name(name: &str) -> Result<Vec<DWORD>, String> {
     }
 
     Ok(pids)
+}
+
+/// 按进程名强制结束所有匹配进程。
+///
+/// 用于关闭游戏客户端的兜底路径（LCU 优雅退出不可用时，见
+/// `command::launcher::close_league`）。逐个 `OpenProcess(PROCESS_TERMINATE)` +
+/// `TerminateProcess`；单个进程失败只记日志、不影响其余进程。
+///
+/// # 参数
+/// - `name`: 进程名（如 `LeagueClientUx.exe`），匹配规则与
+///   [`get_process_pid_by_name`] 一致（不区分大小写的包含匹配）
+///
+/// # 返回值
+/// - `Ok(u32)`: 成功结束的进程数（未找到匹配进程时为 0）
+/// - `Err(String)`: 创建进程快照失败
+pub fn kill_processes_by_name(name: &str) -> Result<u32, String> {
+    let pids = get_process_pid_by_name(name)?;
+    let mut killed = 0u32;
+    for pid in pids {
+        unsafe {
+            let handle = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+            if handle.is_null() {
+                log::warn!(
+                    "无法打开进程 {}（{}）以结束: {}",
+                    pid,
+                    name,
+                    std::io::Error::last_os_error()
+                );
+                continue;
+            }
+            let _handle_guard = ProcessHandle(handle);
+            if TerminateProcess(handle, 1) == FALSE {
+                log::warn!(
+                    "结束进程 {}（{}）失败: {}",
+                    pid,
+                    name,
+                    std::io::Error::last_os_error()
+                );
+            } else {
+                killed += 1;
+            }
+        }
+    }
+    Ok(killed)
 }
 
 fn get_process_command_line(pid: DWORD) -> Result<String, CmdError> {

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -150,6 +150,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::system::relaunch_as_admin,
             command::system::get_device_id,
             command::launcher::launch_league,
+            command::launcher::close_league,
             command::sgp::get_sgp_regions,
             command::sgp::get_current_sgp_region,
             command::sgp::get_sgp_match_history_by_name,

--- a/lol-record-analysis-tauri/src/components/Header.vue
+++ b/lol-record-analysis-tauri/src/components/Header.vue
@@ -36,6 +36,25 @@
       </n-input>
     </div>
     <div class="header-right">
+      <n-popconfirm positive-text="关闭游戏" negative-text="取消" @positive-click="closeLeague">
+        <template #trigger>
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-button
+                quaternary
+                circle
+                class="header-icon-btn close-league-btn"
+                :disabled="!isConnected"
+                :loading="closingLeague"
+              >
+                <n-icon :component="PowerOutline" />
+              </n-button>
+            </template>
+            {{ isConnected ? '关闭游戏客户端' : '游戏客户端未运行' }}
+          </n-tooltip>
+        </template>
+        确定关闭游戏客户端？
+      </n-popconfirm>
       <n-tooltip trigger="hover">
         <template #trigger>
           <n-button quaternary circle class="header-icon-btn" @click="openGithubLink">
@@ -87,14 +106,17 @@ import {
   CloseOutline,
   SunnyOutline,
   MoonOutline,
-  ChevronDownOutline
+  ChevronDownOutline,
+  PowerOutline
 } from '@vicons/ionicons5'
-import { darkTheme } from 'naive-ui'
+import { darkTheme, useMessage } from 'naive-ui'
 import { Window } from '@tauri-apps/api/window'
 import { openUrl } from '@tauri-apps/plugin-opener'
 
 import router from '@renderer/router'
 import { useSettingsStore } from '@renderer/pinia/setting'
+import { useGameState } from '@renderer/composables/useGameState'
+import { closeLeagueByIpc } from '@renderer/services/ipc'
 
 /**
  * 应用顶部导航栏组件
@@ -147,6 +169,34 @@ const onRegionSelect = (key: string): void => {
 
 /** 设置状态管理 Store */
 const settingsStore = useSettingsStore()
+
+/** LCU 连接状态：仅在客户端运行（已连接）时允许点击关闭游戏 */
+const { isConnected } = useGameState()
+
+const message = useMessage()
+
+/** 关闭游戏请求进行中（防重复点击 + 按钮 loading 态） */
+const closingLeague = ref(false)
+
+/**
+ * 关闭游戏客户端（顶栏电源按钮的确认回调）
+ *
+ * 调用后端 close_league：优先 LCU 优雅退出，失败兜底强杀客户端进程链。
+ * 成功/失败均以 message 反馈；连接断开由 game-state-changed 事件自然驱动
+ * UI（按钮变为禁用态），无需在此额外处理。
+ */
+const closeLeague = async (): Promise<void> => {
+  if (closingLeague.value) return
+  closingLeague.value = true
+  try {
+    await closeLeagueByIpc()
+    message.success('已关闭游戏客户端')
+  } catch (e) {
+    message.error(String(e))
+  } finally {
+    closingLeague.value = false
+  }
+}
 
 /**
  * 主题开关状态
@@ -339,6 +389,16 @@ const closeWindow = (): void => {
   color: var(--text-primary);
   background-color: var(--glass-bg-high);
   transform: scale(1.08);
+}
+
+/* 关闭游戏按钮：hover 用败方红提示这是个"下线"动作；禁用态（未连接）淡化 */
+.close-league-btn:hover:not(:disabled) {
+  color: var(--semantic-loss);
+  background-color: color-mix(in srgb, var(--semantic-loss) 14%, transparent);
+}
+
+.close-league-btn:disabled {
+  opacity: 0.4;
 }
 
 .header-theme-switch {

--- a/lol-record-analysis-tauri/src/components/SideNavigation.vue
+++ b/lol-record-analysis-tauri/src/components/SideNavigation.vue
@@ -21,8 +21,8 @@
         <n-icon :size="18"><GameControllerOutline /></n-icon>
         <span class="nav-item-label">对局</span>
       </button>
+      <!-- 设置不依赖 LCU 连接，未连接（Loading 页）时也保持可见可进 -->
       <button
-        v-if="!!mySummoner?.gameName"
         type="button"
         class="nav-item"
         :class="{ 'nav-item--active': getFirstPath(router.currentRoute.value.path) === 'Settings' }"
@@ -100,10 +100,13 @@ watch(
 )
 
 function handleMenuClick(key: string) {
-  // 跳转到对应路由
+  // 跳转到对应路由；未连接时（如从 Loading 页进设置）没有召唤师信息，不带 name
+  // 参数，避免生成 "undefined#undefined" 的脏 query
   router.push({
     name: key,
-    query: { name: mySummoner.value.gameName + '#' + mySummoner.value.tagLine }
+    query: mySummoner.value?.gameName
+      ? { name: mySummoner.value.gameName + '#' + mySummoner.value.tagLine }
+      : undefined
   })
 }
 

--- a/lol-record-analysis-tauri/src/composables/useGameState.ts
+++ b/lol-record-analysis-tauri/src/composables/useGameState.ts
@@ -92,8 +92,9 @@ function handleConnectionRoute(state: GameStateEvent) {
       console.log('📍 Auto navigated to Record page')
     }
   } else {
-    // 游戏客户端断开连接，跳转 Loading
-    if (currentPath !== '/Loading') {
+    // 游戏客户端断开连接，跳转 Loading。设置页豁免：设置不依赖 LCU 连接，
+    // 且状态事件每 ≤10s 心跳一次，不豁免会把正在改设置的用户反复踢回 Loading
+    if (currentPath !== '/Loading' && !currentPath.startsWith('/Settings')) {
       router.push({
         path: '/Loading'
       })

--- a/lol-record-analysis-tauri/src/services/ipc.ts
+++ b/lol-record-analysis-tauri/src/services/ipc.ts
@@ -58,3 +58,13 @@ export async function getAssetDetailsByIpc(typeString: 'item' | 'perk' | 'spell'
 export async function launchLeagueByIpc(): Promise<void> {
   await invoke('launch_league')
 }
+
+/**
+ * 关闭正在运行的英雄联盟客户端。
+ *
+ * 后端优先走 LCU 优雅退出（等同点客户端右上角关闭），LCU 不可用时兜底强杀
+ * 客户端进程链；客户端本就没在运行时 reject 一个中文错误说明。
+ */
+export async function closeLeagueByIpc(): Promise<void> {
+  await invoke('close_league')
+}


### PR DESCRIPTION
## Summary
- **顶栏关闭游戏按钮**：Header 新增电源按钮（popconfirm 二次确认），游戏客户端运行（LCU 已连接）时可一键关闭客户端，未连接时置灰并提示「游戏客户端未运行」
- **后端 `close_league` command**：优先走 LCU `process-control/v1/process/quit` 优雅退出（等同点客户端右上角关闭）；LCU 打不通（卡死等）时兜底按进程名强杀 `LeagueClientUx.exe` / `LeagueClient.exe`。刻意不杀对局进程 `League of Legends.exe`，避免对局中强退被判逃跑
- **未连接也能进设置**：侧边栏「设置」入口去掉连接门控（战绩/对局仍需连接）；`useGameState` 的断线强制跳 Loading 逻辑豁免 `/Settings`——状态事件 ≤10s 心跳一次，不豁免会把正在改设置的用户反复踢回 Loading
- 附带：`token.rs` 新增 `kill_processes_by_name`（OpenProcess + TerminateProcess），未连接时侧边栏跳转不再生成 `undefined#undefined` 脏 query

## Test plan
- [x] `npm run check` passes（prettier + eslint + vue-tsc + cargo fmt + clippy -Dwarnings）
- [x] `npm run test` passes（510 tests）
- [x] `cargo test` passes
- [x] Manual（dev 模式 + MCP bridge 真机验证）：
  - 未连接时侧边栏仅显示「设置」，电源按钮为禁用态
  - 从 Loading 页点「设置」进入 `/Settings/Automation`，等待 12s（跨过 10s 心跳）未被踢回 Loading
  - `close_league` 对真实运行中的客户端调用成功，dev 日志确认走了 LCU 优雅退出路径，客户端进程随后消失