### PR TITLE
refactor(sync): 云同步去冗余整形——命令收编/单次落盘/按需推送/墓碑 TTL 下沉

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/cloud_sync.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/cloud_sync.rs
@@ -19,8 +19,10 @@ const SUPABASE_PUBLISHABLE_KEY: &str = "sb_publishable_ksZfyme84izJY9oTWC4VOw_l9
 
 /// 会话在 config.yaml 里的存储键（序列化为 JSON 字符串存 Value::String）
 const SESSION_CONFIG_KEY: &str = "cloudSyncSession";
-/// 云端行的数据类型标识，v1 只有玩家备注
+/// 云端备注行的数据类型标识
 const DATA_TYPE_NOTES: &str = "playerNotes";
+/// 云端配置行的数据类型标识
+const DATA_TYPE_CONFIG: &str = "appConfig";
 /// access_token 过期前多少秒就触发刷新（留网络往返余量）
 const REFRESH_MARGIN_SECS: u64 = 60;
 
@@ -148,24 +150,24 @@ async fn ensure_session() -> Result<CloudSession, String> {
     Ok(session)
 }
 
-/// 拉取云端某 puuid 下所有设备的备注 payload 列表（前端负责合并）
+/// puuid 拼进 PostgREST 查询串前的校验：命令边界的不信任输入，限定 UUID 字符集防注入。
 ///
-/// # 参数
-/// - `puuid`: 召唤师 PUUID
-///
-/// # 返回值
-/// - `Ok(Vec<Value>)`: 各设备写入的 payload 列表（可能为空）
-/// - `Err(String)`: puuid 格式非法、网络失败或非 2xx 响应
-#[tauri::command]
-pub async fn cloud_pull_notes(puuid: String) -> Result<Vec<serde_json::Value>, String> {
-    // puuid 要拼进 PostgREST 查询串：命令边界的不信任输入，限定 UUID 字符集防注入。
-    // 正常路径 puuid 来自 LCU，恒为 UUID 格式，不受影响。
-    if !puuid.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+/// 空串必须显式拒绝——`chars().all(...)` 对空串恒真，曾放行空 puuid 读写云端
+/// 以 "" 为键的共享行（所有同状态用户混写一行，跨用户数据串流）。
+/// 正常路径 puuid 来自 LCU，恒为 UUID 格式，不受影响。
+fn validate_puuid(puuid: &str) -> Result<(), String> {
+    if puuid.is_empty() || !puuid.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
         return Err("puuid 格式非法".to_string());
     }
+    Ok(())
+}
+
+/// 拉取云端某 puuid + data_type 下所有设备的 payload 行（notes/config 共用）
+async fn pull_payloads(puuid: &str, data_type: &str) -> Result<Vec<serde_json::Value>, String> {
+    validate_puuid(puuid)?;
     let session = ensure_session().await?;
     let url = format!(
-        "{SUPABASE_URL}/rest/v1/sync_data?puuid=eq.{puuid}&data_type=eq.{DATA_TYPE_NOTES}&select=payload"
+        "{SUPABASE_URL}/rest/v1/sync_data?puuid=eq.{puuid}&data_type=eq.{data_type}&select=payload"
     );
     let resp = http()
         .get(url)
@@ -185,23 +187,19 @@ pub async fn cloud_pull_notes(puuid: String) -> Result<Vec<serde_json::Value>, S
     Ok(rows.into_iter().map(|r| r.payload).collect())
 }
 
