### PR TITLE
refactor(record): 队列分组改显式规范映射，与中文显示名解耦

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/config.rs
@@ -160,9 +160,9 @@ pub struct GameModeOption {
 ///
 /// # 去重规则
 ///
-/// 多个队列 ID 共用同一中文名（如新旧人机队列同难度、430/490 均为「匹配」），
-/// 选项按中文名去重，保留最小 ID 作为代表；
-/// 过滤对局时经 `queue_ids_same_group` 按中文名分组匹配
+/// 多个队列 ID 属于同一玩法分组（如新旧人机队列同难度、430/490 均为「匹配」），
+/// 选项按 `canonical_queue_id` 分组去重，保留最小 ID（即代表 ID）；
+/// 过滤对局时经 `queue_ids_same_group` 按分组匹配
 #[tauri::command]
 pub fn get_game_modes() -> Vec<GameModeOption> {
     let mut options = vec![GameModeOption {
@@ -181,7 +181,7 @@ pub fn get_game_modes() -> Vec<GameModeOption> {
 
     modes.sort_by_key(|k| k.value);
     let mut seen = std::collections::HashSet::new();
-    modes.retain(|m| seen.insert(m.label.clone()));
+    modes.retain(|m| seen.insert(constant::game::canonical_queue_id(m.value as u32)));
     options.extend(modes);
 
     options

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -484,14 +484,9 @@ impl EvalContext<'_> {
 
             // 按分组匹配而非精确 contains：配置里存的可能是别名队列 ID
             // （新旧人机、430/490 匹配），LCU 报的当前队列则恒为现行 ID
-            TagCondition::CurrentQueue { ids } => ids
-                .iter()
-                .any(|id| {
-                    crate::constant::game::queue_ids_same_group(
-                        *id as u32,
-                        self.current_mode as u32,
-                    )
-                }),
+            TagCondition::CurrentQueue { ids } => ids.iter().any(|id| {
+                crate::constant::game::queue_ids_same_group(*id as u32, self.current_mode as u32)
+            }),
             TagCondition::CurrentChampion { ids } => {
                 // 未注入当前英雄（如战绩页场景）时恒不命中
                 if let Some(curr) = self.current_champion {

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -482,7 +482,16 @@ impl EvalContext<'_> {
             TagCondition::Or { conditions } => conditions.iter().any(|c| self.evaluate_node(c)),
             TagCondition::Not { condition } => !self.evaluate_node(condition),
 
-            TagCondition::CurrentQueue { ids } => ids.contains(&self.current_mode),
+            // 按分组匹配而非精确 contains：配置里存的可能是别名队列 ID
+            // （新旧人机、430/490 匹配），LCU 报的当前队列则恒为现行 ID
+            TagCondition::CurrentQueue { ids } => ids
+                .iter()
+                .any(|id| {
+                    crate::constant::game::queue_ids_same_group(
+                        *id as u32,
+                        self.current_mode as u32,
+                    )
+                }),
             TagCondition::CurrentChampion { ids } => {
                 // 未注入当前英雄（如战绩页场景）时恒不命中
                 if let Some(curr) = self.current_champion {
@@ -1342,6 +1351,27 @@ mod tests {
             },
         );
         assert!(over);
+    }
+
+    #[test]
+    fn current_queue_matches_alias_ids_across_generations() {
+        let history = make_history(vec![]);
+        // 配置里存的是旧人机 850（一般），LCU 报的当前队列是现行 890 → 同组应命中
+        let ctx = EvalContext {
+            history: &history,
+            current_mode: 890,
+            current_champion: None,
+        };
+        assert!(ctx.evaluate_node(&TagCondition::CurrentQueue { ids: vec![850] }));
+        // 反向：配置存现行匹配 490，当前队列为 430
+        let ctx2 = EvalContext {
+            history: &history,
+            current_mode: 430,
+            current_champion: None,
+        };
+        assert!(ctx2.evaluate_node(&TagCondition::CurrentQueue { ids: vec![490] }));
+        // 不同玩法（大乱斗 450）不得命中
+        assert!(!ctx2.evaluate_node(&TagCondition::CurrentQueue { ids: vec![450] }));
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/constant/game.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/constant/game.rs
@@ -395,19 +395,36 @@ pub fn get_queue_id_to_cn(key: u32) -> Option<&'static str> {
     QUEUE_ID_TO_CN.get(&key).copied()
 }
 
-/// 判断两个队列 ID 是否属于同一模式分组（ID 相同，或中文名相同）。
+/// 同玩法多队列 ID 的规范化映射：别名 ID → 该组的「代表 ID」。
 ///
-/// 多个队列 ID 会共用同一中文名（如新旧人机队列同难度：830/870 均为「人机(入门)」、
-/// 430/490 均为「匹配」）。模式筛选的下拉选项按中文名去重后只保留一个代表 ID，
-/// 过滤对局时必须按中文名分组匹配，否则只能命中代表 ID 对应的那一个队列。
+/// 分组语义的唯一来源。此前分组靠 [`QUEUE_ID_TO_CN`] 中文名字符串相等判定，
+/// 显示文案与筛选语义被绑死——改名/消歧义/本地化任一中文名都会静默改变
+/// 战绩筛选和标签统计的分组结果，且无编译期信号。现在显示名只管显示，
+/// 新增别名队列时在这里加一行即可。
+///
+/// 只收录别名队列，未收录的 ID 自成一组。代表 ID 取每组最小值，
+/// 与模式下拉选项去重后保留的 ID 一致（见 `get_game_modes`）。
+pub static QUEUE_ID_CANONICAL: phf::Map<u32, u32> = phf_map! {
+    // 匹配：430 旧版 / 490 现行（快速对局）
+    490u32 => 430u32,
+    // 人机（合作对抗 AI）：830/840/850 为 7.19 弃用的旧队列（仅存在于老战绩），
+    // 870/880/890 为现行 ID，难度一一对应（入门/新手/一般）
+    870u32 => 830u32,
+    880u32 => 840u32,
+    890u32 => 850u32,
+};
+
+/// 队列 ID 的分组代表 ID（非别名 ID 返回自身）
+pub fn canonical_queue_id(id: u32) -> u32 {
+    QUEUE_ID_CANONICAL.get(&id).copied().unwrap_or(id)
+}
+
+/// 判断两个队列 ID 是否属于同一模式分组（规范化后相等）。
+///
+/// 模式筛选的下拉选项按分组去重后只保留代表 ID，过滤对局时必须按分组
+/// 匹配，否则只能命中代表 ID 对应的那一个队列。
 pub fn queue_ids_same_group(a: u32, b: u32) -> bool {
-    if a == b {
-        return true;
-    }
-    match (QUEUE_ID_TO_CN.get(&a), QUEUE_ID_TO_CN.get(&b)) {
-        (Some(x), Some(y)) => x == y,
-        _ => false,
-    }
+    canonical_queue_id(a) == canonical_queue_id(b)
 }
 
 #[cfg(test)]
@@ -439,5 +456,41 @@ mod tests {
     fn unknown_ids_should_only_match_exactly() {
         assert!(!queue_ids_same_group(999999, 830));
         assert!(queue_ids_same_group(999999, 999999));
+    }
+
+    #[test]
+    fn canonical_maps_alias_to_representative() {
+        assert_eq!(canonical_queue_id(490), 430);
+        assert_eq!(canonical_queue_id(870), 830);
+        assert_eq!(canonical_queue_id(880), 840);
+        assert_eq!(canonical_queue_id(890), 850);
+    }
+
+    #[test]
+    fn canonical_keeps_non_alias_ids() {
+        assert_eq!(canonical_queue_id(420), 420);
+        assert_eq!(canonical_queue_id(450), 450);
+        assert_eq!(canonical_queue_id(999999), 999999);
+    }
+
+    /// 分组语义不再依赖中文名：每个别名的代表 ID 必须也在 CN 表里有名字，
+    /// 且代表自身不得再是别名（防止链式映射）。
+    #[test]
+    fn canonical_representatives_are_terminal_and_named() {
+        for (alias, rep) in QUEUE_ID_CANONICAL.entries() {
+            assert!(
+                QUEUE_ID_CANONICAL.get(rep).is_none(),
+                "代表 {rep} 自身不能是别名（来自 {alias}）"
+            );
+            assert!(
+                QUEUE_ID_TO_CN.get(rep).is_some(),
+                "代表 {rep} 缺少中文名（来自 {alias}）"
+            );
+        }
+    }
+
+    #[test]
+    fn matched_queues_430_490_are_same_group() {
+        assert!(queue_ids_same_group(430, 490));
     }
 }


### PR DESCRIPTION
## Summary
- 「哪些队列 ID 算同一玩法」此前靠 `QUEUE_ID_TO_CN` 中文名字符串相等判定，散布在 5 文件 7 处——改名/消歧义任一中文名都会静默改变战绩筛选、标签统计和模式下拉去重的分组结果，且无编译期信号
- 新增 `QUEUE_ID_CANONICAL`（别名 → 代表 ID）作为分组语义唯一来源：`queue_ids_same_group` 改为规范化后相等；`get_game_modes` 按规范 ID 去重（输出与今日一致，无行为变化）；显示名从此只管显示
- 附带修复：`CurrentQueue` 标签条件从精确 `contains` 改为按分组匹配——配置里存的旧世代人机 ID（830/840/850）现在能命中 LCU 报的现行队列（870/880/890），430/490 匹配同理
- 新增守卫测试：代表 ID 不得再是别名（防链式映射）、必须在 CN 表有名字

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -Dwarnings` passes
- [x] `cargo test` passes（198 个，新增 5 个：canonical 映射/非别名自反/代表终结性守卫/430-490 同组/CurrentQueue 跨世代命中）
- [x] 既有 queue_ids_same_group 行为测试全部保持绿（新旧人机同难度同组、异难度不同组、未知 ID 仅精确匹配）