### PR TITLE
feat(gaming): 选人阶段情报体系——敌方英雄展示/阶段流/四态动画/OPGG情报卡/选人期AI

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -287,8 +287,10 @@ async fn process_session_data(app_handle: AppHandle, seq: u64) -> Result<(), Str
                     crate::lcu::api::session::OnePlayer {
                         champion_id: crate::lcu::api::champion_select::display_champion_id(p),
                         puuid: p.puuid.clone(),
-                        // 我方选人期有 assignedPosition(小写)，转大写供位置排序；敌方为空
-                        selected_position: p.assigned_position.to_uppercase(),
+                        // 选人期刻意不填 position——保持 LCU my_team/their_team 的原始顺序（=客户端选人界面的排列）。
+                        // 进入对局后 gameflow 数据才带 position 做分路排序。sort_by_key 是稳定排序，
+                        // 全部 weight 99 时原序保留。
+                        selected_position: String::new(),
                         team_participant_id: 0,
                         pick_state: pick_states
                             .get(&p.cell_id)
@@ -1505,5 +1507,55 @@ mod tests {
             .count();
         assert_eq!(pair_count, 4);
         assert_eq!(solo_count, 8);
+    }
+
+    /// 回归：选人期我方玩家顺序应与客户端一致，不按分路重排。
+    /// 构造 ChampSelect 场景 team_one 五人（selected_position 全空、champion_id 依次 1..5 标识顺序），
+    /// 断言 build_classic_subteams 后玩家 champion_id 顺序仍为 1..5（未被重排）。
+    #[test]
+    fn champselect_preserves_player_order_without_reordering_by_position() {
+        let mut session = Session {
+            phase: "ChampSelect".into(),
+            game_data: GameData {
+                game_id: 5,
+                is_custom_game: false,
+                queue: Queue {
+                    queue_type: "RANKED_SOLO_5x5".into(),
+                    id: 420,
+                    game_mode: "CLASSIC".into(),
+                },
+                player_champion_selections: vec![],
+                // 选人期我方五人，champion_id 依次 1..5（用来标识顺序），selected_position 全空
+                team_one: (1..=5)
+                    .map(|i| OnePlayer {
+                        champion_id: i,
+                        puuid: format!("champ-{}", i),
+                        selected_position: String::new(),
+                        team_participant_id: 0,
+                        pick_state: String::new(),
+                    })
+                    .collect(),
+                team_two: vec![],
+            },
+        };
+
+        let mut data = SessionData {
+            game_mode: "CLASSIC".into(),
+            ..Default::default()
+        };
+        build_classic_subteams(&mut session, &mut data, "champ-1");
+
+        // 我方五人应保持原序 1..5，不因 selected_position 为空就被 sort_by_key 重排
+        assert_eq!(data.subteams[0].players.len(), 5);
+        let champion_ids: Vec<i32> = data.subteams[0]
+            .players
+            .iter()
+            .map(|p| p.champion_id)
+            .collect();
+        assert_eq!(
+            champion_ids,
+            vec![1, 2, 3, 4, 5],
+            "选人期玩家顺序应保持客户端选人界面排列"
+        );
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -285,7 +285,7 @@ async fn process_session_data(app_handle: AppHandle, seq: u64) -> Result<(), Str
                 champ_select_view = Some(view);
                 let to_one_player = |p: &crate::lcu::api::champion_select::OnePlayer| {
                     crate::lcu::api::session::OnePlayer {
-                        champion_id: p.champion_id,
+                        champion_id: crate::lcu::api::champion_select::display_champion_id(p),
                         puuid: p.puuid.clone(),
                         // 我方选人期有 assignedPosition(小写)，转大写供位置排序；敌方为空
                         selected_position: p.assigned_position.to_uppercase(),

--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -96,6 +96,8 @@ fn is_latest_task(counter: &AtomicU64, seq: u64) -> bool {
 /// - `subteams`: 所有小队，CLASSIC 长度 2，CHERRY 长度 1~8
 /// - `cherry_subteams_pending`: CHERRY 模式下当前分队是否仍是占位数据（EOG 端点尚未返回权威 subteamId）。
 ///   true 表示前端应继续轮询直到该端点 ready。CLASSIC 模式恒为 false。
+/// - `champ_select`: 选人阶段的结构化视图（会话级阶段 + 双方已 ban 列表）。
+///   仅 `phase == "ChampSelect"` 时为 `Some`，其余阶段为 `None` 且不序列化该字段。
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionData {
@@ -110,6 +112,8 @@ pub struct SessionData {
     pub subteams: Vec<Subteam>,
     #[serde(default)]
     pub cherry_subteams_pending: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub champ_select: Option<crate::lcu::api::champion_select::ChampSelectView>,
 }
 
 /// 一个小队的展示数据：编号 + 玩家列表。
@@ -269,11 +273,16 @@ async fn process_session_data(app_handle: AppHandle, seq: u64) -> Result<(), Str
 
     let mut session = Session::get_session().await?;
 
+    // 选人阶段的结构化视图（会话级阶段 + 双方已 ban 列表），随后写入 session_data.champ_select；
+    // 非选人阶段 / 拉取失败时保持 None。
+    let mut champ_select_view: Option<crate::lcu::api::champion_select::ChampSelectView> = None;
+
     if phase == "ChampSelect" {
         match get_champion_select_session().await {
             Ok(select_session) => {
-                let pick_states =
-                    crate::lcu::api::champion_select::derive_pick_states(&select_session);
+                let (view, pick_states) =
+                    crate::lcu::api::champion_select::derive_champ_select_view(&select_session);
+                champ_select_view = Some(view);
                 let to_one_player = |p: &crate::lcu::api::champion_select::OnePlayer| {
                     crate::lcu::api::session::OnePlayer {
                         champion_id: p.champion_id,
@@ -320,6 +329,7 @@ async fn process_session_data(app_handle: AppHandle, seq: u64) -> Result<(), Str
         my_subteam_id: 0,
         subteams: Vec::new(),
         cherry_subteams_pending: false,
+        champ_select: champ_select_view,
     };
 
     if is_multi_team {
@@ -1055,7 +1065,39 @@ fn one_in_arr(e: &str, arr: &[String]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lcu::api::champion_select::ChampSelectView;
     use crate::lcu::api::session::{GameData, OnePlayer, Queue, Session};
+
+    /// `champ_select` 应以 camelCase（`champSelect`/`myBans`/`theirBans`）序列化，
+    /// 供前端直接消费选人阶段流视图。
+    #[test]
+    fn champ_select_field_serializes_camel_case_when_present() {
+        let data = SessionData {
+            phase: "ChampSelect".into(),
+            champ_select: Some(ChampSelectView {
+                stage: "banning".into(),
+                my_bans: vec![266],
+                their_bans: vec![103],
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["champSelect"]["stage"], "banning");
+        assert_eq!(json["champSelect"]["myBans"][0], 266);
+        assert_eq!(json["champSelect"]["theirBans"][0], 103);
+    }
+
+    /// 非选人阶段 `champ_select` 为 None 时，字段应整体省略（skip_serializing_if）。
+    #[test]
+    fn champ_select_field_omitted_when_none() {
+        let data = SessionData {
+            phase: "InProgress".into(),
+            champ_select: None,
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        assert!(json.get("champSelect").is_none());
+    }
 
     #[test]
     fn newer_session_task_supersedes_older() {

--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -156,6 +156,9 @@ pub struct SessionSummoner {
     pub pre_group_markers: PreGroupMarker,
     /// 是否仍在加载中
     pub is_loading: bool,
+    /// 选人状态："none"|"intent"|"picking"|"locked"；非选人阶段为空字符串
+    #[serde(default)]
+    pub pick_state: String,
 }
 
 /// 预组队标记，用于标识同一预组队内的成员名称与类型。
@@ -269,17 +272,31 @@ async fn process_session_data(app_handle: AppHandle, seq: u64) -> Result<(), Str
     if phase == "ChampSelect" {
         match get_champion_select_session().await {
             Ok(select_session) => {
-                session.game_data.team_one = select_session
-                    .my_team
-                    .into_iter()
-                    .map(|p| crate::lcu::api::session::OnePlayer {
+                let pick_states =
+                    crate::lcu::api::champion_select::derive_pick_states(&select_session);
+                let to_one_player = |p: &crate::lcu::api::champion_select::OnePlayer| {
+                    crate::lcu::api::session::OnePlayer {
                         champion_id: p.champion_id,
-                        puuid: p.puuid,
-                        selected_position: String::new(),
+                        puuid: p.puuid.clone(),
+                        // 我方选人期有 assignedPosition(小写)，转大写供位置排序；敌方为空
+                        selected_position: p.assigned_position.to_uppercase(),
                         team_participant_id: 0,
-                    })
+                        pick_state: pick_states
+                            .get(&p.cell_id)
+                            .cloned()
+                            .unwrap_or_else(|| "none".to_string()),
+                    }
+                };
+                session.game_data.team_one =
+                    select_session.my_team.iter().map(to_one_player).collect();
+                // 敌方：champ-select 会话的 theirTeam 是本局权威数据（championId 随锁定
+                // 逐个可见；排位下 puuid 匿名为空，仅展示英雄不展示身份）。
+                // 旧局 selections 残留的防回填守卫（in_champ_select）保持不变。
+                session.game_data.team_two = select_session
+                    .their_team
+                    .iter()
+                    .map(to_one_player)
                     .collect();
-                session.game_data.team_two.clear();
             }
             Err(e) => {
                 log::warn!("Failed to get champion select session: {}", e);
@@ -331,6 +348,7 @@ async fn process_session_data(app_handle: AppHandle, seq: u64) -> Result<(), Str
                 puuid: p.summoner.puuid.clone(),
                 selected_position: String::new(),
                 team_participant_id: 0,
+                pick_state: p.pick_state.clone(),
             })
             .collect();
 
@@ -419,6 +437,7 @@ fn build_classic_subteams(session: &mut Session, session_data: &mut SessionData,
                     puuid: s.puuid.clone(),
                     selected_position: String::new(),
                     team_participant_id: 0,
+                    pick_state: String::new(),
                 })
                 .collect();
         }
@@ -430,6 +449,7 @@ fn build_classic_subteams(session: &mut Session, session_data: &mut SessionData,
                     puuid: s.puuid.clone(),
                     selected_position: String::new(),
                     team_participant_id: 0,
+                    pick_state: String::new(),
                 })
                 .collect();
         }
@@ -463,6 +483,7 @@ fn build_classic_subteams(session: &mut Session, session_data: &mut SessionData,
                     puuid: p.puuid.clone(),
                     ..Default::default()
                 },
+                pick_state: p.pick_state.clone(),
                 ..Default::default()
             })
             .collect()
@@ -507,6 +528,7 @@ async fn build_cherry_subteams(
                 puuid: s.puuid.clone(),
                 selected_position: String::new(),
                 team_participant_id: 0,
+                pick_state: String::new(),
             })
             .collect();
     }
@@ -569,6 +591,7 @@ async fn build_cherry_subteams(
             puuid: p.puuid.clone(),
             ..Default::default()
         },
+        pick_state: p.pick_state.clone(),
         ..Default::default()
     };
 
@@ -604,12 +627,14 @@ async fn push_basic_info(
         let futures = team.iter().map(|placeholder| {
             let puuid = placeholder.summoner.puuid.clone();
             let champion_id = placeholder.champion_id;
+            let pick_state = placeholder.pick_state.clone();
             async move {
                 if puuid.is_empty() {
                     return SessionSummoner {
                         champion_id,
                         champion_key: format!("champion_{}", champion_id),
                         is_loading: false,
+                        pick_state,
                         ..Default::default()
                     };
                 }
@@ -621,6 +646,7 @@ async fn push_basic_info(
                     champion_key: format!("champion_{}", champion_id),
                     summoner,
                     is_loading: true,
+                    pick_state,
                     ..Default::default()
                 }
             }
@@ -673,6 +699,7 @@ async fn process_subteam_parallel(
                     champion_id: player.champion_id,
                     champion_key: format!("champion_{}", player.champion_id),
                     is_loading: false,
+                    pick_state: player.pick_state.clone(),
                     ..Default::default()
                 };
             }
@@ -738,6 +765,7 @@ async fn process_subteam_parallel(
                     meet_games: Vec::new(),
                     pre_group_markers: PreGroupMarker::default(),
                     is_loading: false,
+                    pick_state: player.pick_state.clone(),
                 };
                 let update = PlayerUpdate {
                     subteam_id,
@@ -787,6 +815,7 @@ async fn process_subteam_parallel(
                 meet_games: Vec::new(),
                 pre_group_markers: PreGroupMarker::default(),
                 is_loading: false,
+                pick_state: player.pick_state.clone(),
             }
         });
 
@@ -1071,6 +1100,7 @@ mod tests {
                         puuid: format!("ally-{}", i),
                         selected_position: "TOP".into(),
                         team_participant_id: 0,
+                        pick_state: String::new(),
                     })
                     .collect(),
                 team_two: (6..=10)
@@ -1079,6 +1109,7 @@ mod tests {
                         puuid: format!("enemy-{}", i),
                         selected_position: "TOP".into(),
                         team_participant_id: 0,
+                        pick_state: String::new(),
                     })
                     .collect(),
             },
@@ -1126,7 +1157,8 @@ mod tests {
     fn champselect_must_not_refill_enemy_from_stale_selections() {
         let mut session = make_session_classic();
         session.phase = "ChampSelect".into();
-        // 模拟 process_session_data 的 ChampSelect 分支：我方来自选人会话、敌方已清空
+        // 模拟 process_session_data 的 ChampSelect 分支：我方来自选人会话、
+        // 敌方来自 their_team（此处为空 vec，模拟选人早期敌方尚未亮出任何英雄）
         session.game_data.team_one.truncate(5);
         session.game_data.team_two.clear();
         // gameflow 残留：上一局的 10 条 selections（含"我"在后五）
@@ -1152,6 +1184,65 @@ mod tests {
                 .iter()
                 .any(|p| p.summoner.puuid == "ally-1"),
             "我不应出现在敌方小队"
+        );
+    }
+
+    /// 选人期敌方必须从 their_team 填充（仅英雄无身份），pick_state 贯穿。
+    #[test]
+    fn champselect_fills_enemy_from_their_team_with_pick_state() {
+        let mut session = make_session_classic();
+        session.phase = "ChampSelect".into();
+        // 模拟 ChampSelect 分支产物：我方 5 人已选、敌方 3 人已亮（2 锁定 1 意向）
+        session.game_data.team_one.truncate(5);
+        session.game_data.team_two = vec![
+            crate::lcu::api::session::OnePlayer {
+                champion_id: 10,
+                puuid: String::new(),
+                selected_position: String::new(),
+                team_participant_id: 0,
+                pick_state: "locked".into(),
+            },
+            crate::lcu::api::session::OnePlayer {
+                champion_id: 55,
+                puuid: String::new(),
+                selected_position: String::new(),
+                team_participant_id: 0,
+                pick_state: "intent".into(),
+            },
+            crate::lcu::api::session::OnePlayer {
+                champion_id: 0,
+                puuid: String::new(),
+                selected_position: String::new(),
+                team_participant_id: 0,
+                pick_state: "none".into(),
+            },
+        ];
+        // 残留 selections 依旧不得回填（守卫回归）
+        session.game_data.player_champion_selections = stale_selections_with_me("ally-1");
+
+        let mut data = SessionData {
+            game_mode: "CLASSIC".into(),
+            ..Default::default()
+        };
+        build_classic_subteams(&mut session, &mut data, "ally-1");
+
+        assert_eq!(data.subteams[1].players.len(), 3, "敌方应来自 their_team");
+        assert_eq!(data.subteams[1].players[0].champion_id, 10);
+        assert_eq!(data.subteams[1].players[0].pick_state, "locked");
+        assert_eq!(data.subteams[1].players[1].pick_state, "intent");
+        assert!(
+            data.subteams[1]
+                .players
+                .iter()
+                .all(|p| p.summoner.puuid.is_empty()),
+            "选人期敌方不应有身份"
+        );
+        assert!(
+            !data.subteams[1]
+                .players
+                .iter()
+                .any(|p| p.summoner.puuid == "ally-1"),
+            "我不应出现在敌方"
         );
     }
 
@@ -1201,6 +1292,7 @@ mod tests {
                     puuid: format!("p-{}-{}", tpid, slot),
                     selected_position: "NONE".into(),
                     team_participant_id: tpid,
+                    pick_state: String::new(),
                 });
             }
         }
@@ -1268,18 +1360,21 @@ mod tests {
                         puuid: "a".into(),
                         selected_position: "".into(),
                         team_participant_id: 1,
+                        pick_state: String::new(),
                     },
                     OnePlayer {
                         champion_id: 2,
                         puuid: "b".into(),
                         selected_position: "".into(),
                         team_participant_id: 1,
+                        pick_state: String::new(),
                     },
                     OnePlayer {
                         champion_id: 3,
                         puuid: "c".into(),
                         selected_position: "".into(),
                         team_participant_id: 4,
+                        pick_state: String::new(),
                     },
                 ],
                 team_two: vec![],
@@ -1310,6 +1405,7 @@ mod tests {
                     puuid: format!("paired-{}-{}", tpid, slot),
                     selected_position: "NONE".into(),
                     team_participant_id: tpid,
+                    pick_state: String::new(),
                 });
             }
         }