-/// 把本设备合并后的完整备注表 upsert 到自己的行
-///
-/// # 参数
-/// - `puuid`: 召唤师 PUUID
-/// - `payload`: 合并后的完整备注 JSON
-///
-/// # 返回值
-/// - `Ok(())`: 推送成功
-/// - `Err(String)`: 网络失败或非 2xx 响应
-#[tauri::command]
-pub async fn cloud_push_notes(puuid: String, payload: serde_json::Value) -> Result<(), String> {
+/// 把 payload upsert 到本设备的 (owner_id, puuid, data_type) 行（notes/config 共用）
+async fn push_payload(
+    puuid: &str,
+    data_type: &str,
+    payload: serde_json::Value,
+) -> Result<(), String> {
+    validate_puuid(puuid)?;
     let session = ensure_session().await?;
     let url = format!("{SUPABASE_URL}/rest/v1/sync_data?on_conflict=owner_id,puuid,data_type");
     let body = json!([{
         "owner_id": session.user_id,
         "puuid": puuid,
-        "data_type": DATA_TYPE_NOTES,
+        "data_type": data_type,
         "payload": payload,
     }]);
     let resp = http()
@@ -219,8 +217,32 @@ pub async fn cloud_push_notes(puuid: String, payload: serde_json::Value) -> Resu
     Ok(())
 }
 
-/// 云端配置行的数据类型标识
-const DATA_TYPE_CONFIG: &str = "appConfig";
+/// 拉取云端某 puuid 下所有设备的备注 payload 列表（前端负责合并）
+///
+/// # 参数
+/// - `puuid`: 召唤师 PUUID
+///
+/// # 返回值
+/// - `Ok(Vec<Value>)`: 各设备写入的 payload 列表（可能为空）
+/// - `Err(String)`: puuid 格式非法、网络失败或非 2xx 响应
+#[tauri::command]
+pub async fn cloud_pull_notes(puuid: String) -> Result<Vec<serde_json::Value>, String> {
+    pull_payloads(&puuid, DATA_TYPE_NOTES).await
+}
+
+/// 把本设备合并后的完整备注表 upsert 到自己的行
+///
+/// # 参数
+/// - `puuid`: 召唤师 PUUID
+/// - `payload`: 合并后的完整备注 JSON
+///
+/// # 返回值
+/// - `Ok(())`: 推送成功
+/// - `Err(String)`: puuid 格式非法、网络失败或非 2xx 响应
+#[tauri::command]
+pub async fn cloud_push_notes(puuid: String, payload: serde_json::Value) -> Result<(), String> {
+    push_payload(&puuid, DATA_TYPE_NOTES, payload).await
+}
 
 /// 云端配置行 payload:`updatedAt` 放 payload 内而非依赖数据库列,
 /// 免去 sync_data 表结构迁移;毫秒时间戳由推送方(本地时钟)盖。
@@ -248,30 +270,8 @@ fn pick_latest_config(rows: Vec<serde_json::Value>) -> Option<ConfigPayload> {
 /// 拉取云端最新一份配置(所有设备行中 updatedAt 最大者);云端无配置返回 None
 #[tauri::command]
 pub async fn cloud_pull_config(puuid: String) -> Result<Option<ConfigPayload>, String> {
-    if !puuid.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
-        return Err("puuid 格式非法".to_string());
-    }
-    let session = ensure_session().await?;
-    let url = format!(
-        "{SUPABASE_URL}/rest/v1/sync_data?puuid=eq.{puuid}&data_type=eq.{DATA_TYPE_CONFIG}&select=payload"
-    );
-    let resp = http()
-        .get(url)
-        .header("apikey", SUPABASE_PUBLISHABLE_KEY)
-        .header("Authorization", format!("Bearer {}", session.access_token))
-        .send()
-        .await
-        .map_err(|e| format!("云端连接失败: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("拉取失败: HTTP {}", resp.status()));
-    }
-    #[derive(Deserialize)]
-    struct Row {
-        payload: serde_json::Value,
-    }
-    let rows: Vec<Row> = resp.json().await.map_err(|e| e.to_string())?;
     Ok(pick_latest_config(
-        rows.into_iter().map(|r| r.payload).collect(),
+        pull_payloads(&puuid, DATA_TYPE_CONFIG).await?,
     ))
 }
 
@@ -280,31 +280,16 @@ pub async fn cloud_pull_config(puuid: String) -> Result<Option<ConfigPayload>, S
 /// 快照在 Rust 侧现取现滤——前端无法传入自定义 payload,杜绝绕过黑名单。
 #[tauri::command]
 pub async fn cloud_push_config(puuid: String) -> Result<(), String> {
-    let session = ensure_session().await?;
     let payload = ConfigPayload {
         updated_at: now_unix() * 1000,
         config: crate::config::config_snapshot(true).await,
     };
-    let url = format!("{SUPABASE_URL}/rest/v1/sync_data?on_conflict=owner_id,puuid,data_type");
-    let body = json!([{
-        "owner_id": session.user_id,
-        "puuid": puuid,
-        "data_type": DATA_TYPE_CONFIG,
-        "payload": payload,
-    }]);
-    let resp = http()
-        .post(url)
-        .header("apikey", SUPABASE_PUBLISHABLE_KEY)
-        .header("Authorization", format!("Bearer {}", session.access_token))
-        .header("Prefer", "resolution=merge-duplicates")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| format!("云端连接失败: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("推送失败: HTTP {}", resp.status()));
-    }
-    Ok(())
+    push_payload(
+        &puuid,
+        DATA_TYPE_CONFIG,
+        serde_json::to_value(payload).map_err(|e| e.to_string())?,
+    )
+    .await
 }
 
 /// 前端做"云端 vs 本地"内容比对用的本地快照(云同步口径,已过滤,无敏感键)
@@ -368,17 +353,6 @@ fn validate_backup_path(path: &str) -> Result<(), String> {
     }
 }
 
-/// 把文本写入用户经系统对话框选定的路径（导出备份用，路径来自 plugin-dialog）
-///
-/// # 参数
-/// - `path`: 目标文件路径（必须以 `.json` 结尾，见 [`validate_backup_path`]）
-/// - `content`: 待写入的文本内容
-#[tauri::command]
-pub async fn save_text_file(path: String, content: String) -> Result<(), String> {
-    validate_backup_path(&path)?;
-    std::fs::write(&path, content).map_err(|e| format!("写入文件失败 {path}: {e}"))
-}
-
 /// 读取用户经系统对话框选定的文本文件（导入备份用）
 ///
 /// # 参数
@@ -410,6 +384,26 @@ mod tests {
     #[test]
     fn should_not_refresh_when_fresh() {
         assert!(!needs_refresh(1000, 100)); // 100 + 60 < 1000
+    }
+
+    #[test]
+    fn validate_puuid_accepts_uuid_format() {
+        assert!(validate_puuid("70d5f089-1234-abcd-ef00-0123456789ab").is_ok());
+        assert!(validate_puuid("DEADBEEF-0000-1111-2222-333344445555").is_ok());
+    }
+
+    /// 空串对 `chars().all(...)` 恒真——曾绕过校验读写云端以 "" 为键的共享行，
+    /// 造成跨用户数据串流；必须显式拒绝。
+    #[test]
+    fn validate_puuid_rejects_empty() {
+        assert!(validate_puuid("").is_err());
+    }
+
+    #[test]
+    fn validate_puuid_rejects_injection_chars() {
+        assert!(validate_puuid("abc&data_type=eq.appConfig").is_err());
+        assert!(validate_puuid("x'; drop table").is_err());
+        assert!(validate_puuid("汉字").is_err());
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -156,7 +156,6 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::sgp::get_sgp_match_history_by_name,
             command::cloud_sync::cloud_pull_notes,
             command::cloud_sync::cloud_push_notes,
-            command::cloud_sync::save_text_file,
             command::cloud_sync::read_text_file,
             command::cloud_sync::cloud_pull_config,
             command::cloud_sync::cloud_push_config,

--- a/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/cloudSync.spec.ts
@@ -81,7 +81,7 @@ describe('useCloudSyncStore', () => {
     await store.setEnabled(true)
     expect(mockPut).toHaveBeenCalledWith('cloudSyncEnabled', true)
     await vi.waitFor(() =>
-      expect(mockInvoke).toHaveBeenCalledWith('cloud_push_notes', expect.anything())
+      expect(mockInvoke).toHaveBeenCalledWith('cloud_pull_notes', expect.anything())
     )
   })
 
@@ -125,7 +125,8 @@ describe('useCloudSyncStore', () => {
     const store = useCloudSyncStore()
     await expect(store.syncNow()).resolves.toBeUndefined()
     expect(notesStore.getNote('p2')?.note).toBe('ok')
-    expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_push_notes')).toBe(true)
+    // 本地无云端缺的内容（合并后与云端并集一致），按需推送策略下不再 upsert
+    expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_push_notes')).toBe(false)
     expect(store.lastError).toBeNull()
   })
 
@@ -164,7 +165,7 @@ describe('useCloudSyncStore', () => {
     mockHappyInvoke()
     mockConnected.value = true
     await vi.waitFor(() =>
-      expect(mockInvoke).toHaveBeenCalledWith('cloud_push_notes', expect.anything())
+      expect(mockInvoke).toHaveBeenCalledWith('cloud_pull_notes', expect.anything())
     )
     await vi.waitFor(() => expect(store.lastSyncAt).not.toBeNull())
   })
@@ -220,6 +221,87 @@ describe('useCloudSyncStore', () => {
       await vi.advanceTimersByTimeAsync(30_000)
       await flushAsync()
       expect(mockInvoke).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('同步流程整形(单次落盘/按需推送/不自触发)', () => {
+    it('多设备行内存合并后,notes 只落盘一次', async () => {
+      mockGet.mockResolvedValue(undefined)
+      mockInvoke.mockImplementation(async cmd => {
+        if (cmd === 'get_my_summoner') return { puuid: 'me' }
+        if (cmd === 'cloud_pull_notes')
+          return [
+            { p2: { note: 'dev-a', label: 'friendly', gameName: 'B', tagLine: '2', updatedAt: 5 } },
+            { p3: { note: 'dev-b', label: 'normal', gameName: 'C', tagLine: '3', updatedAt: 6 } }
+          ]
+        return undefined
+      })
+      const store = useCloudSyncStore()
+      const notesStore = usePlayerNotesStore()
+      await store.syncNow()
+      expect(notesStore.getNote('p2')?.note).toBe('dev-a')
+      expect(notesStore.getNote('p3')?.note).toBe('dev-b')
+      const notePersists = mockPut.mock.calls.filter(c => c[0] === 'playerNotes')
+      expect(notePersists.length).toBe(1)
+    })
+
+    it('无任何变化的同步跳过 cloud_push_notes(不打无谓 upsert)', async () => {
+      mockGet.mockResolvedValue(undefined)
+      mockHappyInvoke()
+      const store = useCloudSyncStore()
+      await store.syncNow()
+      expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_push_notes')).toBe(false)
+      expect(store.lastSyncAt).not.toBeNull()
+    })
+
+    it('本地有云端缺的内容时照常推送', async () => {
+      mockGet.mockResolvedValue(undefined)
+      mockHappyInvoke()
+      const notesStore = usePlayerNotesStore()
+      await notesStore.setNote('p1', { note: 'l', label: 'normal', gameName: 'A', tagLine: '1' })
+      const store = useCloudSyncStore()
+      await store.syncNow()
+      expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_push_notes')).toBe(true)
+    })
+
+    it('同步并入的远端变更不自触发下一轮防抖同步', async () => {
+      vi.useFakeTimers()
+      mockGet.mockResolvedValue(undefined)
+      mockInvoke.mockImplementation(async cmd => {
+        if (cmd === 'get_my_summoner') return { puuid: 'me' }
+        if (cmd === 'cloud_pull_notes')
+          return [
+            { p2: { note: 'remote', label: 'friendly', gameName: 'B', tagLine: '2', updatedAt: 5 } }
+          ]
+        if (cmd === 'cloud_pull_config') return null
+        if (cmd === 'get_cloud_config_snapshot') return {}
+        return undefined
+      })
+      const store = useCloudSyncStore()
+      await store.setEnabled(true) // 启动防抖监听 + 立即同步(并入 p2)
+      await flushAsync()
+      mockInvoke.mockClear()
+
+      await vi.advanceTimersByTimeAsync(31_000)
+      await flushAsync()
+      // 旧实现:watcher 观察 notes 引用,sync 自己的合并也会调度 30s 后再同步一轮
+      expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_pull_notes')).toBe(false)
+    })
+
+    it('用户 setNote 仍会调度防抖同步(信号未被误杀)', async () => {
+      vi.useFakeTimers()
+      mockGet.mockResolvedValue(undefined)
+      mockHappyInvoke()
+      const store = useCloudSyncStore()
+      const notesStore = usePlayerNotesStore()
+      await store.setEnabled(true)
+      await flushAsync()
+      mockInvoke.mockClear()
+
+      await notesStore.setNote('a', { note: '1', label: 'normal', gameName: 'A', tagLine: '1' })
+      await vi.advanceTimersByTimeAsync(31_000)
+      await flushAsync()
+      expect(mockInvoke.mock.calls.some(c => c[0] === 'cloud_pull_notes')).toBe(true)
     })
   })
 

--- a/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/pinia/__tests__/playerNotes.spec.ts
@@ -327,7 +327,7 @@ describe('usePlayerNotesStore', () => {
         p2: { note: 'new', label: 'friendly', gameName: 'B', tagLine: '2', updatedAt: 123 }
       })
 
-      expect(stats).toEqual({ added: 1, replaced: 0, kept: 1, invalid: 0 })
+      expect(stats).toEqual({ added: 1, replaced: 0, kept: 1, invalid: 0, expired: 0 })
       expect(store.getNote('p1')!.note).toBe('local') // 本地更新,未被覆盖
       expect(store.getNote('p2')!.note).toBe('new')
       // 正向落盘断言：合并结果（含新增的 p2）确实写盘了
@@ -353,6 +353,43 @@ describe('usePlayerNotesStore', () => {
       })
       await store.setNote('p10', { note: 'y', label: 'normal', gameName: 'D', tagLine: '4' })
       expect(store.getNote('p10')!.updatedAt).toBeGreaterThan(future)
+    })
+  })
+
+  describe('userMutationSeq（云同步防抖的调度信号）', () => {
+    it('setNote / removeNote 递增', async () => {
+      const store = usePlayerNotesStore()
+      const before = store.userMutationSeq
+      await store.setNote('p1', { note: 'x', label: 'normal', gameName: 'A', tagLine: '1' })
+      expect(store.userMutationSeq).toBe(before + 1)
+      await store.removeNote('p1')
+      expect(store.userMutationSeq).toBe(before + 2)
+    })
+
+    it('用户来源 importNotes 有实际变化时递增', async () => {
+      const store = usePlayerNotesStore()
+      const before = store.userMutationSeq
+      await store.importNotes({
+        p2: { note: 'n', label: 'normal', gameName: 'B', tagLine: '2', updatedAt: 1 }
+      })
+      expect(store.userMutationSeq).toBe(before + 1)
+    })
+
+    it('sync 来源 importNotes 不递增（同步合并不得自触发下一轮推送）', async () => {
+      const store = usePlayerNotesStore()
+      const before = store.userMutationSeq
+      await store.importNotes(
+        { p3: { note: 'r', label: 'normal', gameName: 'C', tagLine: '3', updatedAt: 1 } },
+        'sync'
+      )
+      expect(store.userMutationSeq).toBe(before)
+    })
+
+    it('无实际变化的 importNotes 不递增', async () => {
+      const store = usePlayerNotesStore()
+      const before = store.userMutationSeq
+      await store.importNotes({})
+      expect(store.userMutationSeq).toBe(before)
     })
   })
 })

