### PR TITLE
fix(ci): 修复发版 workflow 无法解析——删除 step 重复 env 块

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,16 @@
 name: Release Build
 
 on:
+  # 主路径：推送 v* tag 即发版（tag 名是唯一的版本真相源）
+  push:
+    tags: ['v*']
+  # 兜底：手动补发，必须显式填 version（无 tag 时的版本来源）
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version to release, e.g. v1.8.8 (required for manual run)'
+        required: false
+        default: ''
       notes:
         description: 'Release Notes (optional)'
         required: false
@@ -44,39 +52,48 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
-      # --- 核心步骤：智能获取版本号 ---
+      # --- 核心步骤：从 tag 解析版本号（tag 为唯一真相源）---
+      # tag 触发时用 tag 名；手动触发时用 workflow_dispatch 的 version 输入。
+      # 仓库里 tauri.conf.json 的 version 只是占位值，不参与这里的解析。
       - name: 🔍 Get App Version
         id: get_version
         shell: pwsh
         run: |
-          $configPath = "src-tauri/tauri.conf.json"
-          $configJson = Get-Content $configPath | Out-String | ConvertFrom-Json
-
-          # 适配 Tauri v1 package.version 和 Tauri v2 top-level version
-          if ($configJson.version) {
-              $tauriVersion = $configJson.version
-          } elseif ($configJson.package.version) {
-              $tauriVersion = $configJson.package.version
+          if ("${{ github.ref_type }}" -eq "tag") {
+              $tauriVersion = "${{ github.ref_name }}"
+          } else {
+              $tauriVersion = "${{ github.event.inputs.version }}"
           }
 
-          # 兜底：从 Cargo.toml 读
-          if ([string]::IsNullOrEmpty($tauriVersion)) {
-              $tomlPath = "src-tauri/Cargo.toml"
-              $tomlContent = Get-Content $tomlPath | Select-String -Pattern '^version\s*=\s*"(.+?)"'
-              if ($tomlContent) {
-                  $tauriVersion = $tomlContent.Matches[0].Groups[1].Value
-              } else {
-                  Write-Error "Could not find version in tauri.conf.json or Cargo.toml"
-                  exit 1
-              }
+          if ([string]::IsNullOrWhiteSpace($tauriVersion)) {
+              Write-Error "No version resolved. Push a tag like v1.8.8, or provide the 'version' input on manual run."
+              exit 1
           }
 
           # GitHub Release 惯例：tag 以 'v' 开头
           if ($tauriVersion -notlike 'v*') {
               $tauriVersion = "v$tauriVersion"
           }
-          Write-Host "Release Version: $tauriVersion"
+          $cleanVersion = $tauriVersion -replace '^v',''
+
+          Write-Host "Release Version: $tauriVersion (clean: $cleanVersion)"
           echo "tauri_version=$tauriVersion" >> $env:GITHUB_OUTPUT
+          echo "clean_version=$cleanVersion" >> $env:GITHUB_OUTPUT
+
+      # --- 把解析出的版本号写进 tauri.conf.json（仅 runner 工作区，不回写仓库）---
+      - name: 🔧 Sync version into tauri.conf.json
+        shell: bash
+        env:
+          CLEAN: ${{ steps.get_version.outputs.clean_version }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const f = "src-tauri/tauri.conf.json";
+            const j = JSON.parse(fs.readFileSync(f, "utf8"));
+            j.version = process.env.CLEAN;
+            fs.writeFileSync(f, JSON.stringify(j, null, 2) + "\n");
+            console.log("tauri.conf.json version set to " + j.version);
+          '
 
       # --- 构建并签名 ---
       - name: 🔨 Build Tauri App (Signed)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,7 @@ jobs:
           
           echo "setup_path=$setupPath" >> $env:GITHUB_OUTPUT
           echo "portable_path=$portablePath" >> $env:GITHUB_OUTPUT
-          echo "sig_path=$sigPath" >> $env:GITHUB_OUTPUT 
-        env:
-          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_KEY_PASSWORD }}
+          echo "sig_path=$sigPath" >> $env:GITHUB_OUTPUT
 
       - name: 🔍 Get Previous Tag
         id: get_prev_tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,23 @@ docs: 更新 README 中的安装说明
 - 保持更改尽可能小和专注
 - 响应审查意见
 
+## 🚀 发版流程
+
+版本号以 **git tag 为唯一真相源**，发一个版本只需推 tag：
+
+```bash
+git tag v1.8.8
+git push origin v1.8.8
+```
+
+推送 `v*` tag 会触发 `Release Build` workflow，自动完成构建、签名、生成 changelog、创建 GitHub Release 与 `latest.json`，并同步到 GitCode 国内镜像。
+
+约定：
+
+- `src-tauri/tauri.conf.json` 里的 `version` 是**占位值（`0.0.0`），不要手动改**。CI 会在构建时从 tag 名反推版本号写入（仅构建用，不回写仓库）。
+- tag 命名需匹配 `v*`，且符合 `.github/cliff.toml` 的 `tag_pattern = "v?[0-9].*"`（`beta`/`alpha` 会被 changelog 跳过）。
+- 需要手动补发时，可在 Actions 页手动运行 `Release Build` 并在 `version` 输入框填入版本号（如 `v1.8.8`）。
+
 ## 🔒 安全问题
 
 如果您发现安全漏洞，请不要公开报告。请直接联系项目维护者。

--- a/lol-record-analysis-tauri/src-tauri/tauri.conf.json
+++ b/lol-record-analysis-tauri/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "lol-record-analysis-app",
-  "version": "1.8.7",
+  "version": "0.0.0",
   "identifier": "com.lol-record-analysis-tauri.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- release workflow(release.yml)在 push tag 后 **0 秒即失败**,GitHub 提示 "workflow file issue" —— 文件解析失败,未进任何 job。
- 根因:`📝 Rename, Compress, and Set Paths` step 有**两个 `env:` 块**(`run:` 前后各一),YAML duplicate mapping key 使整个 workflow 非法。
- 第二个 env 块的密钥(`TAURI_PRIVATE_KEY` / `..._PASSWORD`)已被第一个块覆盖,属冗余,删除即可。
- 本分支还包含 tag 驱动发版的相关改动(34c1a53 等)。

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → YAML OK
- [ ] 手动触发 Release Build(workflow_dispatch)或推 `v*` tag,确认能正常进入 `build-and-release` job,不再 0 秒失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)