@@ -1319,6 +1415,7 @@ mod tests {
                 puuid: format!("solo-{}", tpid),
                 selected_position: "NONE".into(),
                 team_participant_id: tpid,
+                pick_state: String::new(),
             });
         }
         let mut session = Session {

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/champion_select.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/champion_select.rs
@@ -55,6 +55,9 @@ pub struct OnePlayer {
     pub puuid: String,
     #[serde(default)]
     pub assigned_position: String,
+    /// 选人格子 ID（0~4 我方、5~9 敌方；旧接口无此字段时默认 0）
+    #[serde(default)]
+    pub cell_id: i32,
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +77,52 @@ impl SelectSessionCache {
 
 static SELECT_CACHE: LazyLock<Mutex<SelectSessionCache>> =
     LazyLock::new(|| Mutex::new(SelectSessionCache::new()));
+
+/// 从选人会话推导每个格子的选人状态。
+///
+/// 状态优先级：已完成 pick(champion>0)=locked > 进行中 pick=picking >
+/// 亮出英雄未锁=intent > 无信息=none。ban 类 action 不参与。
+/// actions 缺失该格信息但队伍条目已有英雄时兜底为 locked
+/// （某些时点 LCU 会清空已结束的 action 轮次）。
+pub fn derive_pick_states(session: &SelectSession) -> std::collections::HashMap<i32, String> {
+    use std::collections::HashMap;
+    let mut states: HashMap<i32, String> = HashMap::new();
+
+    let all_players = session.my_team.iter().chain(session.their_team.iter());
+    for p in all_players {
+        let mut state = "none";
+        let mut intent_champion = p.champion_id;
+
+        for action in session.actions.iter().flatten() {
+            if action.actor_cell_id != p.cell_id || action.action_type != "pick" {
+                continue;
+            }
+            if action.completed && action.champion_id > 0 {
+                state = "locked";
+                break;
+            }
+            if action.is_in_progress {
+                state = "picking";
+            } else if action.champion_id > 0 && state == "none" {
+                state = "intent";
+            }
+            if action.champion_id > 0 {
+                intent_champion = action.champion_id;
+            }
+        }
+
+        // 兜底：无 action 佐证但队伍条目已有英雄 → 视为已锁定
+        if state == "none" && p.champion_id > 0 {
+            state = "locked";
+        }
+        // 亮出英雄但未在选（intent 需有英雄可展示）
+        if state == "intent" && intent_champion <= 0 {
+            state = "none";
+        }
+        states.insert(p.cell_id, state.to_string());
+    }
+    states
+}
 
 pub async fn get_champion_select_session() -> Result<SelectSession, String> {
     {
@@ -152,5 +201,79 @@ mod tests {
         assert_eq!(s.their_team[0].champion_id, 2);
         assert_eq!(s.my_team[0].assigned_position, "middle");
         assert_eq!(s.their_team[0].assigned_position, "");
+    }
+
+    fn mk_session(
+        my: Vec<(i32, i32)>, // (cell_id, champion_id)
+        their: Vec<(i32, i32)>,
+        actions: Vec<Action>,
+    ) -> SelectSession {
+        let mk = |v: Vec<(i32, i32)>| {
+            v.into_iter()
+                .map(|(cell_id, champion_id)| OnePlayer {
+                    champion_id,
+                    puuid: String::new(),
+                    assigned_position: String::new(),
+                    cell_id,
+                })
+                .collect()
+        };
+        SelectSession {
+            my_team: mk(my),
+            their_team: mk(their),
+            actions: vec![actions],
+            timer: Timer::default(),
+            local_player_cell_id: 0,
+        }
+    }
+
+    fn pick_action(cell: i32, champ: i32, completed: bool, in_progress: bool) -> Action {
+        Action {
+            actor_cell_id: cell,
+            id: cell,
+            champion_id: champ,
+            completed,
+            is_ally_action: true,
+            is_in_progress: in_progress,
+            action_type: "pick".into(),
+        }
+    }
+
+    #[test]
+    fn should_derive_locked_picking_intent_none() {
+        let s = mk_session(
+            vec![(0, 86), (1, 0)],
+            vec![(5, 10), (6, 0)],
+            vec![
+                pick_action(0, 86, true, false),  // 已锁定
+                pick_action(1, 0, false, true),   // 正在选(未亮英雄)
+                pick_action(5, 10, false, false), // 亮出未锁 → intent
+            ],
+        );
+        let m = derive_pick_states(&s);
+        assert_eq!(m[&0], "locked");
+        assert_eq!(m[&1], "picking");
+        assert_eq!(m[&5], "intent");
+        assert_eq!(m[&6], "none");
+    }
+
+    #[test]
+    fn should_ignore_ban_actions_and_fallback_to_locked_without_actions() {
+        // ban action 不影响 pick 态；无 actions 但队伍条目有英雄 → locked 兜底
+        let mut ban = pick_action(0, 266, true, false);
+        ban.action_type = "ban".into();
+        let s = mk_session(vec![(0, 86)], vec![], vec![ban]);
+        let m = derive_pick_states(&s);
+        assert_eq!(m[&0], "locked");
+    }
+
+    #[test]
+    fn should_deserialize_cell_id_with_default() {
+        let raw = r#"{"championId": 1, "puuid": "p1", "assignedPosition": "middle"}"#;
+        let p: OnePlayer = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.cell_id, 0); // 缺字段不炸
+        let raw2 = r#"{"championId": 1, "puuid": "p1", "cellId": 7}"#;
+        let p2: OnePlayer = serde_json::from_str(raw2).unwrap();
+        assert_eq!(p2.cell_id, 7);
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/champion_select.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/champion_select.rs
@@ -78,50 +78,151 @@ impl SelectSessionCache {
 static SELECT_CACHE: LazyLock<Mutex<SelectSessionCache>> =
     LazyLock::new(|| Mutex::new(SelectSessionCache::new()));
 
-/// 从选人会话推导每个格子的选人状态。
+/// 选人会话的结构化视图：会话级阶段 + 双方已 ban + 每格状态。
 ///
-/// 状态优先级：已完成 pick(champion>0)=locked > 进行中 pick=picking >
-/// 亮出英雄未锁=intent > 无信息=none。ban 类 action 不参与。
+/// 由 [`derive_champ_select_view`] 从 [`SelectSession`] 推导得到，随
+/// [`crate::command::session::SessionData`] 一并推送给前端，供选人阶段
+/// UI（预选/ban/选人/确认）驱动展示逻辑，无需前端自行拼装 timer+actions。
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ChampSelectView {
+    /// 会话级阶段: "planning"(预选) | "banning"(ban阶段) | "picking"(选人) | "finalization"(确认) | ""(未知)
+    pub stage: String,
+    /// 我方已 ban 英雄（completed ban action, champion_id>0, is_ally_action=true）
+    pub my_bans: Vec<i32>,
+    /// 敌方已 ban
+    pub their_bans: Vec<i32>,
+}
+
+/// 从选人会话推导每个格子的状态。
+///
+/// 状态优先级：已完成 pick(champion>0)=locked > 进行中 ban=banning >
+/// 进行中 pick=picking > 亮出英雄未锁=intent > 无信息=none。
 /// actions 缺失该格信息但队伍条目已有英雄时兜底为 locked
 /// （某些时点 LCU 会清空已结束的 action 轮次）。
-pub fn derive_pick_states(session: &SelectSession) -> std::collections::HashMap<i32, String> {
+///
+/// 是 [`derive_pick_states`] 与 [`derive_champ_select_view`] 共用的唯一实现，
+/// 避免两份格子状态推导逻辑分叉。
+fn derive_cell_states(session: &SelectSession) -> std::collections::HashMap<i32, String> {
     use std::collections::HashMap;
     let mut states: HashMap<i32, String> = HashMap::new();
 
     let all_players = session.my_team.iter().chain(session.their_team.iter());
     for p in all_players {
-        let mut state = "none";
-        let mut intent_champion = p.champion_id;
+        let mut has_locked_pick = false;
+        let mut has_in_progress_ban = false;
+        let mut has_in_progress_pick = false;
+        // 仅由「pick」类 action 揭示的意向英雄；不要用队伍条目的 champion_id
+        // 兜底，否则会把「无 action 佐证、只能靠兜底判 locked」的格子误判成 intent。
+        let mut intent_champion_from_action = 0;
 
         for action in session.actions.iter().flatten() {
-            if action.actor_cell_id != p.cell_id || action.action_type != "pick" {
+            if action.actor_cell_id != p.cell_id {
                 continue;
             }
-            if action.completed && action.champion_id > 0 {
-                state = "locked";
-                break;
-            }
-            if action.is_in_progress {
-                state = "picking";
-            } else if action.champion_id > 0 && state == "none" {
-                state = "intent";
-            }
-            if action.champion_id > 0 {
-                intent_champion = action.champion_id;
+            if action.action_type == "pick" {
+                if action.completed && action.champion_id > 0 {
+                    has_locked_pick = true;
+                }
+                if action.is_in_progress {
+                    has_in_progress_pick = true;
+                }
+                if action.champion_id > 0 {
+                    intent_champion_from_action = action.champion_id;
+                }
+            } else if action.action_type == "ban" && action.is_in_progress {
+                has_in_progress_ban = true;
             }
         }
+
+        let mut state = if has_locked_pick {
+            "locked"
+        } else if has_in_progress_ban {
+            "banning"
+        } else if has_in_progress_pick {
+            "picking"
+        } else if intent_champion_from_action > 0 {
+            "intent"
+        } else {
+            "none"
+        };
 
         // 兜底：无 action 佐证但队伍条目已有英雄 → 视为已锁定
         if state == "none" && p.champion_id > 0 {
             state = "locked";
         }
-        // 亮出英雄但未在选（intent 需有英雄可展示）
-        if state == "intent" && intent_champion <= 0 {
-            state = "none";
-        }
         states.insert(p.cell_id, state.to_string());
     }
     states
+}
+
+/// 从选人会话推导每个格子的选人状态。
+///
+/// 委托给 [`derive_cell_states`]（与 [`derive_champ_select_view`] 共用实现）。
+/// 公开签名保持不变，避免破坏既有调用方/测试。
+pub fn derive_pick_states(session: &SelectSession) -> std::collections::HashMap<i32, String> {
+    derive_cell_states(session)
+}
+
+/// 从 `timer.phase` + `actions` 推导会话级阶段与双方已 ban 列表，
+/// 并返回每格状态（含 "banning"）。
+///
+/// # 阶段推导规则
+///
+/// - `PLANNING` → `"planning"`（预选）
+/// - `BAN_PICK` → 存在 in-progress 的 ban action 时为 `"banning"`，否则 `"picking"`
+/// - `FINALIZATION` / `GAME_STARTING` → `"finalization"`（对前端等价：都已定）
+/// - 其他/空 → `""`
+///
+/// # Ban 列表
+///
+/// 仅统计已完成（`completed`）且 `champion_id > 0` 的 ban action，按
+/// `is_ally_action` 分流到 `my_bans` / `their_bans`。
+pub fn derive_champ_select_view(
+    session: &SelectSession,
+) -> (ChampSelectView, std::collections::HashMap<i32, String>) {
+    let has_in_progress_ban = session
+        .actions
+        .iter()
+        .flatten()
+        .any(|a| a.action_type == "ban" && a.is_in_progress);
+
+    let stage = match session.timer.phase.as_str() {
+        "PLANNING" => "planning",
+        "BAN_PICK" => {
+            if has_in_progress_ban {
+                "banning"
+            } else {
+                "picking"
+            }
+        }
+        "FINALIZATION" | "GAME_STARTING" => "finalization",
+        _ => "",
+    }
+    .to_string();
+
+    let mut my_bans = Vec::new();
+    let mut their_bans = Vec::new();
+    for action in session.actions.iter().flatten() {
+        if action.action_type == "ban" && action.completed && action.champion_id > 0 {
+            if action.is_ally_action {
+                my_bans.push(action.champion_id);
+            } else {
+                their_bans.push(action.champion_id);
+            }
+        }
+    }
+
+    let states = derive_cell_states(session);
+
+    (
+        ChampSelectView {
+            stage,
+            my_bans,
+            their_bans,
+        },
+        states,
+    )
 }
 
 pub async fn get_champion_select_session() -> Result<SelectSession, String> {
@@ -275,5 +376,130 @@ mod tests {
         let raw2 = r#"{"championId": 1, "puuid": "p1", "cellId": 7}"#;
         let p2: OnePlayer = serde_json::from_str(raw2).unwrap();
         assert_eq!(p2.cell_id, 7);
+    }
+
+    fn ban_action(cell: i32, champ: i32, completed: bool, in_progress: bool, ally: bool) -> Action {
+        Action {
+            actor_cell_id: cell,
+            id: cell,
+            champion_id: champ,
+            completed,
+            is_ally_action: ally,
+            is_in_progress: in_progress,
+            action_type: "ban".into(),
+        }
+    }
+
+    fn with_phase(mut session: SelectSession, phase: &str) -> SelectSession {
+        session.timer.phase = phase.into();
+        session
+    }
+
+    #[test]
+    fn planning_stage_marks_revealed_cells_as_intent() {
+        // 预选阶段：亮出英雄但未锁定/未进入 ban-pick，格子态应为 intent
+        let s = with_phase(
+            mk_session(
+                vec![(0, 86)],
+                vec![],
+                vec![pick_action(0, 86, false, false)],
+            ),
+            "PLANNING",
+        );
+        let (view, states) = derive_champ_select_view(&s);
+        assert_eq!(view.stage, "planning");
+        assert_eq!(states[&0], "intent");
+        assert!(view.my_bans.is_empty());
+        assert!(view.their_bans.is_empty());
+    }
+
+    #[test]
+    fn ban_pick_with_in_progress_ban_is_banning_stage_and_completed_bans_split_by_side() {
+        let s = with_phase(
+            mk_session(
+                vec![(0, 0), (1, 0)],
+                vec![(5, 0)],
+                vec![
+                    ban_action(0, 0, false, true, true),   // 我方正在 ban（未选目标）
+                    ban_action(1, 266, true, false, true), // 我方已完成 ban
+                    ban_action(5, 103, true, false, false), // 敌方已完成 ban
+                ],
+            ),
+            "BAN_PICK",
+        );
+        let (view, states) = derive_champ_select_view(&s);
+        assert_eq!(view.stage, "banning");
+        assert_eq!(states[&0], "banning");
+        assert_eq!(view.my_bans, vec![266]);
+        assert_eq!(view.their_bans, vec![103]);
+    }
+
+    #[test]
+    fn ban_pick_without_in_progress_ban_is_picking_stage() {
+        let s = with_phase(
+            mk_session(
+                vec![(0, 0)],
+                vec![],
+                vec![pick_action(0, 0, false, true)], // 正在选人
+            ),
+            "BAN_PICK",
+        );
+        let (view, states) = derive_champ_select_view(&s);
+        assert_eq!(view.stage, "picking");
+        assert_eq!(states[&0], "picking");
+    }
+
+    #[test]
+    fn finalization_stage_keeps_locked_cells_locked() {
+        let s = with_phase(
+            mk_session(vec![(0, 86)], vec![], vec![pick_action(0, 86, true, false)]),
+            "FINALIZATION",
+        );
+        let (view, states) = derive_champ_select_view(&s);
+        assert_eq!(view.stage, "finalization");
+        assert_eq!(states[&0], "locked");
+    }
+
+    #[test]
+    fn game_starting_phase_is_treated_as_finalization() {
+        let s = with_phase(mk_session(vec![], vec![], vec![]), "GAME_STARTING");
+        let (view, _states) = derive_champ_select_view(&s);
+        assert_eq!(view.stage, "finalization");
+    }
+
+    #[test]
+    fn unknown_phase_yields_empty_stage() {
+        let s = with_phase(mk_session(vec![], vec![], vec![]), "");
+        let (view, _states) = derive_champ_select_view(&s);
+        assert_eq!(view.stage, "");
+    }
+
+    #[test]
+    fn ban_with_no_champion_target_is_excluded_from_bans_list() {
+        // 完成的 ban action 但 championId=0（异常/未选目标）不应计入 bans 列表
+        let s = with_phase(
+            mk_session(
+                vec![(0, 0)],
+                vec![],
+                vec![ban_action(0, 0, true, false, true)],
+            ),
+            "BAN_PICK",
+        );
+        let (view, _states) = derive_champ_select_view(&s);
+        assert!(view.my_bans.is_empty());
+        assert!(view.their_bans.is_empty());
+    }
+
+    #[test]
+    fn champ_select_view_serializes_to_camel_case() {
+        let view = ChampSelectView {
+            stage: "banning".into(),
+            my_bans: vec![266],
+            their_bans: vec![103],
+        };
+        let json = serde_json::to_value(&view).unwrap();
+        assert_eq!(json["stage"], "banning");
+        assert_eq!(json["myBans"][0], 266);
+        assert_eq!(json["theirBans"][0], 103);
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/champion_select.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/champion_select.rs
@@ -58,6 +58,21 @@ pub struct OnePlayer {
     /// 选人格子 ID（0~4 我方、5~9 敌方；旧接口无此字段时默认 0）
     #[serde(default)]
     pub cell_id: i32,
+    /// 悬停中（未锁定）的意向英雄 ID。LCU 在队友「正在选用」但还未点击锁定时
+    /// 通过 myTeam[].championPickIntent 推送；敌方通常为 0（隐藏）。
+    /// 旧接口/字段缺失时默认 0。
+    #[serde(default)]
+    pub champion_pick_intent: i32,
+}
+
+/// 选人期该格用于展示的英雄：已锁定用 `champion_id`，否则回退悬停意向
+/// `champion_pick_intent`（尚未锁定时 LCU 才会填充该字段）。
+pub fn display_champion_id(p: &OnePlayer) -> i32 {
+    if p.champion_id > 0 {
+        p.champion_id
+    } else {
+        p.champion_pick_intent
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -98,8 +113,10 @@ pub struct ChampSelectView {
 ///
 /// 状态优先级：已完成 pick(champion>0)=locked > 进行中 ban=banning >
 /// 进行中 pick=picking > 亮出英雄未锁=intent > 无信息=none。
-/// actions 缺失该格信息但队伍条目已有英雄时兜底为 locked
-/// （某些时点 LCU 会清空已结束的 action 轮次）。
+/// actions 缺失该格信息时按队伍条目兜底：`champion_id>0`（真锁定）→ locked；
+/// 否则 `champion_pick_intent>0`（LCU 推送的悬停意向，如队友「正在选用」尚未
+/// 点击锁定）→ intent（某些时点 LCU 会清空已结束的 action 轮次，只能靠队伍
+/// 条目兜底）。
 ///
 /// 是 [`derive_pick_states`] 与 [`derive_champ_select_view`] 共用的唯一实现，
 /// 避免两份格子状态推导逻辑分叉。
@@ -148,8 +165,12 @@ fn derive_cell_states(session: &SelectSession) -> std::collections::HashMap<i32,
         };
 
         // 兜底：无 action 佐证但队伍条目已有英雄 → 视为已锁定
+        // 注意 p.champion_id>0 才是真锁定；championPickIntent>0 不得走这条兜底。
         if state == "none" && p.champion_id > 0 {
             state = "locked";
+        } else if state == "none" && p.champion_id == 0 && p.champion_pick_intent > 0 {
+            // 兜底：无 action 佐证、未锁定，但 LCU 推送了悬停意向 → intent
+            state = "intent";
         }
         states.insert(p.cell_id, state.to_string());
     }
@@ -316,6 +337,7 @@ mod tests {
                     puuid: String::new(),
                     assigned_position: String::new(),
                     cell_id,
+                    champion_pick_intent: 0,
                 })
                 .collect()
         };
@@ -376,6 +398,68 @@ mod tests {
         let raw2 = r#"{"championId": 1, "puuid": "p1", "cellId": 7}"#;
         let p2: OnePlayer = serde_json::from_str(raw2).unwrap();
         assert_eq!(p2.cell_id, 7);
+    }
+
+    #[test]
+    fn should_deserialize_champion_pick_intent_with_default() {
+        // 缺字段（旧接口/敌方通常不下发）默认 0，不炸
+        let raw = r#"{"championId": 0, "puuid": "p1"}"#;
+        let p: OnePlayer = serde_json::from_str(raw).unwrap();
+        assert_eq!(p.champion_pick_intent, 0);
+
+        // LCU 悬停未锁时下发的意向英雄 ID
+        let raw2 = r#"{"championId": 0, "puuid": "p1", "championPickIntent": 157}"#;
+        let p2: OnePlayer = serde_json::from_str(raw2).unwrap();
+        assert_eq!(p2.champion_pick_intent, 157);
+    }
+
+    fn mk_player(champion_id: i32, champion_pick_intent: i32) -> OnePlayer {
+        OnePlayer {
+            champion_id,
+            puuid: String::new(),
+            assigned_position: String::new(),
+            cell_id: 0,
+            champion_pick_intent,
+        }
+    }
+
+    #[test]
+    fn display_champion_id_prefers_locked_champion_over_intent() {
+        // 已锁定：即使 intent 字段仍残留旧值，也应展示 champion_id
+        let p = mk_player(86, 157);
+        assert_eq!(display_champion_id(&p), 86);
+    }
+
+    #[test]
+    fn display_champion_id_falls_back_to_intent_when_not_locked() {
+        // 未锁定（champion_id=0）：展示悬停意向
+        let p = mk_player(0, 157);
+        assert_eq!(display_champion_id(&p), 157);
+    }
+
+    #[test]
+    fn display_champion_id_is_zero_when_neither_locked_nor_hovered() {
+        let p = mk_player(0, 0);
+        assert_eq!(display_champion_id(&p), 0);
+    }
+
+    #[test]
+    fn cell_state_is_intent_when_pick_intent_present_without_any_action() {
+        // 选人期刚进入、还没有该格的 action 记录，但 myTeam 已推送 championPickIntent
+        // → 应识别为 intent，而不是误判 locked 或 none。
+        let mut s = mk_session(vec![(0, 0)], vec![], vec![]);
+        s.my_team[0].champion_pick_intent = 157;
+        let m = derive_pick_states(&s);
+        assert_eq!(m[&0], "intent");
+    }
+
+    #[test]
+    fn cell_state_stays_locked_when_champion_id_set_without_any_action() {
+        // 回归：champion_id>0（真锁定）无 action 佐证时仍应兜底为 locked，
+        // 不应被 championPickIntent 的新分支影响。
+        let s = mk_session(vec![(0, 86)], vec![], vec![]);
+        let m = derive_pick_states(&s);
+        assert_eq!(m[&0], "locked");
     }
 
     fn ban_action(cell: i32, champ: i32, completed: bool, in_progress: bool, ally: bool) -> Action {

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/session.rs
@@ -55,6 +55,9 @@ pub struct OnePlayer {
     /// CHERRY 模式下的 lobby 阶段编号；同 ID 的玩家是同小队（仅作弱信号，最终以 stats.playerSubteamId 为准）
     #[serde(default)]
     pub team_participant_id: i32,
+    /// 选人状态："none"|"intent"|"picking"|"locked"；非选人阶段为空字符串
+    #[serde(default)]
+    pub pick_state: String,
 }
 
 impl Session {

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/aram_sample.json
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/aram_sample.json
@@ -5,8 +5,13 @@
       "is_rotation": false,
       "is_rip": false,
       "average_stats": {
-        "play": 96224, "win_rate": 0.522313, "pick_rate": 0.0594868,
-        "ban_rate": null, "kda": 2.882699, "tier": 2, "rank": 36,
+        "play": 96224,
+        "win_rate": 0.522313,
+        "pick_rate": 0.0594868,
+        "ban_rate": null,
+        "kda": 2.882699,
+        "tier": 2,
+        "rank": 36,
         "tier_data": { "tier": 2, "rank": 36, "rank_prev": 36, "rank_prev_patch": 39 }
       },
       "positions": null

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/ranked_sample.json
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/fixtures/ranked_sample.json
@@ -5,16 +5,25 @@
       "is_rotation": false,
       "is_rip": false,
       "average_stats": {
-        "play": 280051, "win_rate": 0.517106, "pick_rate": 0.0871455,
-        "ban_rate": 0.068954, "kda": 1.84497, "tier": 1, "rank": 7,
+        "play": 280051,
+        "win_rate": 0.517106,
+        "pick_rate": 0.0871455,
+        "ban_rate": 0.068954,
+        "kda": 1.84497,
+        "tier": 1,
+        "rank": 7,
         "tier_data": { "tier": 1, "rank": 7, "rank_prev": 7, "rank_prev_patch": 7 }
       },
       "positions": [
         {
           "name": "TOP",
           "stats": {
-            "play": 259070, "win_rate": 0.517991, "pick_rate": 0.0815533,
-            "role_rate": 0.925081, "ban_rate": 0.0689323, "kda": 1.823866,
+            "play": 259070,
+            "win_rate": 0.517991,
+            "pick_rate": 0.0815533,
+            "role_rate": 0.925081,
+            "ban_rate": 0.0689323,
+            "kda": 1.823866,
             "tier_data": { "tier": 1, "rank": 1, "rank_prev": 1, "rank_prev_patch": 1 }
           },
           "counters": [
@@ -30,25 +39,38 @@
       "is_rotation": false,
       "is_rip": false,
       "average_stats": {
-        "play": 100000, "win_rate": 0.5, "pick_rate": 0.05,
-        "ban_rate": 0.01, "kda": 2.0, "tier": 3, "rank": 60,
+        "play": 100000,
+        "win_rate": 0.5,
+        "pick_rate": 0.05,
+        "ban_rate": 0.01,
+        "kda": 2.0,
+        "tier": 3,
+        "rank": 60,
         "tier_data": { "tier": 3, "rank": 60, "rank_prev": 60, "rank_prev_patch": 60 }
       },
       "positions": [
         {
           "name": "MID",
           "stats": {
-            "play": 70000, "win_rate": 0.51, "pick_rate": 0.04,
-            "role_rate": 0.7, "ban_rate": 0.01, "kda": 2.1,
+            "play": 70000,
+            "win_rate": 0.51,
+            "pick_rate": 0.04,
+            "role_rate": 0.7,
+            "ban_rate": 0.01,
+            "kda": 2.1,
             "tier_data": { "tier": 2, "rank": 20, "rank_prev": 20, "rank_prev_patch": 20 }
           },
-          "counters": [ { "champion_id": 86, "play": 2000, "win": 900 } ]
+          "counters": [{ "champion_id": 86, "play": 2000, "win": 900 }]
         },
         {
           "name": "ADC",
           "stats": {
-            "play": 30000, "win_rate": 0.49, "pick_rate": 0.01,
-            "role_rate": 0.3, "ban_rate": 0.01, "kda": 1.9,
+            "play": 30000,
+            "win_rate": 0.49,
+            "pick_rate": 0.01,
+            "role_rate": 0.3,
+            "ban_rate": 0.01,
+            "kda": 1.9,
             "tier_data": { "tier": 4, "rank": 50, "rank_prev": 50, "rank_prev_patch": 50 }
           },
           "counters": []

--- a/lol-record-analysis-tauri/src-tauri/src/rule_engine.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/rule_engine.rs
@@ -145,6 +145,7 @@ mod tests {
             puuid: puuid.to_string(),
             assigned_position: position.to_string(),
             cell_id: 0,
+            champion_pick_intent: 0,
         }
     }
 
@@ -205,6 +206,7 @@ mod tests {
             puuid: "x".to_string(),
             assigned_position: "".to_string(),
             cell_id: 0,
+            champion_pick_intent: 0,
         }
     }
 
@@ -258,6 +260,7 @@ mod tests {
             puuid: "y".to_string(),
             assigned_position: "".to_string(),
             cell_id: 0,
+            champion_pick_intent: 0,
         }
     }
 

--- a/lol-record-analysis-tauri/src-tauri/src/rule_engine.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/rule_engine.rs
@@ -144,6 +144,7 @@ mod tests {
             champion_id: 0,
             puuid: puuid.to_string(),
             assigned_position: position.to_string(),
+            cell_id: 0,
         }
     }
 
@@ -203,6 +204,7 @@ mod tests {
             champion_id,
             puuid: "x".to_string(),
             assigned_position: "".to_string(),
+            cell_id: 0,
         }
     }
 
@@ -255,6 +257,7 @@ mod tests {
             champion_id,
             puuid: "y".to_string(),
             assigned_position: "".to_string(),
+            cell_id: 0,
         }
     }
 

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="intel-card" :class="[pickStateClass(pickState), `intel-${density}`]">
-    <!-- 未亮英雄：占位（picking 态高亮呼吸） -->
-    <template v-if="!championId || championId <= 0">
+  <div
+    class="intel-card"
+    :class="[pickStateClass(pickState), `intel-${density}`, isEmpty && 'intel-empty']"
+  >
+    <!-- 未亮英雄：占位（虚线边框 + 居中提示，picking 态同样吃 intel-picking 动画） -->
+    <template v-if="isEmpty">
       <div class="intel-placeholder">
         <span class="intel-placeholder-icon">❓</span>
         <span class="intel-placeholder-text">{{
@@ -14,10 +17,15 @@
       <div class="intel-body">
         <div class="intel-row">
           <span class="intel-name">{{ name }}</span>
-          <span v-if="badge.label" class="intel-tier" :style="{ color: badge.color }">{{
-            badge.label
+          <span
+            v-if="badge.label"
+            class="intel-tier"
+            :style="{ color: badge.color, backgroundColor: badge.bg }"
+            >{{ badge.label }}</span
+          >
+          <span class="intel-winrate" :class="winRateClass">{{
+            formatWinRate(meta?.winRate)
           }}</span>
-          <span class="intel-winrate">{{ formatWinRate(meta?.winRate) }}</span>
         </div>
         <div class="intel-row intel-sub">
           <span v-if="pickState === 'intent'" class="intel-state-tag">意向</span>
@@ -66,6 +74,16 @@ const name = ref('')
 const meta = ref<ChampionMeta | null>(null)
 const hints = ref<CounterHint[]>([])
 const badge = computed(() => tierBadge(meta.value?.tier ?? 0))
+/** 未亮出英雄：走占位分支（虚线卡 + 居中 ❓） */
+const isEmpty = computed(() => !props.championId || props.championId <= 0)
+/** 胜率语义色：>=52% 绿、<=48% 红，其余用默认色（模板里不设 class） */
+const winRateClass = computed(() => {
+  const rate = meta.value?.winRate
+  if (rate === undefined || rate <= 0) return ''
+  if (rate >= 0.52) return 'intel-winrate-good'
+  if (rate <= 0.48) return 'intel-winrate-bad'
+  return ''
+})
 
 /** 名字辅助：克制提示里显示我方英雄名 */
 function counterText(h: CounterHint): string {
@@ -123,21 +141,30 @@ watch(
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
+  box-sizing: border-box;
   border: 1px solid var(--n-border-color, rgba(128, 128, 128, 0.2));
   border-radius: 10px;
   background: var(--n-color, transparent);
   min-height: 56px;
-  /* 入场：复用全局 fade-up + 错位 stagger（对齐 PlayerCard 入场节奏） */
-  animation: fade-up var(--dur-normal) var(--ease-expo) both;
-  animation-delay: calc(var(--stagger) * var(--stagger-i, 0));
+  /* 入场：自有 intel-enter keyframe，比全局 fade-up 更大幅度（+scale）更易察觉 */
+  animation: intel-enter 0.45s var(--ease-expo) both;
+  animation-delay: calc(90ms * var(--stagger-i, 0));
 }
 .intel-compact {
   padding: 6px 8px;
   min-height: 44px;
 }
 .intel-avatar {
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  border: 2px solid transparent;
+  flex-shrink: 0;
+  transition: border-color var(--dur-normal) var(--ease-expo);
+}
+.intel-compact .intel-avatar {
+  width: 36px;
+  height: 36px;
   border-radius: 8px;
 }
 .intel-body {
@@ -152,14 +179,30 @@ watch(
 .intel-name {
   font-weight: 600;
 }
+/* T 级徽章：pill chip，颜色/背景来自 tierBadge() 的 color/bg 字段 */
 .intel-tier {
   font-weight: 700;
-  font-size: 12px;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  line-height: 1.5;
+  white-space: nowrap;
 }
 .intel-winrate {
   margin-left: auto;
   font-variant-numeric: tabular-nums;
+  text-align: right;
   opacity: 0.85;
+}
+.intel-winrate-good {
+  color: var(--semantic-win, #18a058);
+  opacity: 1;
+  font-weight: 600;
+}
+.intel-winrate-bad {
+  color: var(--semantic-loss, #d03050);
+  opacity: 1;
+  font-weight: 600;
 }
 .intel-sub {
   margin-top: 2px;
@@ -169,11 +212,18 @@ watch(
 .intel-state-tag {
   opacity: 0.7;
 }
+/* 克制提示：小 pill，背景用语义色 8% 透明度 */
+.intel-counter {
+  padding: 1px 6px;
+  border-radius: 999px;
+}
 .intel-counter-good {
   color: var(--semantic-win, #18a058);
+  background: color-mix(in srgb, var(--semantic-win, #18a058) 8%, transparent);
 }
 .intel-counter-bad {
   color: var(--semantic-loss, #d03050);
+  background: color-mix(in srgb, var(--semantic-loss, #d03050) 8%, transparent);
 }
 .intel-placeholder {
   display: flex;
@@ -181,68 +231,120 @@ watch(
   gap: 8px;
   opacity: 0.55;
 }
+.intel-placeholder-icon {
+  font-size: 16px;
+}
+/* 未锁定占位卡：虚线边框 + 居中内容（picking 态被下方 .intel-picking 的实线+脉冲覆盖） */
+.intel-empty {
+  border-style: dashed;
+  justify-content: center;
+}
 
-/* ---- 三态动画 ----
- * 三态各自的 animation 简写会整体覆盖 .intel-card 上的入场 fade-up（同选择器
- * 特异性下后声明的规则整体替换而非合并），所以这里都显式把 fade-up 复合进去，
- * 用逗号分隔的第二个动画承载各态自身效果，animation-delay 也按位置一一对应。
+/* ---- 入场 + 三态动画 ----
+ * intel-enter 恒为逗号组合里的第一个 animation-name（位序对齐 delay 列表的第一项），
+ * 各 pick-state 类在此基础上追加第二段动画承载状态本身的效果；三态的 animation 简写
+ * 会整体覆盖 .intel-card 上的入场声明（同特异性下后声明整体替换而非合并），所以这里
+ * 都显式把 intel-enter 复合进去。
  */
-/* 意向：亮出未锁 → 半透明 + 呼吸 */
+@keyframes intel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* 意向：半透明呼吸 + 琥珀光晕 + 琥珀细边框，比旧版明显得多 */
 .intel-intent {
-  opacity: 0.8;
+  border-color: rgba(230, 193, 90, 0.55);
   animation:
-    fade-up var(--dur-normal) var(--ease-expo) both,
+    intel-enter 0.45s var(--ease-expo) both,
     intel-breathe 2s ease-in-out infinite;
-  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+}
+.intel-intent .intel-avatar {
+  border-color: rgba(230, 193, 90, 0.7);
 }
 @keyframes intel-breathe {
   0%,
   100% {
+    opacity: 0.7;
     box-shadow: 0 0 0 0 transparent;
   }
   50% {
-    box-shadow: 0 0 10px 1px rgba(99, 226, 183, 0.35);
+    opacity: 1;
+    box-shadow: 0 0 14px 2px rgba(230, 193, 90, 0.45);
   }
 }
-/* 正在选：边框脉冲高亮 */
+
+/* 正在选：绿色粗边框 + 外扩 ring 呼吸 + 极淡绿 tint，头像同步脉冲 */
 .intel-picking {
-  border-color: var(--semantic-win, #18a058);
+  border: 2px solid var(--semantic-win, #18a058);
+  background: rgba(24, 160, 88, 0.06);
   animation:
-    fade-up var(--dur-normal) var(--ease-expo) both,
-    intel-pulse 1.2s ease-in-out infinite;
-  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+    intel-enter 0.45s var(--ease-expo) both,
+    intel-pulse 1.1s ease-in-out infinite;
+  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+}
+.intel-picking .intel-avatar {
+  border-color: var(--semantic-win, #18a058);
+  animation: intel-avatar-pulse 1.1s ease-in-out infinite;
 }
 @keyframes intel-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(24, 160, 88, 0.45);
+    box-shadow: 0 0 0 0 rgba(24, 160, 88, 0.18);
   }
   50% {
-    box-shadow: 0 0 0 4px rgba(24, 160, 88, 0.12);
+    box-shadow: 0 0 0 6px rgba(24, 160, 88, 0.18);
   }
 }
-/* 锁定：定格入场（scale + fade），仅播一次 */
+@keyframes intel-avatar-pulse {
+  0%,
+  100% {
+    border-color: var(--semantic-win, #18a058);
+  }
+  50% {
+    border-color: rgba(24, 160, 88, 0.4);
+  }
+}
+
+/* 锁定：定格入场，bounce 过冲 + 一次性 ring 闪光收敛，仅播一次 */
 .intel-locked {
   animation:
-    fade-up var(--dur-normal) var(--ease-expo) both,
-    intel-lock-in var(--dur-normal, 0.25s) var(--ease-expo, ease-out) both;
-  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+    intel-enter 0.45s var(--ease-expo) both,
+    intel-lock-in 0.4s var(--ease-expo) both;
+  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+}
+.intel-locked .intel-avatar {
+  border-color: var(--semantic-win, #18a058);
 }
 @keyframes intel-lock-in {
-  from {
-    transform: scale(0.88);
-    opacity: 0.4;
+  0% {
+    transform: scale(0.82);
+    opacity: 0.3;
+    box-shadow: 0 0 0 3px rgba(24, 160, 88, 0.55);
   }
-  to {
+  55% {
+    transform: scale(1.05);
+    box-shadow: 0 0 0 3px rgba(24, 160, 88, 0.25);
+  }
+  100% {
     transform: scale(1);
     opacity: 1;
+    box-shadow: 0 0 0 0 transparent;
   }
 }
+
 @media (prefers-reduced-motion: reduce) {
   .intel-card,
   .intel-intent,
   .intel-picking,
-  .intel-locked {
+  .intel-locked,
+  .intel-picking .intel-avatar {
     animation: none;
   }
 }

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -83,11 +83,17 @@ watch(
       hints.value = []
       return
     }
+    // 竞态守卫：选人阶段 championId 快速变化时，旧请求晚到不得覆盖新英雄数据
+    const requestChampionId = id
     await loadChampionNames()
+    if (props.championId !== requestChampionId) return
     name.value = getChampionName(id)
-    meta.value = await getChampionMeta(props.mode, id)
+    const fetchedMeta = await getChampionMeta(props.mode, id)
+    if (props.championId !== requestChampionId) return
+    meta.value = fetchedMeta
     if (props.mode === 'ranked' && myIds.length > 0) {
       const counters = await getLaneCounters(props.mode, [id, ...myIds])
+      if (props.championId !== requestChampionId) return
       hints.value = findCounterHints(id, [...myIds], counters)
     } else {
       hints.value = []

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -8,7 +8,7 @@
       <div class="intel-placeholder">
         <span class="intel-placeholder-icon">❓</span>
         <span class="intel-placeholder-text">{{
-          pickState === 'picking' ? '正在选择…' : '尚未选择'
+          pickState === 'picking' ? '正在选择…' : pickState === 'banning' ? '禁用中…' : '尚未选择'
         }}</span>
       </div>
     </template>
@@ -312,6 +312,29 @@ watch(
   }
 }
 
+/* 禁用中：红色粗边框 + 外扩 ring 呼吸（威胁感），类比 intel-picking 但复用
+   --semantic-loss 色系，与「选择中」形成正/负两极的视觉对比 */
+.intel-banning {
+  border: 2px solid var(--semantic-loss, #d03050);
+  background: rgba(208, 48, 80, 0.06);
+  animation:
+    intel-enter 0.45s var(--ease-expo) both,
+    intel-ban-pulse 1.1s ease-in-out infinite;
+  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+}
+.intel-banning .intel-avatar {
+  border-color: var(--semantic-loss, #d03050);
+}
+@keyframes intel-ban-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(208, 48, 80, 0.18);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(208, 48, 80, 0.18);
+  }
+}
+
 /* 锁定：定格入场，bounce 过冲 + 一次性 ring 闪光收敛，仅播一次 */
 .intel-locked {
   animation:
@@ -343,8 +366,10 @@ watch(
   .intel-card,
   .intel-intent,
   .intel-picking,
+  .intel-banning,
   .intel-locked,
-  .intel-picking .intel-avatar {
+  .intel-picking .intel-avatar,
+  .intel-banning .intel-avatar {
     animation: none;
   }
 }

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="intel-card" :class="[pickStateClass(pickState), `intel-${density}`]">
+    <!-- 未亮英雄：占位（picking 态高亮呼吸） -->
+    <template v-if="!championId || championId <= 0">
+      <div class="intel-placeholder">
+        <span class="intel-placeholder-icon">❓</span>
+        <span class="intel-placeholder-text">{{
+          pickState === 'picking' ? '正在选择…' : '尚未选择'
+        }}</span>
+      </div>
+    </template>
+    <template v-else>
+      <img class="intel-avatar" :src="getChampionUrl(championId)" :alt="name" />
+      <div class="intel-body">
+        <div class="intel-row">
+          <span class="intel-name">{{ name }}</span>
+          <span v-if="badge.label" class="intel-tier" :style="{ color: badge.color }">{{
+            badge.label
+          }}</span>
+          <span class="intel-winrate">{{ formatWinRate(meta?.winRate) }}</span>
+        </div>
+        <div class="intel-row intel-sub">
+          <span v-if="pickState === 'intent'" class="intel-state-tag">意向</span>
+          <span v-else-if="pickState === 'picking'" class="intel-state-tag">选择中</span>
+          <span
+            v-for="h in hints"
+            :key="h.myChampionId"
+            class="intel-counter"
+            :class="h.myWinRate >= 0.5 ? 'intel-counter-good' : 'intel-counter-bad'"
+          >
+            {{ counterText(h) }}
+          </span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * 选人阶段英雄情报卡：无玩家身份时替代 PlayerCard。
+ * 展示英雄头像/名字 + OP.GG T级/胜率 + 对我方阵容的克制提示，
+ * pick-state 驱动三态动画（intent 呼吸 / picking 边框脉冲 / locked 定格入场）。
+ */
+import { computed, ref, watch } from 'vue'
+import { useAssetUrl } from '@renderer/composables/useAssetUrl'
+import { getChampionName, loadChampionNames } from '@renderer/services/ai/champion-names'
+import { getChampionMeta, getLaneCounters, findCounterHints } from '@renderer/services/opgg'
+import type { ChampionMeta, CounterHint, OpggMode } from '@renderer/services/opgg'
+import { pickStateClass, tierBadge, formatWinRate } from './championIntel'
+
+const props = withDefaults(
+  defineProps<{
+    championId: number
+    pickState?: string
+    mode: OpggMode
+    /** 我方已亮出的英雄（用于克制提示），可为空数组 */
+    myChampionIds?: number[]
+    density?: 'normal' | 'compact'
+  }>(),
+  { pickState: 'none', myChampionIds: () => [], density: 'normal' }
+)
+
+const { getChampionUrl } = useAssetUrl()
+const name = ref('')
+const meta = ref<ChampionMeta | null>(null)
+const hints = ref<CounterHint[]>([])
+const badge = computed(() => tierBadge(meta.value?.tier ?? 0))
+
+/** 名字辅助：克制提示里显示我方英雄名 */
+function counterText(h: CounterHint): string {
+  const my = getChampionName(h.myChampionId)
+  return h.myWinRate >= 0.5
+    ? `怕你方${my} ${formatWinRate(h.myWinRate)}`
+    : `克制你方${my} ${formatWinRate(1 - h.myWinRate)}`
+}
+
+watch(
+  () => [props.championId, props.myChampionIds] as const,
+  async ([id, myIds]) => {
+    if (!id || id <= 0) {
+      meta.value = null
+      hints.value = []
+      return
+    }
+    await loadChampionNames()
+    name.value = getChampionName(id)
+    meta.value = await getChampionMeta(props.mode, id)
+    if (props.mode === 'ranked' && myIds.length > 0) {
+      const counters = await getLaneCounters(props.mode, [id, ...myIds])
+      hints.value = findCounterHints(id, [...myIds], counters)
+    } else {
+      hints.value = []
+    }
+  },
+  { immediate: true, deep: true }
+)
+</script>
+
+<style scoped>
+.intel-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--n-border-color, rgba(128, 128, 128, 0.2));
+  border-radius: 10px;
+  background: var(--n-color, transparent);
+  min-height: 56px;
+}
+.intel-compact {
+  padding: 6px 8px;
+  min-height: 44px;
+}
+.intel-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+}
+.intel-body {
+  flex: 1;
+  min-width: 0;
+}
+.intel-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.intel-name {
+  font-weight: 600;
+}
+.intel-tier {
+  font-weight: 700;
+  font-size: 12px;
+}
+.intel-winrate {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+.intel-sub {
+  margin-top: 2px;
+  font-size: 12px;
+  opacity: 0.8;
+}
+.intel-state-tag {
+  opacity: 0.7;
+}
+.intel-counter-good {
+  color: var(--semantic-win, #18a058);
+}
+.intel-counter-bad {
+  color: var(--semantic-loss, #d03050);
+}
+.intel-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0.55;
+}
+
+/* ---- 三态动画 ---- */
+/* 意向：亮出未锁 → 半透明 + 呼吸 */
+.intel-intent {
+  opacity: 0.8;
+  animation: intel-breathe 2s ease-in-out infinite;
+}
+@keyframes intel-breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    box-shadow: 0 0 10px 1px rgba(99, 226, 183, 0.35);
+  }
+}
+/* 正在选：边框脉冲高亮 */
+.intel-picking {
+  border-color: var(--semantic-win, #18a058);
+  animation: intel-pulse 1.2s ease-in-out infinite;
+}
+@keyframes intel-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(24, 160, 88, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(24, 160, 88, 0.12);
+  }
+}
+/* 锁定：定格入场（scale + fade），仅播一次 */
+.intel-locked {
+  animation: intel-lock-in var(--dur-normal, 0.25s) var(--ease-expo, ease-out) both;
+}
+@keyframes intel-lock-in {
+  from {
+    transform: scale(0.88);
+    opacity: 0.4;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .intel-intent,
+  .intel-picking,
+  .intel-locked {
+    animation: none;
+  }
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -147,8 +147,8 @@ watch(
   background: var(--n-color, transparent);
   min-height: 56px;
   /* 入场：自有 intel-enter keyframe，比全局 fade-up 更大幅度（+scale）更易察觉 */
-  animation: intel-enter 0.45s var(--ease-expo) both;
-  animation-delay: calc(90ms * var(--stagger-i, 0));
+  animation: intel-enter 0.32s var(--ease-expo) both;
+  animation-delay: calc(55ms * var(--stagger-i, 0));
 }
 .intel-compact {
   padding: 6px 8px;
@@ -249,7 +249,7 @@ watch(
 @keyframes intel-enter {
   from {
     opacity: 0;
-    transform: translateY(14px) scale(0.95);
+    transform: translateY(8px) scale(0.975);
   }
   to {
     opacity: 1;
@@ -261,9 +261,9 @@ watch(
 .intel-intent {
   border-color: rgba(230, 193, 90, 0.55);
   animation:
-    intel-enter 0.45s var(--ease-expo) both,
+    intel-enter 0.32s var(--ease-expo) both,
     intel-breathe 2s ease-in-out infinite;
-  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+  animation-delay: calc(55ms * var(--stagger-i, 0)), 0s;
 }
 .intel-intent .intel-avatar {
   border-color: rgba(230, 193, 90, 0.7);
@@ -271,12 +271,12 @@ watch(
 @keyframes intel-breathe {
   0%,
   100% {
-    opacity: 0.7;
+    opacity: 0.82;
     box-shadow: 0 0 0 0 transparent;
   }
   50% {
     opacity: 1;
-    box-shadow: 0 0 14px 2px rgba(230, 193, 90, 0.45);
+    box-shadow: 0 0 9px 1px rgba(230, 193, 90, 0.22);
   }
 }
 
@@ -285,9 +285,9 @@ watch(
   border: 2px solid var(--semantic-win, #18a058);
   background: rgba(24, 160, 88, 0.06);
   animation:
-    intel-enter 0.45s var(--ease-expo) both,
+    intel-enter 0.32s var(--ease-expo) both,
     intel-pulse 1.1s ease-in-out infinite;
-  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+  animation-delay: calc(55ms * var(--stagger-i, 0)), 0s;
 }
 .intel-picking .intel-avatar {
   border-color: var(--semantic-win, #18a058);
@@ -296,10 +296,10 @@ watch(
 @keyframes intel-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(24, 160, 88, 0.18);
+    box-shadow: 0 0 0 0 rgba(24, 160, 88, 0.1);
   }
   50% {
-    box-shadow: 0 0 0 6px rgba(24, 160, 88, 0.18);
+    box-shadow: 0 0 0 3px rgba(24, 160, 88, 0.1);
   }
 }
 @keyframes intel-avatar-pulse {
@@ -308,7 +308,7 @@ watch(
     border-color: var(--semantic-win, #18a058);
   }
   50% {
-    border-color: rgba(24, 160, 88, 0.4);
+    border-color: rgba(24, 160, 88, 0.7);
   }
 }
 
@@ -318,9 +318,9 @@ watch(
   border: 2px solid var(--semantic-loss, #d03050);
   background: rgba(208, 48, 80, 0.06);
   animation:
-    intel-enter 0.45s var(--ease-expo) both,
+    intel-enter 0.32s var(--ease-expo) both,
     intel-ban-pulse 1.1s ease-in-out infinite;
-  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+  animation-delay: calc(55ms * var(--stagger-i, 0)), 0s;
 }
 .intel-banning .intel-avatar {
   border-color: var(--semantic-loss, #d03050);
@@ -328,32 +328,32 @@ watch(
 @keyframes intel-ban-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(208, 48, 80, 0.18);
+    box-shadow: 0 0 0 0 rgba(208, 48, 80, 0.1);
   }
   50% {
-    box-shadow: 0 0 0 6px rgba(208, 48, 80, 0.18);
+    box-shadow: 0 0 0 3px rgba(208, 48, 80, 0.1);
   }
 }
 
 /* 锁定：定格入场，bounce 过冲 + 一次性 ring 闪光收敛，仅播一次 */
 .intel-locked {
   animation:
-    intel-enter 0.45s var(--ease-expo) both,
-    intel-lock-in 0.4s var(--ease-expo) both;
-  animation-delay: calc(90ms * var(--stagger-i, 0)), 0s;
+    intel-enter 0.32s var(--ease-expo) both,
+    intel-lock-in 0.28s var(--ease-expo) both;
+  animation-delay: calc(55ms * var(--stagger-i, 0)), 0s;
 }
 .intel-locked .intel-avatar {
   border-color: var(--semantic-win, #18a058);
 }
 @keyframes intel-lock-in {
   0% {
-    transform: scale(0.82);
-    opacity: 0.3;
-    box-shadow: 0 0 0 3px rgba(24, 160, 88, 0.55);
+    transform: scale(0.92);
+    opacity: 0.6;
+    box-shadow: 0 0 0 2px rgba(24, 160, 88, 0.28);
   }
   55% {
-    transform: scale(1.05);
-    box-shadow: 0 0 0 3px rgba(24, 160, 88, 0.25);
+    transform: scale(1.015);
+    box-shadow: 0 0 0 2px rgba(24, 160, 88, 0.12);
   }
   100% {
     transform: scale(1);

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -1,7 +1,12 @@
 <template>
   <div
     class="intel-card"
-    :class="[pickStateClass(pickState), `intel-${density}`, isEmpty && 'intel-empty']"
+    :class="[
+      pickStateClass(pickState),
+      `intel-${density}`,
+      isEmpty && 'intel-empty',
+      justSwapped && 'intel-swapped'
+    ]"
   >
     <!-- 未亮英雄：占位（虚线边框 + 居中提示，picking 态同样吃 intel-picking 动画） -->
     <template v-if="isEmpty">
@@ -50,12 +55,12 @@
  * 展示英雄头像/名字 + OP.GG T级/胜率 + 对我方阵容的克制提示，
  * pick-state 驱动三态动画（intent 呼吸 / picking 边框脉冲 / locked 定格入场）。
  */
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useAssetUrl } from '@renderer/composables/useAssetUrl'
 import { getChampionName, loadChampionNames } from '@renderer/services/ai/champion-names'
 import { getChampionMeta, getLaneCounters, findCounterHints } from '@renderer/services/opgg'
 import type { ChampionMeta, CounterHint, OpggMode } from '@renderer/services/opgg'
-import { pickStateClass, tierBadge, formatWinRate } from './championIntel'
+import { pickStateClass, tierBadge, formatWinRate, isChampionSwap } from './championIntel'
 
 const props = withDefaults(
   defineProps<{
@@ -94,6 +99,29 @@ function counterText(h: CounterHint): string {
 }
 
 /**
+ * 换人一次性闪烁反馈：旧值>0 且新值>0 且不等（真换人，非首次亮出）时点亮 `intel-swapped`，
+ * ~600ms 后自动移除。触发时先归零一帧（nextTick）再点亮，保证连续快速换人也能重播动画。
+ */
+const justSwapped = ref(false)
+let swapFlashTimer: ReturnType<typeof setTimeout> | null = null
+
+function triggerSwapFlash(): void {
+  if (swapFlashTimer) clearTimeout(swapFlashTimer)
+  justSwapped.value = false
+  void nextTick(() => {
+    justSwapped.value = true
+    swapFlashTimer = setTimeout(() => {
+      justSwapped.value = false
+      swapFlashTimer = null
+    }, 600)
+  })
+}
+
+onUnmounted(() => {
+  if (swapFlashTimer) clearTimeout(swapFlashTimer)
+})
+
+/**
  * 上一次实际发起处理的请求标识（championId + myChampionIds 内容拼接）。
  * Gaming.vue 的 computed 每次会话事件都会重新生成 myChampionIds 数组，
  * 引用必变但内容常不变；watch 用 `[championId, myChampionIds]` 数组做浅比较
@@ -103,7 +131,11 @@ let lastRequestKey = ''
 
 watch(
   () => [props.championId, props.myChampionIds] as const,
-  async ([id, myIds]) => {
+  async ([id, myIds], oldSource) => {
+    // 真换人检测：与请求去重 key 无关，仅比较 championId 本身（oldSource 首次触发为 undefined）
+    if (isChampionSwap(oldSource?.[0], id)) {
+      triggerSwapFlash()
+    }
     // 内容级去重：id 与 myIds 拼接后的 key 未变化，说明本次触发只是引用抖动，直接跳过
     const requestKey = `${id}|${myIds.join(',')}`
     if (requestKey === lastRequestKey) return
@@ -362,6 +394,27 @@ watch(
   }
 }
 
+/* 换人闪烁：一次性反馈，动画只落在头像元素上（用卡片级 .intel-swapped 修饰类做触发开关），
+ * 不往 .intel-card 的入场/三态逗号动画列表里加第三项，避免破坏既有组合规则。
+ */
+.intel-card.intel-swapped .intel-avatar {
+  animation: intel-swap-flash 0.5s ease-out;
+}
+@keyframes intel-swap-flash {
+  0% {
+    filter: brightness(1);
+    box-shadow: 0 0 0 0 transparent;
+  }
+  40% {
+    filter: brightness(1.6);
+    box-shadow: 0 0 10px 2px rgba(230, 193, 90, 0.55);
+  }
+  100% {
+    filter: brightness(1);
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .intel-card,
   .intel-intent,
@@ -369,7 +422,8 @@ watch(
   .intel-banning,
   .intel-locked,
   .intel-picking .intel-avatar,
-  .intel-banning .intel-avatar {
+  .intel-banning .intel-avatar,
+  .intel-card.intel-swapped .intel-avatar {
     animation: none;
   }
 }

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -75,25 +75,39 @@ function counterText(h: CounterHint): string {
     : `克制你方${my} ${formatWinRate(1 - h.myWinRate)}`
 }
 
+/**
+ * 上一次实际发起处理的请求标识（championId + myChampionIds 内容拼接）。
+ * Gaming.vue 的 computed 每次会话事件都会重新生成 myChampionIds 数组，
+ * 引用必变但内容常不变；watch 用 `[championId, myChampionIds]` 数组做浅比较
+ * 必然每次触发。这里做内容级去重：内容不变则整个回调直接跳过，避免每事件重拉。
+ */
+let lastRequestKey = ''
+
 watch(
   () => [props.championId, props.myChampionIds] as const,
   async ([id, myIds]) => {
+    // 内容级去重：id 与 myIds 拼接后的 key 未变化，说明本次触发只是引用抖动，直接跳过
+    const requestKey = `${id}|${myIds.join(',')}`
+    if (requestKey === lastRequestKey) return
+    lastRequestKey = requestKey
+
     if (!id || id <= 0) {
       meta.value = null
       hints.value = []
       return
     }
-    // 竞态守卫：选人阶段 championId 快速变化时，旧请求晚到不得覆盖新英雄数据
-    const requestChampionId = id
+    // 竞态守卫：选人阶段 championId/myChampionIds 快速变化时，旧请求晚到不得覆盖新数据。
+    // 用 requestKey 而非单独的 championId 比较，可同时覆盖"同英雄但我方阵容变化"的窄竞态。
+    const requestKeySnapshot = requestKey
     await loadChampionNames()
-    if (props.championId !== requestChampionId) return
+    if (lastRequestKey !== requestKeySnapshot) return
     name.value = getChampionName(id)
     const fetchedMeta = await getChampionMeta(props.mode, id)
-    if (props.championId !== requestChampionId) return
+    if (lastRequestKey !== requestKeySnapshot) return
     meta.value = fetchedMeta
     if (props.mode === 'ranked' && myIds.length > 0) {
       const counters = await getLaneCounters(props.mode, [id, ...myIds])
-      if (props.championId !== requestChampionId) return
+      if (lastRequestKey !== requestKeySnapshot) return
       hints.value = findCounterHints(id, [...myIds], counters)
     } else {
       hints.value = []
@@ -113,6 +127,9 @@ watch(
   border-radius: 10px;
   background: var(--n-color, transparent);
   min-height: 56px;
+  /* 入场：复用全局 fade-up + 错位 stagger（对齐 PlayerCard 入场节奏） */
+  animation: fade-up var(--dur-normal) var(--ease-expo) both;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0));
 }
 .intel-compact {
   padding: 6px 8px;
@@ -165,11 +182,18 @@ watch(
   opacity: 0.55;
 }
 
-/* ---- 三态动画 ---- */
+/* ---- 三态动画 ----
+ * 三态各自的 animation 简写会整体覆盖 .intel-card 上的入场 fade-up（同选择器
+ * 特异性下后声明的规则整体替换而非合并），所以这里都显式把 fade-up 复合进去，
+ * 用逗号分隔的第二个动画承载各态自身效果，animation-delay 也按位置一一对应。
+ */
 /* 意向：亮出未锁 → 半透明 + 呼吸 */
 .intel-intent {
   opacity: 0.8;
-  animation: intel-breathe 2s ease-in-out infinite;
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    intel-breathe 2s ease-in-out infinite;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
 }
 @keyframes intel-breathe {
   0%,
@@ -183,7 +207,10 @@ watch(
 /* 正在选：边框脉冲高亮 */
 .intel-picking {
   border-color: var(--semantic-win, #18a058);
-  animation: intel-pulse 1.2s ease-in-out infinite;
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    intel-pulse 1.2s ease-in-out infinite;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
 }
 @keyframes intel-pulse {
   0%,
@@ -196,7 +223,10 @@ watch(
 }
 /* 锁定：定格入场（scale + fade），仅播一次 */
 .intel-locked {
-  animation: intel-lock-in var(--dur-normal, 0.25s) var(--ease-expo, ease-out) both;
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    intel-lock-in var(--dur-normal, 0.25s) var(--ease-expo, ease-out) both;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
 }
 @keyframes intel-lock-in {
   from {
@@ -209,6 +239,7 @@ watch(
   }
 }
 @media (prefers-reduced-motion: reduce) {
+  .intel-card,
   .intel-intent,
   .intel-picking,
   .intel-locked {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -8,7 +8,8 @@
       props.team === 'mine' && 'player-card-team-mine',
       props.team === 'enemy' && 'player-card-team-enemy',
       `player-card-density-${props.density}`,
-      pickStateClassName
+      pickStateClassName,
+      justSwapped && 'pc-swapped'
     ]"
     size="small"
     :bordered="true"
@@ -181,7 +182,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, toRef, watch } from 'vue'
 import { NCard, NFlex, NAvatar, NImage, NButton, NIcon, NEllipsis, NPopover, NTag } from 'naive-ui'
 import { CopyOutline, HelpCircleOutline } from '@vicons/ionicons5'
 import MettingPlayersCard from './MettingPlayersCard.vue'
@@ -199,7 +200,7 @@ import LazyImg from '@renderer/components/common/LazyImg.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
 import { getChampionMeta, type ChampionMeta, type OpggMode } from '@renderer/services/opgg'
-import { tierBadge, formatWinRate, playerCardPickStateClass } from './championIntel'
+import { tierBadge, formatWinRate, playerCardPickStateClass, isChampionSwap } from './championIntel'
 
 interface Props {
   sessionSummoner: SessionSummoner
@@ -235,6 +236,40 @@ const cardContentStyle = 'padding: var(--space-4);'
 
 /** pickState → 根元素修饰类，驱动选人四态动画（意向/选择中/禁用中/已锁定） */
 const pickStateClassName = computed(() => playerCardPickStateClass(props.pickState))
+
+/**
+ * 换人一次性闪烁反馈：仅当已锁定（pickState === 'locked'）后 championId 仍发生真实变化
+ * （对应选人阶段锁定后的英雄交换 trade）时点亮 `pc-swapped`，~600ms 后自动移除。
+ * 未锁定期换意向是常态，不触发；机制与 ChampionIntelCard 同款（先归零一帧再点亮，保证连续
+ * 快速换人也能重播动画）。
+ */
+const justSwapped = ref(false)
+let swapFlashTimer: ReturnType<typeof setTimeout> | null = null
+
+function triggerSwapFlash(): void {
+  if (swapFlashTimer) clearTimeout(swapFlashTimer)
+  justSwapped.value = false
+  void nextTick(() => {
+    justSwapped.value = true
+    swapFlashTimer = setTimeout(() => {
+      justSwapped.value = false
+      swapFlashTimer = null
+    }, 600)
+  })
+}
+
+onUnmounted(() => {
+  if (swapFlashTimer) clearTimeout(swapFlashTimer)
+})
+
+watch(
+  () => props.sessionSummoner.championId,
+  (id, oldId) => {
+    if (props.pickState === 'locked' && isChampionSwap(oldId, id)) {
+      triggerSwapFlash()
+    }
+  }
+)
 
 const settingsStore = useSettingsStore()
 const { isDark } = useTheme()
@@ -706,11 +741,30 @@ watch(
   filter: saturate(80%);
 }
 
+/* 换人闪烁：一次性反馈，动画只落在头像元素上（同 ChampionIntelCard 的 intel-swapped 机制），
+ * 不往 .player-card 的 fade-up/四态逗号动画列表里加第三项，避免破坏既有组合规则。
+ */
+.player-card.pc-swapped .champion-img {
+  animation: pc-swap-flash 0.5s ease-out;
+}
+@keyframes pc-swap-flash {
+  0% {
+    filter: brightness(1);
+  }
+  40% {
+    filter: brightness(1.6);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .player-card.pc-intent,
   .player-card.pc-picking,
   .player-card.pc-banning,
-  .player-card.pc-locked {
+  .player-card.pc-locked,
+  .player-card.pc-swapped .champion-img {
     animation: none;
   }
 }

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -7,7 +7,8 @@
       props.team === 'red' && 'player-card-team-red',
       props.team === 'mine' && 'player-card-team-mine',
       props.team === 'enemy' && 'player-card-team-enemy',
-      `player-card-density-${props.density}`
+      `player-card-density-${props.density}`,
+      pickStateClassName
     ]"
     size="small"
     :bordered="true"
@@ -198,7 +199,7 @@ import LazyImg from '@renderer/components/common/LazyImg.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
 import { getChampionMeta, type ChampionMeta, type OpggMode } from '@renderer/services/opgg'
-import { tierBadge, formatWinRate } from './championIntel'
+import { tierBadge, formatWinRate, playerCardPickStateClass } from './championIntel'
 
 interface Props {
   sessionSummoner: SessionSummoner
@@ -215,12 +216,25 @@ interface Props {
    * 完全不发起请求、也不渲染 chip。
    */
   opggMode?: OpggMode
+  /**
+   * 选人态：'none'/'intent'/'picking'/'banning'/'locked'/''。
+   * 仅由 SubteamCard 在 ChampSelect 阶段传入我方玩家的实时选人态，驱动四态动画；
+   * 非选人期（对局中等）恒为空，PlayerCard 不带任何选人态修饰。
+   */
+  pickState?: string
 }
 
-const props = withDefaults(defineProps<Props>(), { team: undefined, density: 'normal' })
+const props = withDefaults(defineProps<Props>(), {
+  team: undefined,
+  density: 'normal',
+  pickState: ''
+})
 
 /** n-card content-style：用 token 控制内边距（P0 收紧为 --space-4 让 4 场 1 屏装下） */
 const cardContentStyle = 'padding: var(--space-4);'
+
+/** pickState → 根元素修饰类，驱动选人四态动画（意向/选择中/禁用中/已锁定） */
+const pickStateClassName = computed(() => playerCardPickStateClass(props.pickState))
 
 const settingsStore = useSettingsStore()
 const { isDark } = useTheme()
@@ -596,5 +610,108 @@ watch(
 
 .player-card-density-compact .info-wrapper :deep(.n-button) {
   font-size: var(--font-size-sm);
+}
+
+/* ---- 选人四态动画（同 ChampionIntelCard 的视觉语言：琥珀呼吸/绿脉冲/红脉冲/锁定过冲）----
+ * PlayerCard 比情报卡内容重得多，直接照搬 box-shadow ring 会撞上 .player-card 已有的
+ * `box-shadow: ... !important`（CSS 优先级里 author !important 高于 CSS 动画，动画对它
+ * 无效）。这里改用 filter: drop-shadow 做发光（不受该 !important 影响，且天然贴合圆角），
+ * 边框色/宽度走静态声明——靠复合选择器 `.player-card.pc-xxx` 的更高特异度 + 同为
+ * !important 正常参与层叠，无需动画介入。逗号组合规则同情报卡：fade-up 恒第一位，
+ * 状态动画第二位，delay 列表对应（stagger 延迟, 0s）。
+ */
+.player-card.pc-intent {
+  border-width: 1px !important;
+  border-color: rgba(230, 193, 90, 0.55) !important;
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    pc-breathe 2s ease-in-out infinite;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+}
+@keyframes pc-breathe {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 0 transparent);
+  }
+  50% {
+    filter: drop-shadow(0 0 10px rgba(230, 193, 90, 0.45));
+  }
+}
+
+.player-card.pc-picking {
+  border-width: 2px !important;
+  border-color: var(--semantic-win) !important;
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    pc-pulse 1.1s ease-in-out infinite;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+}
+@keyframes pc-pulse {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 0 rgba(34, 197, 94, 0));
+  }
+  50% {
+    filter: drop-shadow(0 0 8px rgba(34, 197, 94, 0.5));
+  }
+}
+
+.player-card.pc-banning {
+  border-width: 2px !important;
+  border-color: var(--semantic-loss) !important;
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    pc-ban-pulse 1.1s ease-in-out infinite;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+}
+@keyframes pc-ban-pulse {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 0 rgba(239, 68, 68, 0));
+  }
+  50% {
+    filter: drop-shadow(0 0 8px rgba(239, 68, 68, 0.5));
+  }
+}
+
+/* 锁定：一次性 ring 闪光 + 轻微 scale 过冲，比情报卡的 0.82→1.05→1 收敛很多——
+   PlayerCard 尺寸大，同等幅度的 scale 在真实布局里观感是"晃"而非"确认感" */
+.player-card.pc-locked {
+  animation:
+    fade-up var(--dur-normal) var(--ease-expo) both,
+    pc-lock-in 0.4s var(--ease-expo) both;
+  animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
+}
+@keyframes pc-lock-in {
+  0% {
+    transform: scale(0.98);
+    filter: drop-shadow(0 0 6px rgba(34, 197, 94, 0.55));
+  }
+  60% {
+    transform: scale(1.02);
+    filter: drop-shadow(0 0 3px rgba(34, 197, 94, 0.3));
+  }
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0 transparent);
+  }
+}
+
+/* 选人期未锁定（意向/选择中/禁用中）：头像半透明+降饱和，表达"还没定"；
+   locked 与非选人期（无 pc-* 类）保持头像正常展示 */
+.player-card.pc-intent .champion-img,
+.player-card.pc-picking .champion-img,
+.player-card.pc-banning .champion-img {
+  opacity: 0.55;
+  filter: saturate(70%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .player-card.pc-intent,
+  .player-card.pc-picking,
+  .player-card.pc-banning,
+  .player-card.pc-locked {
+    animation: none;
+  }
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -99,6 +99,18 @@
                   <LazyImg v-else class="tier-icon" :src="imgUrl" alt="tier" />
                   <span class="tier-text">{{ tierCn }}</span>
                 </n-flex>
+                <!-- 当前英雄的 OP.GG T 级/胜率 chip：opggMode 未传或无数据时不渲染（无占位） -->
+                <span v-if="opggMeta" class="opgg-chip">
+                  <span
+                    v-if="opggBadge.label"
+                    class="opgg-chip-tier"
+                    :style="{ color: opggBadge.color, backgroundColor: opggBadge.bg }"
+                    >{{ opggBadge.label }}</span
+                  >
+                  <span class="opgg-chip-rate" :class="opggWinRateClass">{{
+                    formatWinRate(opggMeta.winRate)
+                  }}</span>
+                </span>
                 <!-- ARAM Balance Status -->
                 <n-popover
                   v-if="balanceTags.length > 0 && isAramMode"
@@ -168,7 +180,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { NCard, NFlex, NAvatar, NImage, NButton, NIcon, NEllipsis, NPopover, NTag } from 'naive-ui'
 import { CopyOutline, HelpCircleOutline } from '@vicons/ionicons5'
 import MettingPlayersCard from './MettingPlayersCard.vue'
@@ -185,6 +197,8 @@ import PlayerStatsCard from './PlayerStatsCard.vue'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
+import { getChampionMeta, type ChampionMeta, type OpggMode } from '@renderer/services/opgg'
+import { tierBadge, formatWinRate } from './championIntel'
 
 interface Props {
   sessionSummoner: SessionSummoner
@@ -195,6 +209,12 @@ interface Props {
   queueId: number
   team?: 'blue' | 'red' | 'mine' | 'enemy' | undefined
   density?: 'normal' | 'compact'
+  /**
+   * OP.GG 数据模式：驱动当前英雄 T 级/胜率 chip。
+   * PlayerCard 目前仅被 SubteamCard（对局页）复用，未传（如未来被非对局场景复用）时
+   * 完全不发起请求、也不渲染 chip。
+   */
+  opggMode?: OpggMode
 }
 
 const props = withDefaults(defineProps<Props>(), { team: undefined, density: 'normal' })
@@ -217,6 +237,44 @@ const isHiddenRecord = computed(
 const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   toRef(() => props.sessionSummoner.championId),
   toRef(() => props.queueId)
+)
+
+/** 当前英雄的 OP.GG 元数据（T 级/胜率），驱动 chip；championId<=0 或 opggMode 未传时保持 null */
+const opggMeta = ref<ChampionMeta | null>(null)
+const opggBadge = computed(() => tierBadge(opggMeta.value?.tier ?? 0))
+/** 胜率语义色：>=52% 绿、<=48% 红，与 ChampionIntelCard 同一套规则 */
+const opggWinRateClass = computed(() => {
+  const rate = opggMeta.value?.winRate
+  if (rate === undefined || rate <= 0) return ''
+  if (rate >= 0.52) return 'opgg-chip-rate-good'
+  if (rate <= 0.48) return 'opgg-chip-rate-bad'
+  return ''
+})
+
+/**
+ * 上一次实际发起处理的请求标识（championId + opggMode 拼接）。
+ * 与 ChampionIntelCard 同款内容级请求守卫：key 未变则跳过，避免同局内每次会话事件重拉。
+ */
+let lastOpggRequestKey = ''
+
+watch(
+  () => [props.sessionSummoner.championId, props.opggMode] as const,
+  async ([championId, mode]) => {
+    const requestKey = `${championId}|${mode ?? ''}`
+    if (requestKey === lastOpggRequestKey) return
+    lastOpggRequestKey = requestKey
+
+    if (!mode || !championId || championId <= 0) {
+      opggMeta.value = null
+      return
+    }
+    // 竞态守卫：旧请求晚到不得覆盖新数据（英雄/模式快速切换场景）
+    const requestKeySnapshot = requestKey
+    const fetchedMeta = await getChampionMeta(mode, championId)
+    if (lastOpggRequestKey !== requestKeySnapshot) return
+    opggMeta.value = fetchedMeta
+  },
+  { immediate: true }
 )
 </script>
 
@@ -294,6 +352,42 @@ const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
 
 .tier-row {
   gap: var(--space-4);
+}
+
+/* 当前英雄 OP.GG T 级/胜率 chip：样式简化版复用 ChampionIntelCard 的 intel-tier/intel-winrate 语义 */
+.opgg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-2xs);
+  padding: 0 var(--space-6);
+  height: 18px;
+  line-height: 18px;
+  border-radius: 999px;
+  background: rgba(128, 128, 128, 0.12);
+}
+
+.opgg-chip-tier {
+  font-weight: 700;
+  padding: 0 4px;
+  border-radius: 999px;
+}
+
+.opgg-chip-rate {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+.opgg-chip-rate-good {
+  color: var(--semantic-win);
+  opacity: 1;
+  font-weight: 600;
+}
+
+.opgg-chip-rate-bad {
+  color: var(--semantic-loss);
+  opacity: 1;
+  font-weight: 600;
 }
 
 .balance-tag {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -634,7 +634,7 @@ watch(
     filter: drop-shadow(0 0 0 transparent);
   }
   50% {
-    filter: drop-shadow(0 0 10px rgba(230, 193, 90, 0.45));
+    filter: drop-shadow(0 0 6px rgba(230, 193, 90, 0.22));
   }
 }
 
@@ -652,7 +652,7 @@ watch(
     filter: drop-shadow(0 0 0 rgba(34, 197, 94, 0));
   }
   50% {
-    filter: drop-shadow(0 0 8px rgba(34, 197, 94, 0.5));
+    filter: drop-shadow(0 0 5px rgba(34, 197, 94, 0.25));
   }
 }
 
@@ -670,7 +670,7 @@ watch(
     filter: drop-shadow(0 0 0 rgba(239, 68, 68, 0));
   }
   50% {
-    filter: drop-shadow(0 0 8px rgba(239, 68, 68, 0.5));
+    filter: drop-shadow(0 0 5px rgba(239, 68, 68, 0.25));
   }
 }
 
@@ -679,17 +679,17 @@ watch(
 .player-card.pc-locked {
   animation:
     fade-up var(--dur-normal) var(--ease-expo) both,
-    pc-lock-in 0.4s var(--ease-expo) both;
+    pc-lock-in 0.28s var(--ease-expo) both;
   animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
 }
 @keyframes pc-lock-in {
   0% {
-    transform: scale(0.98);
-    filter: drop-shadow(0 0 6px rgba(34, 197, 94, 0.55));
+    transform: scale(0.99);
+    filter: drop-shadow(0 0 6px rgba(34, 197, 94, 0.28));
   }
   60% {
-    transform: scale(1.02);
-    filter: drop-shadow(0 0 3px rgba(34, 197, 94, 0.3));
+    transform: scale(1.008);
+    filter: drop-shadow(0 0 3px rgba(34, 197, 94, 0.14));
   }
   100% {
     transform: scale(1);
@@ -702,8 +702,8 @@ watch(
 .player-card.pc-intent .champion-img,
 .player-card.pc-picking .champion-img,
 .player-card.pc-banning .champion-img {
-  opacity: 0.55;
-  filter: saturate(70%);
+  opacity: 0.7;
+  filter: saturate(80%);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="subteam-card" :class="{ 'subteam-card-mine': isMine }">
+  <!-- 我方标识只保留头部「我方」tag——外层绿框/发光按用户反馈移除，降低视觉噪音 -->
+  <div class="subteam-card">
     <div class="subteam-card-header">
       <span class="subteam-card-title">队伍 {{ subteam.subteamId }}</span>
       <n-tag v-if="isMine" size="small" type="success" :bordered="false">我方</n-tag>
@@ -97,12 +98,6 @@ const placeholderCount = computed(() =>
   min-height: 0;
   height: 100%;
   box-sizing: border-box;
-}
-
-.subteam-card-mine {
-  border-color: var(--semantic-win);
-  /* tinted ring：保持 rgba 以与卡片 token 颜色一致的发光感，复用全局 --glow-win 风格 */
-  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.3);
 }
 
 .subteam-card-header {

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -28,6 +28,7 @@
           :tier-cn="tiersBySubteam[subteam.subteamId]?.[i]?.tierCn ?? '无'"
           :team="isMine ? 'mine' : 'enemy'"
           :density="density"
+          :opgg-mode="opggMode"
           :style="{ '--stagger-i': i }"
         />
       </template>

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -7,7 +7,7 @@
     <div class="subteam-card-body">
       <template
         v-for="(p, i) of subteam.players"
-        :key="`subteam-${subteam.subteamId}-${i}-${p.summoner.puuid || p.championId}`"
+        :key="`subteam-${subteam.subteamId}-${i}-${p.summoner.puuid}`"
       >
         <ChampionIntelCard
           v-if="phase === 'ChampSelect' && !p.summoner.puuid"

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -5,20 +5,34 @@
       <n-tag v-if="isMine" size="small" type="success" :bordered="false">我方</n-tag>
     </div>
     <div class="subteam-card-body">
-      <PlayerCard
+      <template
         v-for="(p, i) of subteam.players"
-        :key="`subteam-${subteam.subteamId}-${i}-${p.summoner.puuid}`"
-        :session-summoner="p"
-        :type-cn="typeCn"
-        :mode-type="modeType"
-        :queue-id="queueId"
-        :img-url="tiersBySubteam[subteam.subteamId]?.[i]?.imgUrl ?? ''"
-        :tier-cn="tiersBySubteam[subteam.subteamId]?.[i]?.tierCn ?? '无'"
-        :team="isMine ? 'mine' : 'enemy'"
-        :density="density"
-      />
+        :key="`subteam-${subteam.subteamId}-${i}-${p.summoner.puuid || p.championId}`"
+      >
+        <ChampionIntelCard
+          v-if="phase === 'ChampSelect' && !p.summoner.puuid"
+          :champion-id="p.championId"
+          :pick-state="p.pickState"
+          :mode="opggMode"
+          :my-champion-ids="isMine ? [] : myChampionIds"
+          :density="density"
+          :style="{ '--stagger-i': i }"
+        />
+        <PlayerCard
+          v-else
+          :session-summoner="p"
+          :type-cn="typeCn"
+          :mode-type="modeType"
+          :queue-id="queueId"
+          :img-url="tiersBySubteam[subteam.subteamId]?.[i]?.imgUrl ?? ''"
+          :tier-cn="tiersBySubteam[subteam.subteamId]?.[i]?.tierCn ?? '无'"
+          :team="isMine ? 'mine' : 'enemy'"
+          :density="density"
+          :style="{ '--stagger-i': i }"
+        />
+      </template>
       <div v-for="i in placeholderCount" :key="`placeholder-${i}`" class="subteam-card-empty">
-        <span>已离开</span>
+        <span>{{ phase === 'ChampSelect' ? '等待选人…' : '已离开' }}</span>
       </div>
     </div>
   </div>
@@ -28,8 +42,10 @@
 import { computed } from 'vue'
 import { NTag } from 'naive-ui'
 import PlayerCard from './PlayerCard.vue'
+import ChampionIntelCard from './ChampionIntelCard.vue'
 import type { Subteam } from '@renderer/types/domain/gaming'
 import type { TierDisplay } from '@renderer/composables/useSessionTiers'
+import type { OpggMode } from '@renderer/services/opgg'
 
 interface Props {
   subteam: Subteam
@@ -40,9 +56,20 @@ interface Props {
   queueId: number
   tiersBySubteam: Record<number, TierDisplay[]>
   density: 'normal' | 'compact'
+  /** 会话阶段（ChampSelect 时启用敌方情报卡渲染 + 空位占位文案） */
+  phase?: string
+  /** OP.GG 数据模式，透传给情报卡 */
+  opggMode?: OpggMode
+  /** 我方已亮出的英雄 id 列表，仅敌方情报卡用于克制提示 */
+  myChampionIds?: number[]
 }
 
-const props = withDefaults(defineProps<Props>(), { density: 'normal' })
+const props = withDefaults(defineProps<Props>(), {
+  density: 'normal',
+  phase: '',
+  opggMode: 'ranked',
+  myChampionIds: () => []
+})
 const placeholderCount = computed(() =>
   Math.max(0, props.expectedSize - props.subteam.players.length)
 )

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -14,7 +14,7 @@
           :champion-id="p.championId"
           :pick-state="p.pickState"
           :mode="opggMode"
-          :my-champion-ids="isMine ? [] : myChampionIds"
+          :my-champion-ids="isMine ? EMPTY_IDS : myChampionIds"
           :density="density"
           :style="{ '--stagger-i': i }"
         />
@@ -46,6 +46,14 @@ import ChampionIntelCard from './ChampionIntelCard.vue'
 import type { Subteam } from '@renderer/types/domain/gaming'
 import type { TierDisplay } from '@renderer/composables/useSessionTiers'
 import type { OpggMode } from '@renderer/services/opgg'
+
+/**
+ * 空英雄 id 列表的稳定引用。
+ * 若在模板里内联 `:my-champion-ids="isMine ? [] : myChampionIds"`，`isMine` 分支每次
+ * 重渲染都会产生一个新的 `[]`，导致 ChampionIntelCard 的 watch 认为数组"变了"而重拉数据。
+ * 提到 setup 顶层，让同一组件实例在整个生命周期内复用同一个空数组引用。
+ */
+const EMPTY_IDS: number[] = []
 
 interface Props {
   subteam: Subteam

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -29,6 +29,7 @@
           :team="isMine ? 'mine' : 'enemy'"
           :density="density"
           :opgg-mode="opggMode"
+          :pick-state="phase === 'ChampSelect' ? p.pickState : ''"
           :style="{ '--stagger-i': i }"
         />
       </template>

--- a/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { pickStateClass, tierBadge, formatWinRate } from '../championIntel'
+
+describe('championIntel helpers', () => {
+  it('pickStateClass 四态映射与兜底', () => {
+    expect(pickStateClass('locked')).toBe('intel-locked')
+    expect(pickStateClass('picking')).toBe('intel-picking')
+    expect(pickStateClass('intent')).toBe('intel-intent')
+    expect(pickStateClass(undefined)).toBe('intel-none')
+    expect(pickStateClass('')).toBe('intel-none')
+  })
+  it('tierBadge 边界', () => {
+    expect(tierBadge(1).label).toBe('T1')
+    expect(tierBadge(0).label).toBe('')
+    expect(tierBadge(5).label).toBe('T5')
+  })
+  it('formatWinRate', () => {
+    expect(formatWinRate(0.5183)).toBe('51.8%')
+    expect(formatWinRate(0)).toBe('--')
+    expect(formatWinRate(undefined)).toBe('--')
+  })
+})

--- a/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { pickStateClass, tierBadge, formatWinRate } from '../championIntel'
+import {
+  pickStateClass,
+  playerCardPickStateClass,
+  tierBadge,
+  formatWinRate
+} from '../championIntel'
 
 describe('championIntel helpers', () => {
   it('pickStateClass 五态映射与兜底', () => {
@@ -9,6 +14,15 @@ describe('championIntel helpers', () => {
     expect(pickStateClass('intent')).toBe('intel-intent')
     expect(pickStateClass(undefined)).toBe('intel-none')
     expect(pickStateClass('')).toBe('intel-none')
+  })
+  it('playerCardPickStateClass 四态映射，none/空/未知值一律不加类', () => {
+    expect(playerCardPickStateClass('intent')).toBe('pc-intent')
+    expect(playerCardPickStateClass('picking')).toBe('pc-picking')
+    expect(playerCardPickStateClass('banning')).toBe('pc-banning')
+    expect(playerCardPickStateClass('locked')).toBe('pc-locked')
+    expect(playerCardPickStateClass('none')).toBe('')
+    expect(playerCardPickStateClass('')).toBe('')
+    expect(playerCardPickStateClass(undefined)).toBe('')
   })
   it('tierBadge 边界', () => {
     expect(tierBadge(1).label).toBe('T1')

--- a/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { pickStateClass, tierBadge, formatWinRate } from '../championIntel'
 
 describe('championIntel helpers', () => {
-  it('pickStateClass 四态映射与兜底', () => {
+  it('pickStateClass 五态映射与兜底', () => {
     expect(pickStateClass('locked')).toBe('intel-locked')
     expect(pickStateClass('picking')).toBe('intel-picking')
+    expect(pickStateClass('banning')).toBe('intel-banning')
     expect(pickStateClass('intent')).toBe('intel-intent')
     expect(pickStateClass(undefined)).toBe('intel-none')
     expect(pickStateClass('')).toBe('intel-none')

--- a/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
@@ -3,7 +3,8 @@ import {
   pickStateClass,
   playerCardPickStateClass,
   tierBadge,
-  formatWinRate
+  formatWinRate,
+  isChampionSwap
 } from '../championIntel'
 
 describe('championIntel helpers', () => {
@@ -38,5 +39,14 @@ describe('championIntel helpers', () => {
     expect(formatWinRate(0.5183)).toBe('51.8%')
     expect(formatWinRate(0)).toBe('--')
     expect(formatWinRate(undefined)).toBe('--')
+  })
+  it('isChampionSwap 仅在新旧 championId 均为正数且不相等时判定为真换人', () => {
+    expect(isChampionSwap(1, 2)).toBe(true)
+    expect(isChampionSwap(1, 1)).toBe(false)
+    expect(isChampionSwap(0, 1)).toBe(false)
+    expect(isChampionSwap(undefined, 1)).toBe(false)
+    expect(isChampionSwap(1, 0)).toBe(false)
+    expect(isChampionSwap(1, undefined)).toBe(false)
+    expect(isChampionSwap(undefined, undefined)).toBe(false)
   })
 })

--- a/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
@@ -14,6 +14,11 @@ describe('championIntel helpers', () => {
     expect(tierBadge(0).label).toBe('')
     expect(tierBadge(5).label).toBe('T5')
   })
+  it('tierBadge 返回 pill chip 背景色，tier 0 时全空', () => {
+    expect(tierBadge(1).bg).toContain('var(--semantic-win)')
+    expect(tierBadge(2).bg).toContain('var(--accent-blue)')
+    expect(tierBadge(0)).toEqual({ label: '', color: '', bg: '' })
+  })
   it('formatWinRate', () => {
     expect(formatWinRate(0.5183)).toBe('51.8%')
     expect(formatWinRate(0)).toBe('--')

--- a/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
@@ -109,6 +109,24 @@ export function tierBadge(tier: number): { label: string; color: string; bg: str
 }
 
 /**
+ * 判断两次 championId 变化是否构成"真正的换人"（trade swap），而非首次亮出/清空。
+ * ChampionIntelCard 与 PlayerCard 共用此判定来决定是否播放一次性换人闪烁动画。
+ * @param oldId - 变化前的 championId
+ * @param newId - 变化后的 championId
+ * @returns 仅当 oldId、newId 均为正数且不相等时为 true（首次从 0/undefined 亮出英雄不算换人）
+ * @example
+ * ```ts
+ * isChampionSwap(0, 1) // false（首次亮出）
+ * isChampionSwap(1, 2) // true（真换人）
+ * isChampionSwap(1, 1) // false（未变化）
+ * isChampionSwap(undefined, 1) // false（初次挂载）
+ * ```
+ */
+export function isChampionSwap(oldId: number | undefined, newId: number | undefined): boolean {
+  return !!oldId && oldId > 0 && !!newId && newId > 0 && oldId !== newId
+}
+
+/**
  * 胜率显示：将 0~1 的小数格式化为百分比字符串
  * @param rate - 胜率（0~1），缺省或 <=0 视为无数据
  * @returns 形如 '51.8%' 的字符串；无数据时返回 '--'

--- a/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
@@ -1,0 +1,73 @@
+/**
+ * ChampionIntelCard 纯逻辑辅助函数
+ *
+ * 与组件渲染解耦，便于单测覆盖 pick-state 分类、T 级徽章语义色、胜率格式化等纯计算。
+ */
+
+/** 选人阶段 pick 态：未选中 / 意向 / 选择中 / 已锁定 */
+export type PickState = 'none' | 'intent' | 'picking' | 'locked'
+
+/**
+ * pick 态 → 卡片修饰类名（驱动 CSS 三态动画）
+ * @param state - pick 态字符串，缺省或未知值一律兜底为 'none'
+ * @returns 'intel-intent' | 'intel-picking' | 'intel-locked' | 'intel-none'
+ * @example
+ * ```ts
+ * pickStateClass('locked') // 'intel-locked'
+ * pickStateClass(undefined) // 'intel-none'
+ * ```
+ */
+export function pickStateClass(state: string | undefined): string {
+  switch (state) {
+    case 'intent':
+      return 'intel-intent'
+    case 'picking':
+      return 'intel-picking'
+    case 'locked':
+      return 'intel-locked'
+    default:
+      return 'intel-none'
+  }
+}
+
+/**
+ * T 级数字 → 徽章文案与语义色 token
+ * @param tier - OP.GG 英雄强度分级（1 最强 ~ 5 最弱，0 表示无数据）
+ * @returns 徽章文案（如 'T1'）与对应 CSS 变量颜色；tier 为 0 时返回空徽章
+ * @example
+ * ```ts
+ * tierBadge(1) // { label: 'T1', color: 'var(--semantic-win)' }
+ * tierBadge(0) // { label: '', color: '' }
+ * ```
+ */
+export function tierBadge(tier: number): { label: string; color: string } {
+  switch (tier) {
+    case 1:
+      return { label: 'T1', color: 'var(--semantic-win)' }
+    case 2:
+      return { label: 'T2', color: 'var(--accent-blue)' }
+    case 3:
+      return { label: 'T3', color: 'var(--text-secondary)' }
+    case 4:
+      return { label: 'T4', color: 'var(--text-tertiary)' }
+    case 5:
+      return { label: 'T5', color: 'var(--text-tertiary)' }
+    default:
+      return { label: '', color: '' }
+  }
+}
+
+/**
+ * 胜率显示：将 0~1 的小数格式化为百分比字符串
+ * @param rate - 胜率（0~1），缺省或 <=0 视为无数据
+ * @returns 形如 '51.8%' 的字符串；无数据时返回 '--'
+ * @example
+ * ```ts
+ * formatWinRate(0.5183) // '51.8%'
+ * formatWinRate(undefined) // '--'
+ * ```
+ */
+export function formatWinRate(rate: number | undefined): string {
+  if (rate === undefined || rate <= 0) return '--'
+  return `${(rate * 100).toFixed(1)}%`
+}

--- a/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
@@ -4,16 +4,17 @@
  * 与组件渲染解耦，便于单测覆盖 pick-state 分类、T 级徽章语义色、胜率格式化等纯计算。
  */
 
-/** 选人阶段 pick 态：未选中 / 意向 / 选择中 / 已锁定 */
-export type PickState = 'none' | 'intent' | 'picking' | 'locked'
+/** 选人阶段 pick 态：未选中 / 意向 / 禁用中 / 选择中 / 已锁定 */
+export type PickState = 'none' | 'intent' | 'banning' | 'picking' | 'locked'
 
 /**
- * pick 态 → 卡片修饰类名（驱动 CSS 三态动画）
+ * pick 态 → 卡片修饰类名（驱动 CSS 多态动画）
  * @param state - pick 态字符串，缺省或未知值一律兜底为 'none'
- * @returns 'intel-intent' | 'intel-picking' | 'intel-locked' | 'intel-none'
+ * @returns 'intel-intent' | 'intel-banning' | 'intel-picking' | 'intel-locked' | 'intel-none'
  * @example
  * ```ts
  * pickStateClass('locked') // 'intel-locked'
+ * pickStateClass('banning') // 'intel-banning'
  * pickStateClass(undefined) // 'intel-none'
  * ```
  */
@@ -21,6 +22,8 @@ export function pickStateClass(state: string | undefined): string {
   switch (state) {
     case 'intent':
       return 'intel-intent'
+    case 'banning':
+      return 'intel-banning'
     case 'picking':
       return 'intel-picking'
     case 'locked':

--- a/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
@@ -34,6 +34,34 @@ export function pickStateClass(state: string | undefined): string {
 }
 
 /**
+ * pick 态 → PlayerCard 修饰类名（我方选人期四态动画）
+ * 与 pickStateClass 的区别：PlayerCard 常驻对局中样式，非选人期（'none'/空/未知值）
+ * 一律不加类，避免对局中卡片被误套选人态视觉。
+ * @param state - pick 态字符串，缺省或未知值统一兜底为无类
+ * @returns 'pc-intent' | 'pc-picking' | 'pc-banning' | 'pc-locked' | ''（无修饰）
+ * @example
+ * ```ts
+ * playerCardPickStateClass('locked') // 'pc-locked'
+ * playerCardPickStateClass('none') // ''
+ * playerCardPickStateClass(undefined) // ''
+ * ```
+ */
+export function playerCardPickStateClass(state: string | undefined): string {
+  switch (state) {
+    case 'intent':
+      return 'pc-intent'
+    case 'picking':
+      return 'pc-picking'
+    case 'banning':
+      return 'pc-banning'
+    case 'locked':
+      return 'pc-locked'
+    default:
+      return ''
+  }
+}
+
+/**
  * T 级数字 → 徽章文案、语义色 token 与背景色（pill chip 用）
  * @param tier - OP.GG 英雄强度分级（1 最强 ~ 5 最弱，0 表示无数据）
  * @returns 徽章文案（如 'T1'）、CSS 变量颜色、对应色 15% 透明度背景；tier 为 0 时全空

--- a/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
@@ -31,29 +31,49 @@ export function pickStateClass(state: string | undefined): string {
 }
 
 /**
- * T 级数字 → 徽章文案与语义色 token
+ * T 级数字 → 徽章文案、语义色 token 与背景色（pill chip 用）
  * @param tier - OP.GG 英雄强度分级（1 最强 ~ 5 最弱，0 表示无数据）
- * @returns 徽章文案（如 'T1'）与对应 CSS 变量颜色；tier 为 0 时返回空徽章
+ * @returns 徽章文案（如 'T1'）、CSS 变量颜色、对应色 15% 透明度背景；tier 为 0 时全空
  * @example
  * ```ts
- * tierBadge(1) // { label: 'T1', color: 'var(--semantic-win)' }
- * tierBadge(0) // { label: '', color: '' }
+ * tierBadge(1) // { label: 'T1', color: 'var(--semantic-win)', bg: 'color-mix(...)' }
+ * tierBadge(0) // { label: '', color: '', bg: '' }
  * ```
  */
-export function tierBadge(tier: number): { label: string; color: string } {
+export function tierBadge(tier: number): { label: string; color: string; bg: string } {
   switch (tier) {
     case 1:
-      return { label: 'T1', color: 'var(--semantic-win)' }
+      return {
+        label: 'T1',
+        color: 'var(--semantic-win)',
+        bg: 'color-mix(in srgb, var(--semantic-win) 15%, transparent)'
+      }
     case 2:
-      return { label: 'T2', color: 'var(--accent-blue)' }
+      return {
+        label: 'T2',
+        color: 'var(--accent-blue)',
+        bg: 'color-mix(in srgb, var(--accent-blue) 15%, transparent)'
+      }
     case 3:
-      return { label: 'T3', color: 'var(--text-secondary)' }
+      return {
+        label: 'T3',
+        color: 'var(--text-secondary)',
+        bg: 'color-mix(in srgb, var(--text-secondary) 15%, transparent)'
+      }
     case 4:
-      return { label: 'T4', color: 'var(--text-tertiary)' }
+      return {
+        label: 'T4',
+        color: 'var(--text-tertiary)',
+        bg: 'color-mix(in srgb, var(--text-tertiary) 15%, transparent)'
+      }
     case 5:
-      return { label: 'T5', color: 'var(--text-tertiary)' }
+      return {
+        label: 'T5',
+        color: 'var(--text-tertiary)',
+        bg: 'color-mix(in srgb, var(--text-tertiary) 15%, transparent)'
+      }
     default:
-      return { label: '', color: '' }
+      return { label: '', color: '', bg: '' }
   }
 }
 

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { syncPlayers, playerSignature } from './useSessionSync'
+import type { SessionSummoner } from '@renderer/types/domain/gaming'
+
+/** 造一个最小 SessionSummoner（选人期敌方形态：空 puuid 仅英雄） */
+function enemy(championId: number, pickState: string): SessionSummoner {
+  return {
+    championId,
+    championKey: `champion_${championId}`,
+    summoner: { puuid: '' } as SessionSummoner['summoner'],
+    matchHistory: {} as SessionSummoner['matchHistory'],
+    userTag: {} as SessionSummoner['userTag'],
+    rank: {} as SessionSummoner['rank'],
+    meetGames: [],
+    preGroupMarkers: { name: '', type: '' },
+    pickState
+  }
+}
+
+describe('选人期 pickState 合并', () => {
+  it('basic 合并应更新同位置空 puuid 敌人的 pickState 与 championId', () => {
+    const current = [enemy(0, 'none')]
+    syncPlayers(current, [enemy(10, 'intent')], 'basic')
+    expect(current[0].championId).toBe(10)
+    expect(current[0].pickState).toBe('intent')
+  })
+
+  it('full 合并下仅 pickState 变化也应触发更新（签名包含 pickState）', () => {
+    const a = enemy(10, 'intent')
+    const b = enemy(10, 'locked')
+    expect(playerSignature(a)).not.toBe(playerSignature(b))
+    const current = [a]
+    syncPlayers(current, [b], 'full')
+    expect(current[0].pickState).toBe('locked')
+  })
+})

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.ts
@@ -196,6 +196,7 @@ export function useSessionSync() {
     sessionData.isMultiTeam = false
     sessionData.mySubteamId = 0
     sessionData.cherrySubteamsPending = false
+    sessionData.champSelect = undefined
     sessionData.subteams.splice(0, sessionData.subteams.length)
     requestSessionData()
   }
@@ -228,6 +229,9 @@ export function useSessionSync() {
     sessionData.isMultiTeam = !!data.isMultiTeam
     sessionData.mySubteamId = data.mySubteamId ?? 0
     sessionData.cherrySubteamsPending = !!data.cherrySubteamsPending
+    // 后端仅在 ChampSelect 期间下发该字段（skip_serializing_if）；离开选人后
+    // 事件里 data.champSelect 缺席 → undefined 直接覆盖旧值，面板自动清空阶段/ban 展示。
+    sessionData.champSelect = data.champSelect
   }
 
   /**

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.ts
@@ -50,7 +50,7 @@ function updatePreGroupMarkers(subteams: Subteam[], markers: Record<string, PreG
  * 生成玩家状态的轻量签名：同 puuid 下若以下关键字段全部一致，视为"数据未变"可跳过更新。
  * 远快于 JSON.stringify 整个对象（后者会序列化 matchHistory.games.games 等大数组）。
  */
-function playerSignature(p: SessionSummoner): string {
+export function playerSignature(p: SessionSummoner): string {
   const solo = p.rank?.queueMap?.RANKED_SOLO_5x5
   return [
     p.summoner.puuid,
@@ -61,7 +61,8 @@ function playerSignature(p: SessionSummoner): string {
     p.meetGames?.length ?? -1,
     solo?.tier ?? '',
     solo?.leaguePoints ?? -1,
-    p.preGroupMarkers?.name ?? ''
+    p.preGroupMarkers?.name ?? '',
+    p.pickState ?? ''
   ].join('|')
 }
 
@@ -103,7 +104,7 @@ function syncSubteams(current: Subteam[], next: Subteam[], mode: 'basic' | 'full
   current.sort((a, b) => a.subteamId - b.subteamId)
 }
 
-function syncPlayers(
+export function syncPlayers(
   currentTeam: SessionSummoner[],
   newTeam: SessionSummoner[],
   mode: 'basic' | 'full'
@@ -121,6 +122,7 @@ function syncPlayers(
           oldPlayer.championId = newPlayer.championId
           oldPlayer.championKey = newPlayer.championKey
           oldPlayer.summoner = newPlayer.summoner
+          oldPlayer.pickState = newPlayer.pickState
         } else {
           currentTeam[i] = newPlayer
         }

--- a/lol-record-analysis-tauri/src/router/index.ts
+++ b/lol-record-analysis-tauri/src/router/index.ts
@@ -30,6 +30,13 @@ const routes: Array<RouteRecordRaw> = [
     meta: { title: '加载中' }
   },
   {
+    // 开发用：情报卡动画演示，无导航入口，仅 #/IntelDemo 直达
+    path: '/IntelDemo',
+    name: 'IntelDemo',
+    component: () => import('@renderer/views/IntelDemo.vue'),
+    meta: { title: '情报卡演示' }
+  },
+  {
     path: '/Settings',
     name: 'Settings',
     redirect: '/Settings/Automation',

--- a/lol-record-analysis-tauri/src/services/__tests__/opgg.spec.ts
+++ b/lol-record-analysis-tauri/src/services/__tests__/opgg.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+import { invoke } from '@tauri-apps/api/core'
+import { queueIdToOpggMode, getChampionMeta, findCounterHints, ensureOpggData } from '../opgg'
+import type { LaneCounter } from '../opgg'
+
+describe('opgg service', () => {
+  it('queueIdToOpggMode: 450→aram, 420/440/其他→ranked', () => {
+    expect(queueIdToOpggMode(450)).toBe('aram')
+    expect(queueIdToOpggMode(420)).toBe('ranked')
+    expect(queueIdToOpggMode(0)).toBe('ranked')
+  })
+
+  it('getChampionMeta 透传 invoke 并容错', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce({ championId: 86, tier: 1 })
+    const m = await getChampionMeta('ranked', 86, 'TOP')
+    expect(invoke).toHaveBeenCalledWith('get_champion_meta', {
+      mode: 'ranked',
+      championId: 86,
+      position: 'TOP'
+    })
+    expect(m?.tier).toBe(1)
+    vi.mocked(invoke).mockRejectedValueOnce('boom')
+    expect(await getChampionMeta('ranked', 86)).toBeNull()
+  })
+
+  it('ensureOpggData 失败返回 null 不抛', async () => {
+    vi.mocked(invoke).mockRejectedValueOnce('net down')
+    expect(await ensureOpggData('ranked')).toBeNull()
+  })
+
+  it('findCounterHints 双向克制判定与排序', () => {
+    const counters: Record<number, LaneCounter[]> = {
+      // 敌方 10 最怕我方 86（10 对 86 胜率 0.44 → 我方 86 对其 0.56）
+      10: [{ opponentId: 86, position: 'TOP', subjectWinRate: 0.44, play: 4000 }],
+      // 我方 99 被敌方 10 克制（99 对 10 胜率 0.42）
+      99: [{ opponentId: 10, position: 'MIDDLE', subjectWinRate: 0.42, play: 3000 }]
+    }
+    const hints = findCounterHints(10, [86, 99], counters)
+    expect(hints).toHaveLength(2)
+    expect(hints[0].myChampionId).toBe(99) // |0.5-0.42|=0.08 > |0.5-0.56|=0.06
+    expect(hints[0].myWinRate).toBeCloseTo(0.42)
+    expect(hints[1].myWinRate).toBeCloseTo(0.56)
+  })
+
+  it('findCounterHints 无关联返回空', () => {
+    expect(findCounterHints(10, [86], {})).toEqual([])
+  })
+})

--- a/lol-record-analysis-tauri/src/services/ai/index.ts
+++ b/lol-record-analysis-tauri/src/services/ai/index.ts
@@ -5,12 +5,15 @@
  */
 
 import type { Game } from '@renderer/types/domain/match'
+import type { SessionData } from '@renderer/types/domain/gaming'
+import type { OpggMode } from '@renderer/services/opgg'
 import { getConfigByIpc } from '@renderer/services/ipc'
 import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import type { AIAnalysisResult, MatchDetailAnalysisOptions, StreamCallbacks } from './types'
 import { loadChampionNames } from './champion-names'
 import { requestAIContentStream } from './stream'
 import { buildPlayerAnalysisPrompt, buildTeamAnalysisPrompt } from './prompts/team'
+import { buildChampSelectPrompt } from './prompts/champSelect'
 import { analyzeMatchDetail } from './matchDetail'
 import type { RecentPlayerProfile } from './shared/types'
 
@@ -60,6 +63,29 @@ export async function analyzeGameWithAI(
       onError: (error: string) => resolve({ success: false, error })
     })
   })
+}
+
+/**
+ * 选人阶段（ChampSelect）AI 阵容分析：无需等进入对局，选人期即可用。
+ * 我方走 puuid 齐全的画像摘要，敌方靠 OP.GG 静态数据（T 级/胜率/克制）撑情报。
+ *
+ * @param sessionData - 对局会话数据（含 champSelect 结构化视图）
+ * @param opggMode - OP.GG 数据模式，决定敌方情报是否含分路克制数据
+ * @param callbacks - 流式回调
+ */
+export async function analyzeChampSelectWithAIStream(
+  sessionData: SessionData,
+  opggMode: OpggMode,
+  callbacks: StreamCallbacks
+): Promise<void> {
+  try {
+    await loadChampionNames()
+    const prompt = await buildChampSelectPrompt(sessionData, opggMode)
+    await requestAIContentStream(prompt, callbacks, IN_GAME_SYSTEM_PROMPT)
+  } catch (error: any) {
+    console.error('Champ select AI analysis error:', error)
+    callbacks.onError(error.message || '网络请求失败')
+  }
 }
 
 /**

--- a/lol-record-analysis-tauri/src/services/ai/index.ts
+++ b/lol-record-analysis-tauri/src/services/ai/index.ts
@@ -11,7 +11,7 @@ import { getConfigByIpc } from '@renderer/services/ipc'
 import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import type { AIAnalysisResult, MatchDetailAnalysisOptions, StreamCallbacks } from './types'
 import { loadChampionNames } from './champion-names'
-import { requestAIContentStream } from './stream'
+import { DEFAULT_SYSTEM_PROMPT, requestAIContentStream } from './stream'
 import { buildPlayerAnalysisPrompt, buildTeamAnalysisPrompt } from './prompts/team'
 import { buildChampSelectPrompt } from './prompts/champSelect'
 import { analyzeMatchDetail } from './matchDetail'
@@ -81,7 +81,9 @@ export async function analyzeChampSelectWithAIStream(
   try {
     await loadChampionNames()
     const prompt = await buildChampSelectPrompt(sessionData, opggMode)
-    await requestAIContentStream(prompt, callbacks, IN_GAME_SYSTEM_PROMPT)
+    // 用 stream.ts 的 DEFAULT_SYSTEM_PROMPT（含"所有结论都必须绑定数据证据"的反幻觉指令），
+    // 与选人期 prompt 里的分析纪律硬规则配套；不沿用对局中的 IN_GAME_SYSTEM_PROMPT。
+    await requestAIContentStream(prompt, callbacks, DEFAULT_SYSTEM_PROMPT)
   } catch (error: any) {
     console.error('Champ select AI analysis error:', error)
     callbacks.onError(error.message || '网络请求失败')

--- a/lol-record-analysis-tauri/src/services/ai/prompts/__tests__/champSelect.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/__tests__/champSelect.spec.ts
@@ -21,7 +21,7 @@ vi.mock('@renderer/services/opgg', () => ({
     championId === 238
       ? {
           championId: 238,
-          position: 'mid',
+          position: 'JUNGLE',
           tier: 1,
           rank: 1,
           winRate: 0.532,
@@ -149,6 +149,12 @@ describe('buildChampSelectPrompt', () => {
     expect(prompt).toContain('T1')
   })
 
+  it('includes 敌方主分路（中文，来自 OP.GG position）', async () => {
+    // mock 里 championId 238（劫）的 meta.position 为 'JUNGLE'
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('主分路打野')
+  })
+
   it('includes ban 名字', async () => {
     const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
     expect(prompt).toContain('李青') // 我方 ban
@@ -200,5 +206,45 @@ describe('buildChampSelectPrompt', () => {
   it('shows "敌方不可见" when enemy subteam is entirely absent (随机英雄模式)', async () => {
     const prompt = await buildChampSelectPrompt(makeSessionData({ noEnemySubteam: true }), 'aram')
     expect(prompt).toContain('敌方不可见')
+  })
+
+  it('禁止选人类建议 when 我方全部锁定 (allMyLocked)', async () => {
+    const session = makeSessionData({})
+    // 我方乙从 championId=0/none 改为已选且已锁定 → 我方两人均 locked，触发 allMyLocked
+    session.subteams[0].players[1] = makeMyPlayer({
+      name: '我方乙',
+      puuid: 'p2',
+      championId: 55,
+      pickState: 'locked',
+      tierCn: '铂金II'
+    })
+    const prompt = await buildChampSelectPrompt(session, 'ranked')
+    expect(prompt).toContain('禁止给出任何选英雄')
+  })
+
+  it('允许选人类建议 when 我方尚未全部锁定', async () => {
+    // 默认 fixture：我方乙 championId=0/pickState='none' → 未全部锁定
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('尚未结束')
+  })
+
+  it('禁止选人类建议 when stage 为 finalization（即使 pickState 数据未跟上）', async () => {
+    const session = makeSessionData({})
+    session.champSelect!.stage = 'finalization'
+    const prompt = await buildChampSelectPrompt(session, 'ranked')
+    expect(prompt).toContain('禁止给出任何选英雄')
+  })
+
+  it('includes 数据指标引用纪律（禁止出场率/ban率等未提供指标，区分英雄版本数据与玩家个人数据）', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('出场率')
+    expect(prompt).toContain('版本胜率')
+    expect(prompt).toContain('不是英雄的版本数据')
+  })
+
+  it('includes 禁止职能标签纪律', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('禁止给英雄贴')
+    expect(prompt).toContain('主分路≠职能')
   })
 })

--- a/lol-record-analysis-tauri/src/services/ai/prompts/__tests__/champSelect.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/__tests__/champSelect.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildChampSelectPrompt } from '../champSelect'
+import type { SessionData, SessionSummoner } from '@renderer/types/domain/gaming'
+
+const CHAMP_NAMES: Record<number, string> = {
+  103: '阿狸',
+  238: '劫',
+  64: '李青',
+  55: '卡特琳娜'
+}
+
+vi.mock('../../champion-names', () => ({
+  getChampionName: vi.fn((id: number) => CHAMP_NAMES[id] || `英雄${id}`),
+  loadChampionNames: vi.fn(async () => {})
+}))
+
+vi.mock('@renderer/services/opgg', () => ({
+  getChampionMeta: vi.fn(async (_mode: string, championId: number) =>
+    championId === 238
+      ? {
+          championId: 238,
+          position: 'mid',
+          tier: 1,
+          rank: 1,
+          winRate: 0.532,
+          pickRate: 0.1,
+          banRate: 0.05,
+          roleRate: 0.9,
+          isMainPosition: true
+        }
+      : null
+  ),
+  getLaneCounters: vi.fn(async () => ({})),
+  findCounterHints: vi.fn(() => [])
+}))
+
+/** 构造我方玩家（puuid/战绩齐全） */
+function makeMyPlayer(opts: {
+  name: string
+  puuid: string
+  championId: number
+  pickState: string
+  tierCn: string
+}): SessionSummoner {
+  return {
+    championId: opts.championId,
+    championKey: '',
+    summoner: {
+      puuid: opts.puuid,
+      gameName: opts.name,
+      tagLine: 'CN1',
+      summonerLevel: 100,
+      profileIconId: 1
+    },
+    matchHistory: { games: { games: [] } },
+    userTag: { tag: [], recentData: { selectWins: 6, selectLosses: 4, kda: 3.2 } },
+    rank: { queueMap: { RANKED_SOLO_5x5: { tierCn: opts.tierCn } } },
+    meetGames: [],
+    preGroupMarkers: { name: '', type: '' },
+    pickState: opts.pickState
+  } as unknown as SessionSummoner
+}
+
+/** 构造敌方玩家（puuid 空，只有 championId + pickState） */
+function makeEnemyPlayer(championId: number, pickState: string): SessionSummoner {
+  return {
+    championId,
+    championKey: '',
+    summoner: { puuid: '', gameName: '', tagLine: '', summonerLevel: 0, profileIconId: 0 },
+    matchHistory: { games: { games: [] } },
+    userTag: { tag: [] },
+    rank: {},
+    meetGames: [],
+    preGroupMarkers: { name: '', type: '' },
+    pickState
+  } as unknown as SessionSummoner
+}
+
+function makeSessionData(opts: {
+  enemyPlayers?: SessionSummoner[]
+  noEnemySubteam?: boolean
+}): SessionData {
+  const subteams = [
+    {
+      subteamId: 1,
+      players: [
+        makeMyPlayer({
+          name: '我方甲',
+          puuid: 'p1',
+          championId: 103,
+          pickState: 'locked',
+          tierCn: '钻石IV'
+        }),
+        makeMyPlayer({
+          name: '我方乙',
+          puuid: 'p2',
+          championId: 0,
+          pickState: 'none',
+          tierCn: '铂金II'
+        })
+      ]
+    }
+  ]
+  if (!opts.noEnemySubteam) {
+    subteams.push({
+      subteamId: 2,
+      players: opts.enemyPlayers ?? [makeEnemyPlayer(238, 'locked'), makeEnemyPlayer(0, 'none')]
+    })
+  }
+
+  return {
+    phase: 'ChampSelect',
+    type: 'RANKED_SOLO_5x5',
+    typeCn: '单双排位',
+    queueId: 420,
+    gameMode: 'CLASSIC',
+    isMultiTeam: false,
+    mySubteamId: 1,
+    subteams,
+    champSelect: {
+      stage: 'picking',
+      myBans: [64],
+      theirBans: [55]
+    }
+  }
+}
+
+describe('buildChampSelectPrompt', () => {
+  it('includes 模式/我方玩家名与段位', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('单双排位')
+    expect(prompt).toContain('我方甲')
+    expect(prompt).toContain('钻石IV')
+    expect(prompt).toContain('我方乙')
+    expect(prompt).toContain('铂金II')
+  })
+
+  it('includes 敌方英雄名与 T 级', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('劫')
+    expect(prompt).toContain('T1')
+  })
+
+  it('includes ban 名字', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('李青') // 我方 ban
+    expect(prompt).toContain('卡特琳娜') // 敌方 ban
+  })
+
+  it('includes 「未亮出」计数', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('其余 1 人未亮出')
+  })
+
+  it('includes 分析纪律关键词"禁止编造"', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('禁止编造')
+  })
+
+  it('marks 未锁定 champion picks', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    // 我方乙 championId=0 → 显示"未选"，不应出现"未锁定"误标
+    expect(prompt).toContain('未选')
+  })
+
+  it('shows "敌方不可见" when enemy subteam is entirely absent (随机英雄模式)', async () => {
+    const prompt = await buildChampSelectPrompt(makeSessionData({ noEnemySubteam: true }), 'aram')
+    expect(prompt).toContain('敌方不可见')
+  })
+})

--- a/lol-record-analysis-tauri/src/services/ai/prompts/__tests__/champSelect.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/__tests__/champSelect.spec.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildChampSelectPrompt } from '../champSelect'
+import { findCounterHints } from '@renderer/services/opgg'
 import type { SessionData, SessionSummoner } from '@renderer/types/domain/gaming'
 
 const CHAMP_NAMES: Record<number, string> = {
   103: '阿狸',
   238: '劫',
   64: '李青',
-  55: '卡特琳娜'
+  55: '卡特琳娜',
+  266: '剑魔'
 }
 
 vi.mock('../../champion-names', () => ({
@@ -126,6 +128,12 @@ function makeSessionData(opts: {
 }
 
 describe('buildChampSelectPrompt', () => {
+  beforeEach(() => {
+    // 清掉上一个用例遗留的 mockReturnValueOnce 队列，回到默认"无克制提示"
+    vi.mocked(findCounterHints).mockReset()
+    vi.mocked(findCounterHints).mockReturnValue([])
+  })
+
   it('includes 模式/我方玩家名与段位', async () => {
     const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
     expect(prompt).toContain('单双排位')
@@ -161,6 +169,32 @@ describe('buildChampSelectPrompt', () => {
     const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
     // 我方乙 championId=0 → 显示"未选"，不应出现"未锁定"误标
     expect(prompt).toContain('未选')
+  })
+
+  it('annotates （未锁定） when my player has champion but pickState !== locked', async () => {
+    const session = makeSessionData({})
+    // 我方乙改为已选英雄但仍在 picking → 名字后要带"（未锁定）"标注
+    session.subteams[0].players[1] = makeMyPlayer({
+      name: '我方乙',
+      puuid: 'p2',
+      championId: 55,
+      pickState: 'picking',
+      tierCn: '铂金II'
+    })
+    const prompt = await buildChampSelectPrompt(session, 'ranked')
+    expect(prompt).toContain('卡特琳娜（未锁定）')
+  })
+
+  it('renders 「怕我方」 counter hint with percent when enemy fears my champion', async () => {
+    vi.mocked(findCounterHints).mockReturnValueOnce([{ myChampionId: 266, myWinRate: 0.56 }])
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('怕我方剑魔（56%）')
+  })
+
+  it('renders 「克制我方」 counter hint with percent when enemy counters my champion', async () => {
+    vi.mocked(findCounterHints).mockReturnValueOnce([{ myChampionId: 266, myWinRate: 0.44 }])
+    const prompt = await buildChampSelectPrompt(makeSessionData({}), 'ranked')
+    expect(prompt).toContain('克制我方剑魔（56%）')
   })
 
   it('shows "敌方不可见" when enemy subteam is entirely absent (随机英雄模式)', async () => {

--- a/lol-record-analysis-tauri/src/services/ai/prompts/champSelect.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/champSelect.ts
@@ -1,0 +1,170 @@
+/**
+ * 选人阶段（ChampSelect）AI 阵容分析 Prompt
+ *
+ * 与 team.ts（对局中/赛后整队分析）的关键区别：
+ * - 我方：puuid/战绩齐全，画像复用 extractPlayerInsight，但选人期只取核心字段
+ *   （名字/段位/近期胜率/KDA/主玩位置/常用英雄 top3）。isOffRole 判定依赖
+ *   shared/recentProfile.ts 的 buildRecentProfile()，需要 teamPosition 形状的原始
+ *   对局数据，与 extractPlayerInsight 消费的 matchHistory.games.games 形状不同；
+ *   选人期这层不做二次转换，故略去该字段（取舍：宁可少一个字段，不引入重复的画像抽取逻辑）。
+ * - 敌方：选人期只有英雄 id + pickState，没有玩家身份，只能靠 OP.GG 静态数据
+ *   （T 级/胜率/克制关系）撑情报，不能像 team.ts 那样输出玩家战绩画像。
+ */
+
+import { extractPlayerInsight } from '../player-insight'
+import { getChampionName } from '../champion-names'
+import { getChampionMeta, getLaneCounters, findCounterHints } from '@renderer/services/opgg'
+import type { OpggMode, LaneCounter } from '@renderer/services/opgg'
+import type { SessionData, SessionSummoner } from '@renderer/types/domain/gaming'
+
+/** 会话级 stage → 中文，需与 Gaming.vue 的 STAGE_STEPS 保持一致 */
+const STAGE_CN: Record<string, string> = {
+  planning: '预选',
+  banning: '禁用',
+  picking: '选人',
+  finalization: '确认'
+}
+
+function stageLabel(stage: string | undefined): string {
+  return (stage && STAGE_CN[stage]) || '未知'
+}
+
+/** ban 列表 → 英雄名字串，空列表显示"无" */
+function banListText(ids: number[]): string {
+  return ids.length > 0 ? ids.map(id => getChampionName(id)).join('、') : '无'
+}
+
+/** 我方玩家一行的核心画像摘要（选人期精简版，字段取舍见文件头注释） */
+function myPlayerLine(p: SessionSummoner): string {
+  const insight = extractPlayerInsight(p, { detailed: false })
+  const champLabel =
+    p.championId > 0
+      ? `${getChampionName(p.championId)}${p.pickState !== 'locked' ? '（未锁定）' : ''}`
+      : '未选'
+  const topChampsText =
+    insight.topChampions
+      .slice(0, 3)
+      .map(
+        (c: { champion: string; winRate: number; games: number }) =>
+          `${c.champion}(${c.winRate}%/${c.games}场)`
+      )
+      .join('、') || '无近期数据'
+  return `- ${insight.name}（${insight.tier}）本局：${champLabel}｜近期胜率 ${insight.recentStats.winRate}% KDA ${insight.recentStats.kda}｜主打位置 ${insight.mainPosition}｜常用：${topChampsText}`
+}
+
+/** OP.GG tier 数字 → 展示文案，0/undefined 视为无数据 */
+function tierLabel(tier: number | undefined): string {
+  return tier ? `T${tier}` : '无数据'
+}
+
+/** 克制提示 → 一句话文案，正向（怕我方）与负向（克制我方）分开措辞 */
+function counterHintText(myWinRate: number, myChampionId: number): string {
+  const myName = getChampionName(myChampionId)
+  return myWinRate >= 0.5
+    ? `怕我方${myName}（${(myWinRate * 100).toFixed(0)}%）`
+    : `克制我方${myName}（${((1 - myWinRate) * 100).toFixed(0)}%）`
+}
+
+/**
+ * 构建选人期阵容分析 prompt
+ * @param sessionData - 对局会话数据（subteams 统一模型，需带 champSelect 结构化视图）
+ * @param opggMode - OP.GG 数据模式（ranked/aram），决定是否有分路克制数据
+ * @returns 可直接喂给 requestAIContentStream 的 prompt 字符串
+ */
+export async function buildChampSelectPrompt(
+  sessionData: SessionData,
+  opggMode: OpggMode
+): Promise<string> {
+  const mySubteamId = sessionData.mySubteamId ?? 0
+  const subteams = sessionData.subteams ?? []
+  const myTeam = subteams.find(s => s.subteamId === mySubteamId)
+  const myPlayers = myTeam?.players ?? []
+  const enemyPlayers = subteams.filter(s => s.subteamId !== mySubteamId).flatMap(s => s.players)
+
+  const myChampionIds = myPlayers.map(p => p.championId).filter(id => id > 0)
+  const revealedEnemies = enemyPlayers.filter(p => p.championId > 0)
+  const hiddenCount = enemyPlayers.length - revealedEnemies.length
+
+  const myBans = sessionData.champSelect?.myBans ?? []
+  const theirBans = sessionData.champSelect?.theirBans ?? []
+
+  const myBlock =
+    myPlayers.length > 0 ? myPlayers.map(myPlayerLine).join('\n') : '（我方数据暂未到位）'
+
+  let enemyBlock: string
+  if (enemyPlayers.length === 0) {
+    // 大乱斗类随机英雄模式，选人期敌方队伍不可见（后端不下发敌方 subteam）
+    enemyBlock = '本模式选人期敌方不可见（随机英雄类模式，选人阶段无法获取敌方英雄信息）。'
+  } else if (revealedEnemies.length === 0) {
+    enemyBlock = `敌方 ${enemyPlayers.length} 人均未亮出英雄，暂无情报。`
+  } else {
+    const uniqueEnemyIds = Array.from(new Set(revealedEnemies.map(p => p.championId)))
+    const metaEntries = await Promise.all(
+      uniqueEnemyIds.map(async id => [id, await getChampionMeta(opggMode, id)] as const)
+    )
+    const metaById = new Map(metaEntries)
+
+    // 分路克制关系仅 ranked 模式有数据，且需要我方已亮出至少一个英雄才有比较意义
+    let countersByChampion: Record<number, LaneCounter[]> = {}
+    if (opggMode === 'ranked' && myChampionIds.length > 0) {
+      countersByChampion = await getLaneCounters(opggMode, [...uniqueEnemyIds, ...myChampionIds])
+    }
+
+    const lines = revealedEnemies.map(p => {
+      const meta = metaById.get(p.championId) ?? null
+      const name = getChampionName(p.championId)
+      const winRateText = meta?.winRate ? `${(meta.winRate * 100).toFixed(1)}%` : '--'
+      const hints =
+        opggMode === 'ranked' && myChampionIds.length > 0
+          ? findCounterHints(p.championId, myChampionIds, countersByChampion)
+          : []
+      const hintText =
+        hints.length > 0
+          ? '｜' + hints.map(h => counterHintText(h.myWinRate, h.myChampionId)).join('，')
+          : ''
+      return `- ${name}｜${tierLabel(meta?.tier)}/胜率${winRateText}${hintText}`
+    })
+    if (hiddenCount > 0) {
+      lines.push(`- 其余 ${hiddenCount} 人未亮出`)
+    }
+    enemyBlock = lines.join('\n')
+  }
+
+  // ranked 有分路对线概念，aram/其它模式没有，用「关键威胁」代替「关键对线」
+  const laneSectionTitle = opggMode === 'ranked' ? '关键对线' : '关键威胁'
+
+  return `你是LOL资深分析师，现在是选人阶段，请基于以下信息给出速读分析：
+
+【对局】
+模式：${sessionData.typeCn || '未知'}
+阶段：${stageLabel(sessionData.champSelect?.stage)}
+我方禁用：${banListText(myBans)}
+敌方禁用：${banListText(theirBans)}
+
+【我方】
+${myBlock}
+
+【敌方情报】
+${enemyBlock}
+
+===== 分析纪律（硬规则，必须遵守）=====
+- 敌方只有英雄没有玩家身份，禁止臆测敌方玩家的水平、段位或操作习惯。
+- "近期常用英雄"战绩 ≠ 本局英雄：玩家本局锁定的英雄若不在其常用列表中，不能当成他不熟练的证据，只能如实说"本局英雄非其常用英雄，风格未知"。
+- 禁止编造英雄的技能、被动机制、连招或数值——材料里没给出的机制信息一律不许提。
+- "补位"仅指位置状态（本局位置偏离主玩位置），不代表水平高低；禁止生造"XX流"之类的术语。
+
+===== 输出要求 =====
+给一份约 250 字的速读分析，严格按下面 markdown 模板，章节标题与顺序不可改：
+
+## 阵容对比
+{一两句话点出双方阵容强弱/风格差异，基于上面给出的数据}
+
+## ${laneSectionTitle}
+{结合敌方英雄的 T 级/胜率/克制关系，指出我方最该注意的点；信息不足就说"数据不足"}
+
+## 给我方的建议
+- 2-3 条针对当前 BP 阶段可执行的建议（选人/克制/资源分配）
+
+【语气】像懂哥开黑前的速读：简洁、戏谑、有梗；不辱骂、不地域黑、不人身攻击；
+只用给定数据里的数字，缺数据就说"数据不足"而不是编。`
+}

--- a/lol-record-analysis-tauri/src/services/ai/prompts/champSelect.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/champSelect.ts
@@ -29,6 +29,25 @@ function stageLabel(stage: string | undefined): string {
   return (stage && STAGE_CN[stage]) || '未知'
 }
 
+/**
+ * OP.GG 主分路（LCU 命名，见 opgg::data::normalize_position）→ 中文。
+ * 注意：这是 OP.GG 统计意义上的"主分路"，不是英雄职能（坦克/刺客/法师...）——
+ * 材料没有职能字段，禁止据此推断或标注职能。
+ */
+const POSITION_CN: Record<string, string> = {
+  TOP: '上单',
+  JUNGLE: '打野',
+  MIDDLE: '中单',
+  BOTTOM: '下路',
+  UTILITY: '辅助'
+}
+
+/** OP.GG 主分路 → 中文展示片段，position 为空串（aram 等无分路模式）时不展示该段 */
+function positionSegment(position: string | undefined): string {
+  const cn = position ? POSITION_CN[position] : undefined
+  return cn ? `｜主分路${cn}` : ''
+}
+
 /** ban 列表 → 英雄名字串，空列表显示"无" */
 function banListText(ids: number[]): string {
   return ids.length > 0 ? ids.map(id => getChampionName(id)).join('、') : '无'
@@ -85,6 +104,15 @@ export async function buildChampSelectPrompt(
   const revealedEnemies = enemyPlayers.filter(p => p.championId > 0)
   const hiddenCount = enemyPlayers.length - revealedEnemies.length
 
+  // 我方是否已全部锁定：每个我方玩家都已选英雄(championId>0)且 pickState 为 locked。
+  // 用于决定分析纪律里能不能给"选/抢/换英雄"类建议——已经锁定的选人建议是幻觉的重灾区。
+  const allMyLocked =
+    myPlayers.length > 0 && myPlayers.every(p => p.championId > 0 && p.pickState === 'locked')
+  const suggestionDiscipline =
+    allMyLocked || sessionData.champSelect?.stage === 'finalization'
+      ? '当前所有选择已锁定：禁止给出任何选英雄/抢英雄/换英雄类建议，只允许给对局执行层面的建议（对线思路/资源决策/注意事项）'
+      : '选人尚未结束，可以给选人建议，但只能针对我方尚未锁定的位置'
+
   const myBans = sessionData.champSelect?.myBans ?? []
   const theirBans = sessionData.champSelect?.theirBans ?? []
 
@@ -122,7 +150,7 @@ export async function buildChampSelectPrompt(
         hints.length > 0
           ? '｜' + hints.map(h => counterHintText(h.myWinRate, h.myChampionId)).join('，')
           : ''
-      return `- ${name}｜${tierLabel(meta?.tier)}/胜率${winRateText}${hintText}`
+      return `- ${name}${positionSegment(meta?.position)}｜${tierLabel(meta?.tier)}/胜率${winRateText}${hintText}`
     })
     if (hiddenCount > 0) {
       lines.push(`- 其余 ${hiddenCount} 人未亮出`)
@@ -152,6 +180,9 @@ ${enemyBlock}
 - "近期常用英雄"战绩 ≠ 本局英雄：玩家本局锁定的英雄若不在其常用列表中，不能当成他不熟练的证据，只能如实说"本局英雄非其常用英雄，风格未知"。
 - 禁止编造英雄的技能、被动机制、连招或数值——材料里没给出的机制信息一律不许提。
 - "补位"仅指位置状态（本局位置偏离主玩位置），不代表水平高低；禁止生造"XX流"之类的术语。
+- ${suggestionDiscipline}
+- 材料中的每个数字都有明确的指标名：敌方英雄的"胜率"是 OP.GG 版本胜率；我方玩家"常用"括号里的胜率/场次是该玩家个人近期数据，不是英雄的版本数据。禁止使用材料中不存在的指标名（如"出场率""ban率"——材料未提供），禁止把玩家个人数据说成英雄版本数据。
+- 禁止给英雄贴"坦克/刺客/法师/射手"等职能标签或基于职能给玩法建议——材料未提供英雄职能信息，主分路≠职能。
 
 ===== 输出要求 =====
 给一份约 250 字的速读分析，严格按下面 markdown 模板，章节标题与顺序不可改：

--- a/lol-record-analysis-tauri/src/services/ai/prompts/champSelect.ts
+++ b/lol-record-analysis-tauri/src/services/ai/prompts/champSelect.ts
@@ -108,10 +108,14 @@ export async function buildChampSelectPrompt(
   // 用于决定分析纪律里能不能给"选/抢/换英雄"类建议——已经锁定的选人建议是幻觉的重灾区。
   const allMyLocked =
     myPlayers.length > 0 && myPlayers.every(p => p.championId > 0 && p.pickState === 'locked')
-  const suggestionDiscipline =
-    allMyLocked || sessionData.champSelect?.stage === 'finalization'
-      ? '当前所有选择已锁定：禁止给出任何选英雄/抢英雄/换英雄类建议，只允许给对局执行层面的建议（对线思路/资源决策/注意事项）'
-      : '选人尚未结束，可以给选人建议，但只能针对我方尚未锁定的位置'
+  const picksSettled = allMyLocked || sessionData.champSelect?.stage === 'finalization'
+  const suggestionDiscipline = picksSettled
+    ? '当前所有选择已锁定：禁止给出任何选英雄/抢英雄/换英雄类建议，只允许给对局执行层面的建议（对线思路/资源决策/注意事项）'
+    : '选人尚未结束，可以给选人建议，但只能针对我方尚未锁定的位置'
+  // 输出模板里的建议示例词必须与上面的纪律同频——锁定后模板再出现「选人」示例会诱导幻觉
+  const suggestionTemplateLine = picksSettled
+    ? '- 2-3 条面向对局执行的建议（对线思路/资源决策/团战注意事项）'
+    : '- 2-3 条针对当前 BP 阶段可执行的建议（选人/克制/资源分配）'
 
   const myBans = sessionData.champSelect?.myBans ?? []
   const theirBans = sessionData.champSelect?.theirBans ?? []
@@ -194,7 +198,7 @@ ${enemyBlock}
 {结合敌方英雄的 T 级/胜率/克制关系，指出我方最该注意的点；信息不足就说"数据不足"}
 
 ## 给我方的建议
-- 2-3 条针对当前 BP 阶段可执行的建议（选人/克制/资源分配）
+${suggestionTemplateLine}
 
 【语气】像懂哥开黑前的速读：简洁、戏谑、有梗；不辱骂、不地域黑、不人身攻击；
 只用给定数据里的数字，缺数据就说"数据不足"而不是编。`

--- a/lol-record-analysis-tauri/src/services/opgg.ts
+++ b/lol-record-analysis-tauri/src/services/opgg.ts
@@ -1,0 +1,210 @@
+/**
+ * OP.GG 数据访问封装
+ *
+ * 对应 Rust command/opgg.rs 四命令的类型安全包装。
+ * 所有网络型失败吞掉返回 null/空——数据缺失是常态降级。
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+
+export type OpggMode = 'ranked' | 'aram'
+
+export interface ChampionMeta {
+  championId: number
+  position: string
+  tier: number
+  rank: number
+  winRate: number
+  pickRate: number
+  banRate: number
+  roleRate: number
+  isMainPosition: boolean
+}
+
+export interface LaneCounter {
+  opponentId: number
+  position: string
+  subjectWinRate: number
+  play: number
+}
+
+export interface OpggStatus {
+  mode: string
+  patch: string
+  fetchedAt: number
+  stale: boolean
+  championCount: number
+}
+
+export interface CounterHint {
+  myChampionId: number
+  myWinRate: number
+}
+
+/**
+ * 将队列 ID 转换为 OP.GG 模式
+ * @param queueId - 队列 ID (450=ARAM, 其他=ranked)
+ * @returns 'aram' 或 'ranked'
+ */
+export function queueIdToOpggMode(queueId: number): OpggMode {
+  return queueId === 450 ? 'aram' : 'ranked'
+}
+
+/**
+ * 确保 OP.GG 数据已更新
+ * @param mode - 游戏模式
+ * @returns 状态对象或 null (网络错误时)
+ */
+export async function ensureOpggData(mode: OpggMode): Promise<OpggStatus | null> {
+  try {
+    const result = await invoke('update_opgg_data', { mode })
+    return result as OpggStatus
+  } catch (error) {
+    console.warn(`[opgg] ensureOpggData failed for mode ${mode}:`, error)
+    return null
+  }
+}
+
+/**
+ * 获取英雄元数据
+ * @param mode - 游戏模式
+ * @param championId - 英雄 ID
+ * @param position - 位置 (可选)
+ * @returns 英雄元数据或 null
+ */
+export async function getChampionMeta(
+  mode: OpggMode,
+  championId: number,
+  position?: string
+): Promise<ChampionMeta | null> {
+  try {
+    const result = await invoke('get_champion_meta', {
+      mode,
+      championId,
+      ...(position && { position })
+    })
+    return result as ChampionMeta
+  } catch (error) {
+    console.warn(`[opgg] getChampionMeta failed for champion ${championId}:`, error)
+    return null
+  }
+}
+
+/**
+ * 获取多个英雄的克制信息
+ * @param mode - 游戏模式
+ * @param championIds - 英雄 ID 列表
+ * @returns 按英雄 ID 索引的克制列表 Map
+ */
+export async function getLaneCounters(
+  mode: OpggMode,
+  championIds: number[]
+): Promise<Record<number, LaneCounter[]>> {
+  try {
+    const result = await invoke('get_lane_counters', {
+      mode,
+      championIds
+    })
+    return result as Record<number, LaneCounter[]>
+  } catch (error) {
+    console.warn(`[opgg] getLaneCounters failed for champions [${championIds}]:`, error)
+    return {}
+  }
+}
+
+/**
+ * 获取 OP.GG 数据状态
+ * @param mode - 游戏模式
+ * @returns 状态对象或 null
+ */
+export async function getOpggStatus(mode: OpggMode): Promise<OpggStatus | null> {
+  try {
+    const result = await invoke('get_opgg_status', { mode })
+    return result as OpggStatus
+  } catch (error) {
+    console.warn(`[opgg] getOpggStatus failed for mode ${mode}:`, error)
+    return null
+  }
+}
+
+/**
+ * 纯函数：分析敌方英雄是否被我方某英雄克制
+ *
+ * 语义：countersByChampion[c] 是英雄 c 最难打的对手列表，subjectWinRate 是 c 对该对手的胜率
+ *
+ * 返回条件：
+ * 1. 若 countersByChampion[enemyId] 中存在 opponentId ∈ myChampionIds 的条目
+ *    → 敌人怕我方该英雄，返回 { myChampionId: opponentId, myWinRate: 1 - subjectWinRate }
+ * 2. 若 countersByChampion[myId] 中存在 opponentId === enemyId
+ *    → 我方该英雄被敌人克制，返回 { myChampionId: myId, myWinRate: subjectWinRate }
+ *
+ * 去重：同 myChampionId 取样本大的 (play 值更大)
+ * 排序：按 |0.5 - myWinRate| 降序（偏离 50% 胜率越大越优先）
+ * 最多：返回 2 条
+ *
+ * @param enemyId - 敌方英雄 ID
+ * @param myChampionIds - 我方英雄 ID 列表
+ * @param countersByChampion - 克制关系 Map
+ * @returns 克制提示列表 (最多 2 条)
+ */
+export function findCounterHints(
+  enemyId: number,
+  myChampionIds: number[],
+  countersByChampion: Record<number, LaneCounter[]>
+): CounterHint[] {
+  // 使用 Map 进行去重和合并
+  const hints = new Map<number, { hint: CounterHint; play: number }>()
+
+  // 情况 1：敌方英雄的克制列表中有我方某英雄
+  // countersByChampion[enemyId] = 敌方英雄最怕的对手列表
+  const enemyCounters = countersByChampion[enemyId] || []
+  for (const counter of enemyCounters) {
+    if (myChampionIds.includes(counter.opponentId)) {
+      const myChampionId = counter.opponentId
+      // 敌人怕我方英雄，所以我方胜率 = 1 - (敌人对我方的胜率)
+      const myWinRate = 1 - counter.subjectWinRate
+      const key = myChampionId
+
+      // 去重：保留 play 更大的
+      if (!hints.has(key) || hints.get(key)!.play < counter.play) {
+        hints.set(key, {
+          hint: { myChampionId, myWinRate },
+          play: counter.play
+        })
+      }
+    }
+  }
+
+  // 情况 2：我方英雄的克制列表中有敌方英雄
+  for (const myChampionId of myChampionIds) {
+    const myCounters = countersByChampion[myChampionId] || []
+    for (const counter of myCounters) {
+      if (counter.opponentId === enemyId) {
+        // 我方英雄被敌人克制，胜率直接用
+        const myWinRate = counter.subjectWinRate
+        const key = myChampionId
+
+        // 去重：保留 play 更大的
+        if (!hints.has(key) || hints.get(key)!.play < counter.play) {
+          hints.set(key, {
+            hint: { myChampionId, myWinRate },
+            play: counter.play
+          })
+        }
+      }
+    }
+  }
+
+  // 提取 hints，排序并返回最多 2 条
+  const result = Array.from(hints.values())
+    .map(({ hint }) => hint)
+    .sort((a, b) => {
+      // 按 |0.5 - winRate| 降序
+      const devA = Math.abs(0.5 - a.myWinRate)
+      const devB = Math.abs(0.5 - b.myWinRate)
+      return devB - devA
+    })
+    .slice(0, 2)
+
+  return result
+}

--- a/lol-record-analysis-tauri/src/types/domain/gaming.ts
+++ b/lol-record-analysis-tauri/src/types/domain/gaming.ts
@@ -28,6 +28,10 @@ export interface SessionSummoner {
   meetGames: OneGamePlayer[]
   preGroupMarkers: PreGroupMarkers
   isLoading?: boolean
+  /**
+   * 选人状态：none/intent/picking/locked（非选人期为空）
+   */
+  pickState?: string
 }
 
 export interface Subteam {

--- a/lol-record-analysis-tauri/src/types/domain/gaming.ts
+++ b/lol-record-analysis-tauri/src/types/domain/gaming.ts
@@ -29,7 +29,7 @@ export interface SessionSummoner {
   preGroupMarkers: PreGroupMarkers
   isLoading?: boolean
   /**
-   * 选人状态：none/intent/picking/locked（非选人期为空）
+   * 选人状态：none/intent/picking/banning/locked（非选人期为空）
    */
   pickState?: string
 }
@@ -37,6 +37,19 @@ export interface SessionSummoner {
 export interface Subteam {
   subteamId: number
   players: SessionSummoner[]
+}
+
+/**
+ * 选人阶段的结构化视图：会话级阶段 + 双方已 ban 列表。
+ * 由后端从 timer.phase + actions 推导，非选人期（无 ChampSelect 数据）整体缺席。
+ */
+export interface ChampSelect {
+  /** 会话级阶段: planning(预选) | banning(禁用) | picking(选人) | finalization(确认) | ''(未知) */
+  stage: string
+  /** 我方已 ban 的英雄 id 列表 */
+  myBans: number[]
+  /** 敌方已 ban 的英雄 id 列表 */
+  theirBans: number[]
 }
 
 export interface SessionData {
@@ -54,4 +67,9 @@ export interface SessionData {
    * CLASSIC 模式恒为 false。
    */
   cherrySubteamsPending?: boolean
+  /**
+   * 选人阶段结构化视图（阶段 + 双方 ban 列表）。
+   * 仅 ChampSelect 期间存在；非选人期该字段整体缺席（后端 skip_serializing_if）。
+   */
+  champSelect?: ChampSelect
 }

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -446,13 +446,13 @@ onMounted(async () => {
   filter: grayscale(1) brightness(0.7);
   border: 1px solid rgba(196, 92, 92, 0.5);
   /* 新 ban 弹入：仅在元素首次挂载时播放一次（列表增长时旧图标不会重新触发） */
-  animation: ban-pop 0.3s var(--ease-expo) both;
+  animation: ban-pop 0.24s var(--ease-expo) both;
 }
 
 @keyframes ban-pop {
   from {
     opacity: 0;
-    transform: scale(0.5);
+    transform: scale(0.75);
   }
   to {
     opacity: 1;

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -209,9 +209,11 @@ onMounted(async () => {
     }, 2000)
   }
 
-  // OP.GG 数据兜底刷新：后端启动已预热，此处 fire-and-forget 兜底软件长开超 12h 未重启的场景
-  void ensureOpggData('ranked')
-  void ensureOpggData('aram')
+  // OP.GG 数据兜底刷新：后端启动已预热，此处 fire-and-forget 兜底软件长开超 12h 未重启的场景。
+  // 两个模式都刷新完成后，重新拉取当前模式状态以更新横幅（版本号/滞后标记跟着变化）。
+  void Promise.all([ensureOpggData('ranked'), ensureOpggData('aram')]).then(() =>
+    getOpggStatus(opggMode.value).then(s => (opggStatus.value = s))
+  )
 })
 </script>
 

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -25,7 +25,7 @@
             type="info"
             class="gaming-ai-btn"
             :loading="aiLoading"
-            :disabled="!sessionData.phase || sessionData.phase === 'ChampSelect'"
+            :disabled="!sessionData.phase"
             @click="handleAIAnalysis"
           >
             <template #icon>
@@ -33,7 +33,7 @@
             </template>
           </n-button>
         </template>
-        ✨ AI分析功能：点击可智能分析双方阵容和玩家战绩
+        ✨ AI分析功能：选人阶段分析阵容情报，对局中分析双方阵容和玩家战绩
       </n-tooltip>
 
       <n-modal v-model:show="showConfig" preset="card" title="显示设置" style="width: 400px">
@@ -49,7 +49,12 @@
       </n-modal>
 
       <!-- AI 分析结果弹窗 -->
-      <n-modal v-model:show="showAIResult" preset="card" title="AI 分析" style="width: 600px">
+      <n-modal
+        v-model:show="showAIResult"
+        preset="card"
+        :title="aiResultTitle"
+        style="width: 600px"
+      >
         <div class="ai-result-content ai-report" v-html="renderedAIResult"></div>
       </n-modal>
 
@@ -144,7 +149,11 @@ import { useMessage } from 'naive-ui'
 
 import LoadingComponent from '@renderer/components/LoadingComponent.vue'
 import SubteamCard from '@renderer/components/gaming/SubteamCard.vue'
-import { analyzeGameWithAIStream, type StreamCallbacks } from '@renderer/services/ai'
+import {
+  analyzeChampSelectWithAIStream,
+  analyzeGameWithAIStream,
+  type StreamCallbacks
+} from '@renderer/services/ai'
 import { renderAnalysisReport } from '@renderer/services/ai/matchDetail/renderReport'
 import { useSessionSync } from '@renderer/composables/useSessionSync'
 import { useSessionTiers } from '@renderer/composables/useSessionTiers'
@@ -224,6 +233,10 @@ const showAITooltip = ref(false)
 let hasShownAITip = false
 
 const renderedAIResult = computed(() => renderAnalysisReport(aiResult.value))
+/** 弹窗标题：选人期是「阵容分析」，对局中/赛后沿用旧的「AI 分析」 */
+const aiResultTitle = computed(() =>
+  sessionData.phase === 'ChampSelect' ? '选人期阵容分析' : 'AI 分析'
+)
 
 const handleUpdateConfig = async (value: number | null) => {
   if (!value) return
@@ -257,7 +270,11 @@ const handleAIAnalysis = async () => {
         aiLoading.value = false
       }
     }
-    await analyzeGameWithAIStream(sessionData, 'team', callbacks)
+    if (sessionData.phase === 'ChampSelect') {
+      await analyzeChampSelectWithAIStream(sessionData, opggMode.value, callbacks)
+    } else {
+      await analyzeGameWithAIStream(sessionData, 'team', callbacks)
+    }
   } catch (e: any) {
     message.error('AI 分析出错: ' + (e.message || '未知错误'))
     aiLoading.value = false

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -53,6 +53,14 @@
         <div class="ai-result-content ai-report" v-html="renderedAIResult"></div>
       </n-modal>
 
+      <div v-if="sessionData.phase === 'ChampSelect'" class="gaming-intel-banner">
+        选人中 · {{ sessionData.typeCn }}
+        <template v-if="opggStatus">
+          · OP.GG {{ opggStatus.patch
+          }}<span v-if="opggStatus.stale" class="banner-stale">（数据滞后）</span>
+        </template>
+      </div>
+
       <div class="gaming-grid" :class="{ 'gaming-grid-multi': sessionData.isMultiTeam }">
         <SubteamCard
           v-for="st of orderedSubteams"
@@ -65,6 +73,9 @@
           :queue-id="sessionData.queueId"
           :tiers-by-subteam="tiersBySubteam"
           :density="density"
+          :phase="sessionData.phase"
+          :opgg-mode="opggMode"
+          :my-champion-ids="myChampionIds"
         />
       </div>
     </div>
@@ -72,7 +83,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { SettingsOutline, SparklesOutline } from '@vicons/ionicons5'
 import { useMessage } from 'naive-ui'
@@ -83,6 +94,12 @@ import { analyzeGameWithAIStream, type StreamCallbacks } from '@renderer/service
 import { renderAnalysisReport } from '@renderer/services/ai/matchDetail/renderReport'
 import { useSessionSync } from '@renderer/composables/useSessionSync'
 import { useSessionTiers } from '@renderer/composables/useSessionTiers'
+import {
+  ensureOpggData,
+  getOpggStatus,
+  queueIdToOpggMode,
+  type OpggStatus
+} from '@renderer/services/opgg'
 
 const { sessionData, requestSessionData } = useSessionSync()
 const tiersBySubteam = useSessionTiers(sessionData)
@@ -101,6 +118,22 @@ const orderedSubteams = computed(() => {
     .sort((a, b) => a.subteamId - b.subteamId)
   return my ? [my, ...others] : others
 })
+
+/** 当前对局对应的 OP.GG 数据模式（ARAM 队列走 aram，其余走 ranked） */
+const opggMode = computed(() => queueIdToOpggMode(sessionData.queueId))
+
+/** 我方已亮出的英雄 id 列表（用于敌方情报卡的克制提示，过滤未选中的 0/负值） */
+const myChampionIds = computed(
+  () =>
+    orderedSubteams.value
+      .find(s => s.subteamId === sessionData.mySubteamId)
+      ?.players.map(p => p.championId)
+      .filter(id => id > 0) ?? []
+)
+
+/** OP.GG 数据状态（版本号/是否滞后），驱动选人期数据横幅 */
+const opggStatus = ref<OpggStatus | null>(null)
+watch(opggMode, m => getOpggStatus(m).then(s => (opggStatus.value = s)), { immediate: true })
 
 const showConfig = ref(false)
 const matchCount = ref(4)
@@ -175,6 +208,10 @@ onMounted(async () => {
       }, 5000)
     }, 2000)
   }
+
+  // OP.GG 数据兜底刷新：后端启动已预热，此处 fire-and-forget 兜底软件长开超 12h 未重启的场景
+  void ensureOpggData('ranked')
+  void ensureOpggData('aram')
 })
 </script>
 
@@ -208,6 +245,18 @@ onMounted(async () => {
 .gaming-config-hint {
   font-size: var(--font-size-sm);
   color: var(--text-tertiary);
+}
+
+.gaming-intel-banner {
+  text-align: center;
+  font-size: 12px;
+  opacity: 0.7;
+  margin-bottom: var(--space-8);
+}
+
+.banner-stale {
+  /* 品牌 token 名为 --semantic-loss（无对应 --semantic-lose 定义） */
+  color: var(--semantic-loss);
 }
 
 .ai-result-content {

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -54,11 +54,65 @@
       </n-modal>
 
       <div v-if="sessionData.phase === 'ChampSelect'" class="gaming-intel-banner">
-        选人中 · {{ sessionData.typeCn }}
-        <template v-if="opggStatus">
-          · OP.GG {{ opggStatus.patch
-          }}<span v-if="opggStatus.stale" class="banner-stale">（数据滞后）</span>
-        </template>
+        <div class="banner-main" :class="{ 'banner-main-split': champSelectStage }">
+          <!-- 阶段 stepper：预选/禁用/选人/确认，仅 stage 非空时展示；'' 时保留原有单行文案 -->
+          <div v-if="champSelectStage" class="stage-stepper">
+            <template v-for="(step, i) in STAGE_STEPS" :key="step.key">
+              <div
+                class="stage-step"
+                :class="{
+                  'stage-step-active': i === currentStageIndex,
+                  'stage-step-done': i < currentStageIndex
+                }"
+              >
+                <span class="stage-dot"></span>
+                <span class="stage-label">{{ step.label }}</span>
+              </div>
+              <span
+                v-if="i < STAGE_STEPS.length - 1"
+                class="stage-connector"
+                :class="{ 'stage-connector-done': i < currentStageIndex }"
+              ></span>
+            </template>
+          </div>
+          <div class="banner-meta">
+            选人中 · {{ sessionData.typeCn }}
+            <template v-if="opggStatus">
+              · OP.GG {{ opggStatus.patch
+              }}<span v-if="opggStatus.stale" class="banner-stale">（数据滞后）</span>
+            </template>
+          </div>
+        </div>
+
+        <!-- 双方 ban 条：位于 stepper 下、grid 上，任一方有 ban 才展示整块 -->
+        <div v-if="hasBans" class="ban-bar">
+          <div class="ban-group">
+            <span class="ban-group-label">我方禁用</span>
+            <div v-if="myBans.length > 0" class="ban-icons">
+              <img
+                v-for="id in myBans"
+                :key="`my-ban-${id}`"
+                class="ban-icon"
+                :src="getChampionUrl(id)"
+                :alt="`ban-${id}`"
+              />
+            </div>
+            <span v-else class="ban-group-empty">-</span>
+          </div>
+          <div class="ban-group">
+            <span class="ban-group-label">敌方禁用</span>
+            <div v-if="theirBans.length > 0" class="ban-icons">
+              <img
+                v-for="id in theirBans"
+                :key="`their-ban-${id}`"
+                class="ban-icon"
+                :src="getChampionUrl(id)"
+                :alt="`ban-${id}`"
+              />
+            </div>
+            <span v-else class="ban-group-empty">-</span>
+          </div>
+        </div>
       </div>
 
       <div class="gaming-grid" :class="{ 'gaming-grid-multi': sessionData.isMultiTeam }">
@@ -94,6 +148,7 @@ import { analyzeGameWithAIStream, type StreamCallbacks } from '@renderer/service
 import { renderAnalysisReport } from '@renderer/services/ai/matchDetail/renderReport'
 import { useSessionSync } from '@renderer/composables/useSessionSync'
 import { useSessionTiers } from '@renderer/composables/useSessionTiers'
+import { useAssetUrl } from '@renderer/composables/useAssetUrl'
 import {
   ensureOpggData,
   getOpggStatus,
@@ -101,8 +156,17 @@ import {
   type OpggStatus
 } from '@renderer/services/opgg'
 
+/** 选人阶段 stepper 的四步定义，顺序与展示文案固定 */
+const STAGE_STEPS: Array<{ key: string; label: string }> = [
+  { key: 'planning', label: '预选' },
+  { key: 'banning', label: '禁用' },
+  { key: 'picking', label: '选人' },
+  { key: 'finalization', label: '确认' }
+]
+
 const { sessionData, requestSessionData } = useSessionSync()
 const tiersBySubteam = useSessionTiers(sessionData)
+const { getChampionUrl } = useAssetUrl()
 
 const density = computed<'normal' | 'compact'>(() =>
   sessionData.isMultiTeam ? 'compact' : 'normal'
@@ -130,6 +194,18 @@ const myChampionIds = computed(
       ?.players.map(p => p.championId)
       .filter(id => id > 0) ?? []
 )
+
+/** 选人阶段结构化视图的 stage 字段（''=未知，驱动 stepper 是否展示） */
+const champSelectStage = computed(() => sessionData.champSelect?.stage ?? '')
+/** 当前 stage 在 STAGE_STEPS 中的下标，未匹配（如 '' 或非法值）时为 -1，stepper 各步均不高亮 */
+const currentStageIndex = computed(() =>
+  STAGE_STEPS.findIndex(s => s.key === champSelectStage.value)
+)
+/** 我方 / 敌方已 ban 英雄 id 列表，非选人期或无 ban 数据时为空数组 */
+const myBans = computed(() => sessionData.champSelect?.myBans ?? [])
+const theirBans = computed(() => sessionData.champSelect?.theirBans ?? [])
+/** 任一方存在 ban 记录才展示 ban 条整块 */
+const hasBans = computed(() => myBans.value.length > 0 || theirBans.value.length > 0)
 
 /** OP.GG 数据状态（版本号/是否滞后），驱动选人期数据横幅 */
 const opggStatus = ref<OpggStatus | null>(null)
@@ -250,15 +326,144 @@ onMounted(async () => {
 }
 
 .gaming-intel-banner {
+  margin-bottom: var(--space-8);
+}
+
+.banner-main {
   text-align: center;
   font-size: 12px;
   opacity: 0.7;
-  margin-bottom: var(--space-8);
+}
+
+/* stage 非空时：左 stepper、右数据源信息并排 */
+.banner-main-split {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-16);
+  text-align: left;
+}
+
+.banner-meta {
+  white-space: nowrap;
 }
 
 .banner-stale {
   /* 品牌 token 名为 --semantic-loss（无对应 --semantic-lose 定义） */
   color: var(--semantic-loss);
+}
+
+/* ---- 阶段 stepper：预选/禁用/选人/确认，当前步高亮，切换带 transition ---- */
+.stage-stepper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stage-step {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  transition: color var(--dur-normal) var(--ease-expo);
+}
+
+.stage-step-active {
+  color: var(--semantic-win);
+  font-weight: 600;
+}
+
+.stage-step-done {
+  color: var(--text-secondary, var(--text-tertiary));
+}
+
+.stage-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  transition:
+    background-color var(--dur-normal) var(--ease-expo),
+    box-shadow var(--dur-normal) var(--ease-expo);
+}
+
+.stage-step-active .stage-dot {
+  background: var(--semantic-win);
+  box-shadow: 0 0 6px 1px rgba(61, 155, 122, 0.55);
+}
+
+.stage-step-done .stage-dot {
+  background: var(--semantic-win);
+  opacity: 0.5;
+}
+
+.stage-connector {
+  width: 16px;
+  height: 1px;
+  background: var(--border-subtle);
+  transition: background-color var(--dur-normal) var(--ease-expo);
+}
+
+.stage-connector-done {
+  background: var(--semantic-win);
+  opacity: 0.5;
+}
+
+/* ---- 双方 ban 条：位于 stepper 下、grid 上 ---- */
+.ban-bar {
+  display: flex;
+  gap: var(--space-24);
+  margin-top: var(--space-8);
+  font-size: 12px;
+}
+
+.ban-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.ban-group-label {
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.ban-group-empty {
+  color: var(--text-tertiary);
+}
+
+.ban-icons {
+  display: flex;
+  gap: 4px;
+}
+
+.ban-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: cover;
+  filter: grayscale(1) brightness(0.7);
+  border: 1px solid rgba(196, 92, 92, 0.5);
+  /* 新 ban 弹入：仅在元素首次挂载时播放一次（列表增长时旧图标不会重新触发） */
+  animation: ban-pop 0.3s var(--ease-expo) both;
+}
+
+@keyframes ban-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ban-icon {
+    animation: none;
+  }
 }
 
 .ai-result-content {

--- a/lol-record-analysis-tauri/src/views/IntelDemo.vue
+++ b/lol-record-analysis-tauri/src/views/IntelDemo.vue
@@ -1,9 +1,38 @@
 <template>
   <div class="intel-demo">
     <div class="intel-demo-bar">
-      <span>情报卡动画演示（模拟征召选人：意向 → 选择中 → 锁定）</span>
+      <span>情报卡动画演示（模拟征召选人：禁用 → 意向 → 选择中 → 锁定）</span>
       <n-button size="small" @click="replay">重播</n-button>
     </div>
+
+    <!-- 假 ban 条：静态展示，验证图标弹入动画（scale .5→1 + fade） -->
+    <div class="intel-demo-bans">
+      <div class="ban-group">
+        <span class="ban-group-label">我方禁用</span>
+        <div class="ban-icons">
+          <img
+            v-for="id in DEMO_MY_BANS"
+            :key="`my-ban-${id}`"
+            class="ban-icon"
+            :src="getChampionUrl(id)"
+            :alt="`ban-${id}`"
+          />
+        </div>
+      </div>
+      <div class="ban-group">
+        <span class="ban-group-label">敌方禁用</span>
+        <div class="ban-icons">
+          <img
+            v-for="id in DEMO_THEIR_BANS"
+            :key="`their-ban-${id}`"
+            class="ban-icon"
+            :src="getChampionUrl(id)"
+            :alt="`ban-${id}`"
+          />
+        </div>
+      </div>
+    </div>
+
     <div class="intel-demo-grid" :key="round">
       <ChampionIntelCard
         v-for="(cell, i) in cells"
@@ -27,11 +56,17 @@
 import { onMounted, onUnmounted, reactive, ref } from 'vue'
 import { NButton } from 'naive-ui'
 import ChampionIntelCard from '@renderer/components/gaming/ChampionIntelCard.vue'
+import { useAssetUrl } from '@renderer/composables/useAssetUrl'
+
+const { getChampionUrl } = useAssetUrl()
 
 /** 模拟敌方五人（盖伦/阿狸/盲僧/女警/锤石） */
 const ENEMY = [86, 103, 64, 51, 412]
 /** 模拟我方已锁英雄（用于克制提示）：剑魔/佐伊/赵信/EZ/璐璐 */
 const MY_TEAM = [266, 142, 5, 81, 117]
+/** 假 ban 数据（静态，仅用于演示弹入动画）：我方禁塞特/男刀，敌方禁疾风剑豪/劫 */
+const DEMO_MY_BANS = [875, 92]
+const DEMO_THEIR_BANS = [157, 238]
 
 interface DemoCell {
   championId: number
@@ -49,7 +84,7 @@ function at(ms: number, fn: () => void) {
   timers.push(setTimeout(fn, ms))
 }
 
-/** 依次演出：每人 意向(亮英雄) → 选择中 → 锁定，节奏仿真实征召 */
+/** 依次演出：每人 禁用中(1.2s，未亮英雄) → 意向(亮英雄) → 选择中 → 锁定，节奏仿真实征召 */
 function play() {
   timers.forEach(clearTimeout)
   timers.length = 0
@@ -60,13 +95,16 @@ function play() {
   cells.forEach((cell, i) => {
     const base = 600 + i * 1600
     at(base, () => {
+      cell.state = 'banning'
+    })
+    at(base + 1200, () => {
       cell.shownChampionId = cell.championId
       cell.state = 'intent'
     })
-    at(base + 700, () => {
+    at(base + 1200 + 700, () => {
       cell.state = 'picking'
     })
-    at(base + 1500, () => {
+    at(base + 1200 + 1500, () => {
       cell.state = 'locked'
     })
   })
@@ -95,6 +133,49 @@ onUnmounted(() => timers.forEach(clearTimeout))
   margin-bottom: 16px;
   font-size: 13px;
   opacity: 0.85;
+}
+.intel-demo-bans {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 16px;
+  font-size: 12px;
+}
+.ban-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ban-group-label {
+  opacity: 0.6;
+  white-space: nowrap;
+}
+.ban-icons {
+  display: flex;
+  gap: 4px;
+}
+.ban-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: cover;
+  filter: grayscale(1) brightness(0.7);
+  border: 1px solid rgba(196, 92, 92, 0.5);
+  animation: ban-pop 0.3s var(--ease-expo) both;
+}
+@keyframes ban-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ban-icon {
+    animation: none;
+  }
 }
 .intel-demo-grid {
   display: flex;

--- a/lol-record-analysis-tauri/src/views/IntelDemo.vue
+++ b/lol-record-analysis-tauri/src/views/IntelDemo.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="intel-demo">
+    <div class="intel-demo-bar">
+      <span>情报卡动画演示（模拟征召选人：意向 → 选择中 → 锁定）</span>
+      <n-button size="small" @click="replay">重播</n-button>
+    </div>
+    <div class="intel-demo-grid" :key="round">
+      <ChampionIntelCard
+        v-for="(cell, i) in cells"
+        :key="`${round}-${i}`"
+        :champion-id="cell.shownChampionId"
+        :pick-state="cell.state"
+        mode="ranked"
+        :my-champion-ids="MY_TEAM"
+        density="normal"
+        :style="{ '--stagger-i': i }"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * 开发用演示页：不进真实对局即可预览 ChampionIntelCard 的
+ * 入场错峰与三态动画。仅通过 #/IntelDemo 直达，无导航入口。
+ */
+import { onMounted, onUnmounted, reactive, ref } from 'vue'
+import { NButton } from 'naive-ui'
+import ChampionIntelCard from '@renderer/components/gaming/ChampionIntelCard.vue'
+
+/** 模拟敌方五人（盖伦/阿狸/盲僧/女警/锤石） */
+const ENEMY = [86, 103, 64, 51, 412]
+/** 模拟我方已锁英雄（用于克制提示）：剑魔/佐伊/赵信/EZ/璐璐 */
+const MY_TEAM = [266, 142, 5, 81, 117]
+
+interface DemoCell {
+  championId: number
+  shownChampionId: number
+  state: string
+}
+
+const round = ref(0)
+const cells = reactive<DemoCell[]>(
+  ENEMY.map(id => ({ championId: id, shownChampionId: 0, state: 'none' }))
+)
+const timers: ReturnType<typeof setTimeout>[] = []
+
+function at(ms: number, fn: () => void) {
+  timers.push(setTimeout(fn, ms))
+}
+
+/** 依次演出：每人 意向(亮英雄) → 选择中 → 锁定，节奏仿真实征召 */
+function play() {
+  timers.forEach(clearTimeout)
+  timers.length = 0
+  cells.forEach(c => {
+    c.shownChampionId = 0
+    c.state = 'none'
+  })
+  cells.forEach((cell, i) => {
+    const base = 600 + i * 1600
+    at(base, () => {
+      cell.shownChampionId = cell.championId
+      cell.state = 'intent'
+    })
+    at(base + 700, () => {
+      cell.state = 'picking'
+    })
+    at(base + 1500, () => {
+      cell.state = 'locked'
+    })
+  })
+}
+
+function replay() {
+  round.value++
+  // key 变化触发整组重挂载，重播入场错峰
+  at(50, play)
+}
+
+onMounted(play)
+onUnmounted(() => timers.forEach(clearTimeout))
+</script>
+
+<style scoped>
+.intel-demo {
+  padding: 24px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+.intel-demo-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  font-size: 13px;
+  opacity: 0.85;
+}
+.intel-demo-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+</style>


### PR DESCRIPTION
## Summary
- 选人期不再丢弃敌方：theirTeam 填充（排位匿名仅英雄），敌方渲染「英雄情报卡」（OP.GG T级/胜率/克制提示）
- 选人阶段流抽象：planning/banning/picking/finalization 四步 stepper + 双方 ban 条（灰度图标弹入）
- 四态动画（意向呼吸/选择中脉冲/禁用中红脉冲/锁定定格）贯穿敌我双方卡片；悬停英雄（championPickIntent）即时显示；swap 视觉反馈；入场 stagger；动画已按用户反馈整体减重一轮
- 我方 PlayerCard 加 OPGG chip（T级+版本胜率，选人与对局中均展示）
- 选人期 ✨AI 解禁：「阵容分析」轻量 prompt 变体（OPGG 情报注入+反幻觉纪律条款+阶段语义）
- 隐藏演示页 #/IntelDemo（动画全流程可复播，无导航入口）
- 基于用户 6 轮真机走查迭代（选人顺序对齐客户端、绿框降噪、动画减重等均已吸收）

## Test plan
- [x] vitest 552 全绿；prettier/eslint/vue-tsc 干净
- [ ] cargo fmt/clippy/test：本机被 Windows 应用控制策略拦截（os error 4551），依赖 CI 验证
- [x] Manual: 真机排位/海斗多轮选人走查（渐进显示/动画/ban 条/stepper/AI 输出）