--- a/lol-record-analysis-tauri/src/pinia/cloudSync.ts
+++ b/lol-record-analysis-tauri/src/pinia/cloudSync.ts
@@ -12,6 +12,8 @@ import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import { lcuConnected } from '@renderer/composables/useGameState'
 import { deepEqual } from '@renderer/utils/deepEqual'
+import { isPlainObject } from '@renderer/utils/backupFile'
+import { mergeNotesMaps } from '@renderer/utils/mergePlayerNotes'
 import { usePlayerNotesStore } from './playerNotes'
 import { useSettingsStore } from './setting'
 import type { PlayerNotesMap } from '@renderer/types/domain/playerNote'
@@ -86,9 +88,7 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     configWatchStarted = true
     listen<string>('config-changed', () => {
       markConfigDirty()
-      if (!enabled.value) return
-      if (autoPushTimer) clearTimeout(autoPushTimer)
-      autoPushTimer = setTimeout(flushAutoPush, AUTO_PUSH_DEBOUNCE_MS)
+      scheduleAutoPush()
     }).catch(() => {})
   }
 
@@ -125,10 +125,14 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
   async function syncConfig(puuid: string): Promise<void> {
     // 首次确认弹窗未决:不重新评估,等用户裁决(防重复弹窗/与 resolve 竞态)
     if (pendingCloudConfig.value !== null) return
-    const pulled = await invoke<CloudConfig | null>('cloud_pull_config', { puuid })
-    const local = await invoke<Record<string, unknown>>('get_cloud_config_snapshot')
-    const syncedOnce =
-      (await getConfigByIpc<boolean>(CONFIG_KEYS.configSyncedOnce).catch(() => false)) === true
+    // 三个读取互相独立:本地 IPC 与云端往返并行,不给同步转圈平白叠加延迟
+    const [pulled, local, syncedOnce] = await Promise.all([
+      invoke<CloudConfig | null>('cloud_pull_config', { puuid }),
+      invoke<Record<string, unknown>>('get_cloud_config_snapshot'),
+      getConfigByIpc<boolean>(CONFIG_KEYS.configSyncedOnce)
+        .catch(() => false)
+        .then(v => v === true)
+    ])
 
     if (!syncedOnce) {
       if (pulled && !deepEqual(pulled.config, local)) {
@@ -201,20 +205,24 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     syncNow().catch(() => {})
   }
 
-  /** 备注变更后延迟推送（合并短时间内的连续编辑，避免每次落盘都打云端） */
+  /** （重新）调度一次防抖同步：notes 用户变更与 config-changed 共用同一个定时器 */
+  function scheduleAutoPush(): void {
+    if (!enabled.value) return
+    if (autoPushTimer) clearTimeout(autoPushTimer)
+    autoPushTimer = setTimeout(flushAutoPush, AUTO_PUSH_DEBOUNCE_MS)
+  }
+
+  /**
+   * 备注变更后延迟推送（合并短时间内的连续编辑，避免每次落盘都打云端）。
+   *
+   * 调度信号是 userMutationSeq（仅用户来源写操作递增）而非 notes 引用本身：
+   * 云同步 pull 合并的写入不该再调度下一轮同步，否则形成自触发回环。
+   */
   function startAutoPush(): void {
     if (autoPushStarted || isStandaloneDetailWindow()) return
     autoPushStarted = true
     const notesStore = usePlayerNotesStore()
-    // notes 的写路径都是整体替换引用（setNote/removeNote/importNotes），浅 watch 足够
-    watch(
-      () => notesStore.notes,
-      () => {
-        if (!enabled.value) return
-        if (autoPushTimer) clearTimeout(autoPushTimer)
-        autoPushTimer = setTimeout(flushAutoPush, AUTO_PUSH_DEBOUNCE_MS)
-      }
-    )
+    watch(() => notesStore.userMutationSeq, scheduleAutoPush)
   }
 
   /**
@@ -273,8 +281,9 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
   }
 
   /**
-   * 执行一次完整同步：当前召唤师 puuid → 拉取所有设备的行 → 逐份并入本地
-   * （updatedAt 新者赢）→ 把合并结果推回本设备的行。
+   * 执行一次完整同步：当前召唤师 puuid → 拉取所有设备的行 → 内存合并成
+   * 云端并集 → 一次性并入本地（updatedAt 新者赢，至多一次落盘+广播）→
+   * 仅当本地有云端缺的内容时才推回本设备的行。
    * @throws 网络/LCU 未连接等失败，错误已记入 lastError
    */
   async function syncNow(): Promise<void> {
@@ -285,16 +294,24 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
       const me = await invoke<{ puuid: string }>('get_my_summoner')
       const payloads = await invoke<PlayerNotesMap[]>('cloud_pull_notes', { puuid: me.puuid })
       const notesStore = usePlayerNotesStore()
+      // 云端行任何人可插入（spec 接受的开放写入面），容器形状必须当不可信输入
+      // 过滤——jsonb 列可存 JSON null/数组/原始值，直接喂 mergeNotesMaps 的
+      // Object.entries 会抛 TypeError，该 puuid 的同步从此永久失败（受害者
+      // 还删不掉毒行）。条目级校验在 mergeNotesMaps 的 isValidNote，这里只管容器。
+      // 先在内存里把各设备行合并成一张并集表，再一次性并入本地——
+      // 逐份 importNotes 会造成 N 次全表落盘 + N 次跨窗口广播。
+      let cloudUnion: PlayerNotesMap = {}
       for (const payload of payloads) {
-        // 云端行任何人可插入（spec 接受的开放写入面），容器形状必须当不可信输入
-        // 过滤——jsonb 列可存 JSON null/数组/原始值，直接喂 importNotes 的
-        // Object.entries 会抛 TypeError，该 puuid 的同步从此永久失败（受害者
-        // 还删不掉毒行）。与 utils/backupFile 的 isBackupFileV2 容器校验对称；
-        // 条目级校验在 mergeNotesMaps 的 isValidNote，这里只管容器。
-        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) continue
-        await notesStore.importNotes(payload)
+        if (!isPlainObject(payload)) continue
+        cloudUnion = mergeNotesMaps(cloudUnion, payload).merged
       }
-      await invoke('cloud_push_notes', { puuid: me.puuid, payload: notesStore.notes })
+      await notesStore.importNotes(cloudUnion, 'sync')
+      // 本地有云端并集缺少/更旧的条目才需要推送；无变化的同步（启动、连接
+      // 补触发的常态路径）不再对云端做无谓的全量 upsert。
+      const { stats: pushNeed } = mergeNotesMaps(cloudUnion, notesStore.notes)
+      if (pushNeed.added > 0 || pushNeed.replaced > 0) {
+        await invoke('cloud_push_notes', { puuid: me.puuid, payload: notesStore.notes })
+      }
       await syncConfig(me.puuid)
       lastSyncAt.value = Date.now()
     } catch (e) {

--- a/lol-record-analysis-tauri/src/pinia/playerNotes.ts
+++ b/lol-record-analysis-tauri/src/pinia/playerNotes.ts
@@ -4,7 +4,10 @@ import { emit, listen } from '@tauri-apps/api/event'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import type { NoteLabel, PlayerNote, PlayerNotesMap } from '@renderer/types/domain/playerNote'
 import type { OneGamePlayer } from '@renderer/types/domain/analysis'
-import { mergeNotesMaps, type MergeStats } from '@renderer/utils/mergePlayerNotes'
+import { mergeNotesMaps, TOMBSTONE_TTL_MS, type MergeStats } from '@renderer/utils/mergePlayerNotes'
+
+/** 备注写入来源：用户操作（编辑/手动导入）或云同步合并 */
+export type NotesMutationOrigin = 'user' | 'sync'
 
 /** 持久化 key，复用 config 系统，无需新增 Rust command */
 const STORAGE_KEY = 'playerNotes'
@@ -20,16 +23,6 @@ const NOTES_CHANGED_EVENT = 'player-notes-changed'
 
 /** 单个玩家最多保留的遇见记录条数（最近在前，超出截断） */
 const MAX_ENCOUNTERS = 20
-
-/**
- * 墓碑保留时长：30 天。
- *
- * 墓碑（`deleted: true` 条目）的唯一使命是把"删除"随合并传播到云端与其他
- * 设备，之后就是死重——不 GC 的话 map 只增不减。30 天窗口的取值权衡：
- * 太短则长期离线的设备错过删除传播（回线后其旧活备注会复活该条目）；
- * 太长则墓碑堆积。30 天足以覆盖绝大多数设备的回线周期。
- */
-const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
 
 /** 时间字符串转毫秒，无效值归零（用于遇见记录排序） */
 function toTimestamp(date: string): number {
@@ -66,6 +59,15 @@ function mergeEncounters(
 export const usePlayerNotesStore = defineStore('playerNotes', () => {
   /** 内存副本：puuid -> 备注 */
   const notes = ref<PlayerNotesMap>({})
+
+  /**
+   * 用户来源写操作的单调计数（setNote/removeNote/手动导入，含其他窗口广播来的）。
+   *
+   * 云同步的防抖调度信号：只有用户改动需要排期推送——若直接 watch `notes`
+   * 引用，云同步自己 pull 合并的写入也会调度 30s 后再来一轮同步，形成
+   * "每次有合并的同步都附赠一轮空同步"的自触发回环。
+   */
+  const userMutationSeq = ref(0)
 
   /**
    * 单调递增时间戳：保证同一毫秒内的多次写入仍有稳定先后，
@@ -131,8 +133,11 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
     if (!syncRegistered) {
       syncRegistered = true
       // 收到其他窗口的变更广播后重载；loadFromConfig 不再 emit，无回环。
-      listen(NOTES_CHANGED_EVENT, () => {
+      // 用户来源的广播同时递增 userMutationSeq——详情窗口的编辑要靠主窗口
+      // 的防抖调度才能推送云端；sync 来源不递增（防同步自触发）。
+      listen<{ origin?: NotesMutationOrigin }>(NOTES_CHANGED_EVENT, event => {
         loadFromConfig()
+        if (event.payload?.origin !== 'sync') userMutationSeq.value++
       }).catch(error => console.error('Failed to listen player-notes-changed:', error))
     }
   }
@@ -170,6 +175,7 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
       ...notes.value,
       [puuid]: { ...rest, updatedAt: nextTs(), ...(encounters ? { encounters } : {}) }
     }
+    userMutationSeq.value++
     await persist()
   }
 
@@ -199,18 +205,24 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
         deleted: true
       }
     }
+    userMutationSeq.value++
     await persist()
   }
 
   /**
    * 批量并入外部备注表（手动导入 / 云端拉取共用），同 puuid 按 updatedAt 新者赢。
-   * 无实际变化（仅 kept/invalid）时不落盘、不广播。
+   * 无实际变化（仅 kept/invalid/expired）时不落盘、不广播。
    * 墓碑就是普通条目，走同一套"新者赢"——较新的墓碑压过旧活备注（删除传播），
-   * 较新的活备注压过旧墓碑（删除后重新标记），无需特判。
+   * 较新的活备注压过旧墓碑（删除后重新标记）；过期墓碑由 mergeNotesMaps 拦下。
    * @param incoming - 外部备注表
+   * @param origin - 写入来源：'user'（默认，手动导入）会触发云同步防抖调度，
+   *   'sync'（云同步 pull 合并）不触发——否则每次有合并的同步都自触发下一轮
    * @returns 合并统计，供 UI 反馈
    */
-  async function importNotes(incoming: PlayerNotesMap): Promise<MergeStats> {
+  async function importNotes(
+    incoming: PlayerNotesMap,
+    origin: NotesMutationOrigin = 'user'
+  ): Promise<MergeStats> {
     const { merged, stats } = mergeNotesMaps(notes.value, incoming)
     if (stats.added === 0 && stats.replaced === 0) return stats
     notes.value = merged
@@ -218,7 +230,8 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
     for (const note of Object.values(merged)) {
       if (note.updatedAt > lastTs) lastTs = note.updatedAt
     }
-    await persist()
+    if (origin === 'user') userMutationSeq.value++
+    await persist(origin)
     return stats
   }
 
@@ -226,8 +239,9 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
    * 整表落盘，并广播变更通知其他窗口重载。
    * 落盘失败时**重新抛出**——否则 setNote/removeNote 即使写盘失败也会 resolve，
    * 上层 try/catch 永远进不去，用户看到"已保存/已删除"却实际未持久化。
+   * @param origin - 广播携带的来源标记，各窗口据此决定是否调度云同步推送
    */
-  async function persist(): Promise<void> {
+  async function persist(origin: NotesMutationOrigin = 'user'): Promise<void> {
     try {
       await putConfigByIpc(STORAGE_KEY, notes.value)
     } catch (error) {
@@ -235,8 +249,8 @@ export const usePlayerNotesStore = defineStore('playerNotes', () => {
       throw error
     }
     // 落盘成功后再广播
-    emit(NOTES_CHANGED_EVENT).catch(() => {})
+    emit(NOTES_CHANGED_EVENT, { origin }).catch(() => {})
   }
 
-  return { notes, count, list, init, getNote, setNote, removeNote, importNotes }
+  return { notes, count, list, userMutationSeq, init, getNote, setNote, removeNote, importNotes }
 })

--- a/lol-record-analysis-tauri/src/utils/__tests__/mergePlayerNotes.spec.ts
+++ b/lol-record-analysis-tauri/src/utils/__tests__/mergePlayerNotes.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mergeNotesMaps } from '../mergePlayerNotes'
+import { mergeNotesMaps, TOMBSTONE_TTL_MS } from '../mergePlayerNotes'
 import type { PlayerNotesMap } from '@renderer/types/domain/playerNote'
 
 function note(updatedAt: number, text = 'x'): PlayerNotesMap[string] {
@@ -10,7 +10,7 @@ describe('mergeNotesMaps', () => {
   it('新 puuid 直接加入,计入 added', () => {
     const { merged, stats } = mergeNotesMaps({}, { p1: note(100) })
     expect(merged.p1.updatedAt).toBe(100)
-    expect(stats).toEqual({ added: 1, replaced: 0, kept: 0, invalid: 0 })
+    expect(stats).toEqual({ added: 1, replaced: 0, kept: 0, invalid: 0, expired: 0 })
   })
 
   it('同 puuid 时间戳新者赢', () => {
@@ -49,7 +49,7 @@ describe('mergeNotesMaps', () => {
 
   it('toString 等原型链键的合法 note 正常 added', () => {
     const { merged, stats } = mergeNotesMaps({}, { toString: note(100, 'proto-key') })
-    expect(stats).toEqual({ added: 1, replaced: 0, kept: 0, invalid: 0 })
+    expect(stats).toEqual({ added: 1, replaced: 0, kept: 0, invalid: 0, expired: 0 })
     expect(merged.toString).toEqual(note(100, 'proto-key'))
   })
 
@@ -70,7 +70,7 @@ describe('mergeNotesMaps', () => {
       p4: note(NaN)
     } as unknown as PlayerNotesMap
     const { merged, stats } = mergeNotesMaps({ p1: note(100, 'old') }, incoming)
-    expect(stats).toEqual({ added: 1, replaced: 1, kept: 0, invalid: 2 })
+    expect(stats).toEqual({ added: 1, replaced: 1, kept: 0, invalid: 2, expired: 0 })
     expect(merged.p1.note).toBe('newer')
     expect(merged.p2.note).toBe('fresh')
   })
@@ -79,5 +79,49 @@ describe('mergeNotesMaps', () => {
     const base = { p1: note(100) }
     mergeNotesMaps(base, { p2: note(50) })
     expect(Object.keys(base)).toEqual(['p1'])
+  })
+
+  describe('墓碑 TTL(过期删除标记不随合并复活)', () => {
+    const NOW = 1_800_000_000_000
+
+    function tombstone(updatedAt: number): PlayerNotesMap[string] {
+      return { note: '', label: 'normal', gameName: 'A', tagLine: '1', updatedAt, deleted: true }
+    }
+
+    it('过期墓碑(超过 TTL)被跳过,计入 expired,不并入结果', () => {
+      const dead = tombstone(NOW - TOMBSTONE_TTL_MS - 1)
+      const { merged, stats } = mergeNotesMaps({}, { p1: dead }, NOW)
+      expect(merged.p1).toBeUndefined()
+      expect(stats.expired).toBe(1)
+      expect(stats.added).toBe(0)
+    })
+
+    it('未过期墓碑正常参与新者赢(删除传播不受影响)', () => {
+      const fresh = tombstone(NOW - 1000)
+      const { merged, stats } = mergeNotesMaps(
+        { p1: note(NOW - 2000, 'alive') },
+        { p1: fresh },
+        NOW
+      )
+      expect(merged.p1.deleted).toBe(true)
+      expect(stats.replaced).toBe(1)
+      expect(stats.expired).toBe(0)
+    })
+
+    it('活备注不受 TTL 影响(再老也照常合并)', () => {
+      const ancient = note(NOW - TOMBSTONE_TTL_MS * 10, 'old-but-alive')
+      const { merged, stats } = mergeNotesMaps({}, { p1: ancient }, NOW)
+      expect(merged.p1.note).toBe('old-but-alive')
+      expect(stats.added).toBe(1)
+      expect(stats.expired).toBe(0)
+    })
+
+    it('过期墓碑不能压过本地条目(跳过即保持本地)', () => {
+      const dead = tombstone(NOW - TOMBSTONE_TTL_MS - 1)
+      const { merged, stats } = mergeNotesMaps({ p1: note(1, 'local') }, { p1: dead }, NOW)
+      expect(merged.p1.note).toBe('local')
+      expect(merged.p1.deleted).toBeUndefined()
+      expect(stats.expired).toBe(1)
+    })
   })
 })

--- a/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
+++ b/lol-record-analysis-tauri/src/utils/mergePlayerNotes.ts
@@ -7,6 +7,20 @@
  */
 import type { PlayerNote, PlayerNotesMap } from '@renderer/types/domain/playerNote'
 
+/**
+ * 墓碑保留时长：30 天。
+ *
+ * 墓碑（`deleted: true` 条目）的唯一使命是把"删除"随合并传播到云端与其他
+ * 设备，之后就是死重——不清理的话 map 只增不减。30 天窗口的取值权衡：
+ * 太短则长期离线的设备错过删除传播（回线后其旧活备注会复活该条目）；
+ * 太长则墓碑堆积。30 天足以覆盖绝大多数设备的回线周期。
+ *
+ * 过期裁决放在 {@link mergeNotesMaps}（所有外部数据的必经信任边界）：
+ * 若只在加载时过滤内存，云端行里的老墓碑每次 pull 都会被当"新增"并入、
+ * 落盘再推回云端，GC 永远无法收敛。
+ */
+export const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
 /** 合并统计,供导入/同步完成后的 UI 反馈 */
 export interface MergeStats {
   /** 本地原本没有、新增的条数 */
@@ -17,6 +31,8 @@ export interface MergeStats {
   kept: number
   /** 结构非法或键不安全、被跳过的条数 */
   invalid: number
+  /** 过期墓碑(删除标记超过 {@link TOMBSTONE_TTL_MS})、被跳过的条数 */
+  expired: number
 }
 
 /**
@@ -34,17 +50,26 @@ function isValidNote(v: unknown): v is PlayerNote {
  * 合并两张备注表,不修改入参。
  * @param base - 本地表(冲突时的"守方")
  * @param incoming - 传入表(导入文件 / 云端拉取)
+ * @param now - 当前时刻(毫秒),墓碑过期判定用;默认 `Date.now()`,测试可注入
  * @returns 合并结果与统计
  */
 export function mergeNotesMaps(
   base: PlayerNotesMap,
-  incoming: PlayerNotesMap
+  incoming: PlayerNotesMap,
+  now: number = Date.now()
 ): { merged: PlayerNotesMap; stats: MergeStats } {
   const merged: PlayerNotesMap = { ...base }
-  const stats: MergeStats = { added: 0, replaced: 0, kept: 0, invalid: 0 }
+  const stats: MergeStats = { added: 0, replaced: 0, kept: 0, invalid: 0, expired: 0 }
+  const expireBefore = now - TOMBSTONE_TTL_MS
   for (const [puuid, note] of Object.entries(incoming)) {
     if (!isValidNote(note)) {
       stats.invalid++
+      continue
+    }
+    // 过期墓碑不参与合并:它的"删除传播"使命早已完成,并入只会让加载时
+    // 的 GC 白做(复活→落盘→推回云端的循环)。跳过即保持本地现状。
+    if (note.deleted && note.updatedAt < expireBefore) {
+      stats.expired++
       continue
     }
     // `__proto__` 是保留键:普通对象字面量上 `merged['__proto__'] = note` 走原型


### PR DESCRIPTION
## Summary
- **Rust 命令收编**：`cloud_pull/push_notes` 与 `cloud_pull/push_config` 四个近乎逐行复制的命令收成按 `data_type` 参数化的 `pull_payloads`/`push_payload`；puuid 校验集中到 `validate_puuid` 并显式拒绝空串（`chars().all` 对空串恒真，曾放行空 puuid 读写云端 `""` 共享行造成跨用户串流；push 侧此前完全无校验）；删除零调用方的 `save_text_file` 命令（暴露给 webview 的文件写入原语）
- **前端 syncNow 整形**：各设备行先内存合并成并集再一次性 `importNotes`（原来逐行导入 = N 次全表落盘 + N 次跨窗口广播）；本地有云端缺的内容才推送，无变化同步不再全量 upsert；`syncConfig` 三个独立读取并行
- **根除自触发回环**：防抖调度信号从 watch notes 引用改为 `userMutationSeq`（仅用户来源写操作递增，跨窗口广播事件携带 origin）——原来每次有合并的同步都会在 30s 后自触发一轮空同步
- **墓碑 TTL 下沉**：30 天过期裁决从"加载时过滤内存"下沉到 `mergeNotesMaps` 合并层（所有外部数据的必经信任边界）——原来云端行里的过期墓碑每次 pull 都被当"新增"复活（复活→落盘→推回循环），GC 永不收敛

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -Dwarnings` / `cargo test` passes（196 个，新增 3 个 validate_puuid）
- [x] `npm run format/lint/typecheck` passes
- [x] `npm run test` passes（523 个，新增 13 个：合并单次落盘/无变化跳过推送/不自触发/用户编辑仍调度/seq 计数器语义/墓碑 TTL 合并语义 ×4）
- [x] Manual（真机 dev + MCP bridge）：空 puuid / 注入字符在 pull 与 push 两侧均被拒；真实 puuid 走共享 helper 打通 Supabase（拉取 4 行备注 + 云端配置行）；`save_text_file` 已从命令表消失