### PR TITLE
feat(ui): 对局/战绩页体验修复、浅色主题重做、滚轮缩放与版本趋势徽章

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,6 @@ wrangler.toml
 
 config.yaml
 opgg_cache_*.json
+patch_notes_cache.json
 
 app.log.*

--- a/lol-record-analysis-tauri/src-tauri/capabilities/default.json
+++ b/lol-record-analysis-tauri/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "core:webview:allow-create-webview-window",
+    "core:webview:allow-set-webview-zoom",
     "core:window:allow-create",
     "core:window:allow-minimize",
     "core:window:allow-maximize",

--- a/lol-record-analysis-tauri/src-tauri/src/command/fandom.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/fandom.rs
@@ -81,3 +81,46 @@ pub async fn get_aram_balance(
 ) -> Result<Option<AramBalanceData>, String> {
     Ok(state.fandom_cache.get(&id).await)
 }
+
+/// 查询英雄在指定版本的官方补丁改动（LoL Wiki `V{patch}` 页解析）。
+///
+/// # 参数
+///
+/// - `champion_id`: 英雄 ID（经 LCU 英雄缓存映射为英文 alias 再匹配 wiki 名）
+/// - `patch`: 版本号（如 "16.14"，前端从 OP.GG 状态取）
+///
+/// # 返回值
+///
+/// - `Ok(Some(ChampionPatchNote))`: 该英雄本版本有改动（方向 + 英文条目）
+/// - `Ok(None)`: 本版本无改动，或英雄缓存尚未就绪（未连接客户端时）
+///
+/// # 缓存策略
+///
+/// 快照按 patch 三级缓存（内存/磁盘/网络，TTL 24h），网络失败降级空快照，
+/// 不会因 wiki 不可达阻塞选人页。
+#[tauri::command]
+pub async fn get_champion_patch_note(
+    champion_id: i64,
+    patch: String,
+) -> Result<Option<crate::fandom::patch_notes::ChampionPatchNote>, String> {
+    use crate::fandom::patch_notes;
+
+    // 英雄 ID → LCU 英文 alias（如 91 → "Talon"）；缓存未就绪时静默返回 None
+    let alias = {
+        let cache = crate::lcu::api::asset::CHAMPION_CACHE
+            .read()
+            .map_err(|e| e.to_string())?;
+        match cache.get(&champion_id) {
+            Some(c) => c.alias.clone(),
+            None => return Ok(None),
+        }
+    };
+    let alias_key = patch_notes::normalize_champion_name(&alias);
+    let snapshot = patch_notes::get_or_fetch(&patch).await;
+    let hit = snapshot
+        .champions
+        .iter()
+        .find(|(wiki_key, _)| patch_notes::wiki_name_to_alias_key(wiki_key) == alias_key)
+        .map(|(_, note)| note.clone());
+    Ok(hit)
+}

--- a/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
@@ -264,6 +264,7 @@ mod tests {
             position: position.into(),
             tier: 1,
             rank: 1,
+            rank_prev_patch: 0,
             win_rate: 0.52,
             pick_rate: 0.1,
             ban_rate: 0.05,

--- a/lol-record-analysis-tauri/src-tauri/src/command/session.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/session.rs
@@ -169,7 +169,8 @@ pub struct SessionSummoner {
 ///
 /// # 字段说明
 ///
-/// - `name`: 队伍名称（如 "队伍1", "队伍2"）
+/// - `name`: 预组队组名（如 "队伍1", "队伍2"；与对局页两侧「队伍 1 / 队伍 2」列标题
+///   同词但含义不同——前端徽章上有 tooltip 说明这是预组队分组，跟敌我阵营无关）
 /// - `marker_type`: 标记类型（用于前端样式，如 "success", "warning", "error", "info"）
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]

--- a/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/user_tag_config.rs
@@ -879,18 +879,27 @@ pub fn get_default_tags() -> Vec<TagConfig> {
             good: false,
             enabled: true,
             is_default: true,
-            condition: TagCondition::History {
-                filters: vec![MatchFilter::Queue {
-                    ids: QUEUE_IDS
-                        .iter()
-                        .filter(|&id| *id != 420 && *id != 440)
-                        .cloned()
-                        .collect(),
-                }],
-                refresh: MatchRefresh::Count {
-                    op: Operator::Gt,
-                    value: 5.0,
-                },
+            // 排位专属：只在当前对局是单双排/灵活组排时展示。
+            // 乱斗等娱乐队列里「非排位场次多」几乎人人命中，标签沦为噪音
+            condition: TagCondition::And {
+                conditions: vec![
+                    TagCondition::CurrentQueue {
+                        ids: vec![QUEUE_SOLO_5X5, QUEUE_FLEX],
+                    },
+                    TagCondition::History {
+                        filters: vec![MatchFilter::Queue {
+                            ids: QUEUE_IDS
+                                .iter()
+                                .filter(|&id| *id != 420 && *id != 440)
+                                .cloned()
+                                .collect(),
+                        }],
+                        refresh: MatchRefresh::Count {
+                            op: Operator::Gt,
+                            value: 5.0,
+                        },
+                    },
+                ],
             },
         },
         TagConfig {
@@ -1125,6 +1134,45 @@ fn merge_missing_defaults(mut tags: Vec<TagConfig>) -> Vec<TagConfig> {
     tags
 }
 
+/// 条件树中是否已含 CurrentQueue 节点（用于迁移幂等判断）。
+fn condition_has_current_queue(c: &TagCondition) -> bool {
+    match c {
+        TagCondition::CurrentQueue { .. } => true,
+        TagCondition::And { conditions } | TagCondition::Or { conditions } => {
+            conditions.iter().any(condition_has_current_queue)
+        }
+        TagCondition::Not { condition } => condition_has_current_queue(condition),
+        _ => false,
+    }
+}
+
+/// 一次性迁移：「娱乐」标签补上排位专属门控。
+///
+/// 旧版条件只有 History（非排位场次多），在乱斗等娱乐队列里几乎人人命中、沦为噪音。
+/// 就地把原条件包进 `And[CurrentQueue(排位), 原条件]`——用户自调的阈值原样保留。
+/// 幂等：条件树里已有 CurrentQueue（无论是迁移过还是用户自己加的）则不动。
+///
+/// # 返回值
+/// 是否发生了迁移（调用方据此决定要不要落盘）
+fn migrate_casual_ranked_only(tags: &mut [TagConfig]) -> bool {
+    let mut changed = false;
+    for t in tags.iter_mut() {
+        if t.id == "default_casual" && !condition_has_current_queue(&t.condition) {
+            let inner = t.condition.clone();
+            t.condition = TagCondition::And {
+                conditions: vec![
+                    TagCondition::CurrentQueue {
+                        ids: vec![QUEUE_SOLO_5X5, QUEUE_FLEX],
+                    },
+                    inner,
+                ],
+            };
+            changed = true;
+        }
+    }
+    changed
+}
+
 /// 加载标签配置。
 ///
 /// 如果配置文件不存在，会自动创建默认配置；
@@ -1138,8 +1186,9 @@ pub async fn load_config() -> Vec<TagConfig> {
         Ok(val) => {
             let tags = config_value_to_tags(val);
             let before = tags.len();
-            let merged = merge_missing_defaults(tags);
-            if merged.len() != before {
+            let mut merged = merge_missing_defaults(tags);
+            let migrated = migrate_casual_ranked_only(&mut merged);
+            if merged.len() != before || migrated {
                 let _ = save_tag_configs(merged.clone()).await;
             }
             merged
@@ -1707,5 +1756,54 @@ mod tests {
         // 幂等：再 merge 不再增长
         let len = merged.len();
         assert_eq!(merge_missing_defaults(merged).len(), len);
+    }
+
+    /// 造一个旧版（无 CurrentQueue 门控）的「娱乐」标签配置
+    fn legacy_casual_tag() -> TagConfig {
+        TagConfig {
+            id: "default_casual".to_string(),
+            name: "娱乐".to_string(),
+            desc: "排位比例较少".to_string(),
+            good: false,
+            enabled: true,
+            is_default: true,
+            condition: TagCondition::History {
+                filters: vec![MatchFilter::Queue { ids: vec![450] }],
+                refresh: MatchRefresh::Count {
+                    op: Operator::Gt,
+                    value: 5.0,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn should_migrate_legacy_casual_to_ranked_only_once() {
+        let mut tags = vec![legacy_casual_tag()];
+        // 首次迁移：包上 CurrentQueue 门控
+        assert!(migrate_casual_ranked_only(&mut tags));
+        assert!(condition_has_current_queue(&tags[0].condition));
+        // 用户自调的 History 阈值保留在内层
+        if let TagCondition::And { conditions } = &tags[0].condition {
+            assert!(matches!(conditions[1], TagCondition::History { .. }));
+        } else {
+            panic!("expected And-wrapped condition");
+        }
+        // 幂等：已迁移过不再动
+        assert!(!migrate_casual_ranked_only(&mut tags));
+    }
+
+    #[test]
+    fn casual_tag_should_only_hit_in_ranked_lobby() {
+        let casual = get_default_tags()
+            .into_iter()
+            .find(|t| t.id == "default_casual")
+            .unwrap();
+        // 近 20 场大量非排位（450 ARAM）→ History 条件满足
+        let history = make_history((0..10).map(|_| make_game(1, true, 450)).collect());
+        // 当前在排位（420）→ 展示
+        assert!(casual.evaluate(&history, 420, None).is_some());
+        // 当前在乱斗等非排位队列 → 不展示
+        assert!(casual.evaluate(&history, 450, None).is_none());
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/fandom.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/fandom.rs
@@ -1,2 +1,3 @@
 pub mod api;
 pub mod data;
+pub mod patch_notes;

--- a/lol-record-analysis-tauri/src-tauri/src/fandom/patch_notes.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/fandom/patch_notes.rs
@@ -1,0 +1,479 @@
+//! 版本补丁英雄改动：拉取 LoL Wiki 的 `V{patch}` 页面 wikitext，
+//! 解析 `== Champions ==` 段落得到每个英雄的官方改动条目与整体方向。
+//!
+//! # 数据流
+//! 1. `get_or_fetch(patch)`：内存 → 磁盘 → 网络 三级取快照（补丁页发布后仍会被
+//!    编辑补充，TTL 取 24h）
+//! 2. `parse_patch_champions`：wikitext → 归一化英文名 → [`ChampionPatchNote`]
+//! 3. 方向分类为启发式（见 [`classify_line`]）：识别 `increased/reduced to X from Y`
+//!    句式 + 冷却/耗蓝类反向属性；无法判定时整体记 `Adjusted`，不硬猜
+//!
+//! # 已知限制
+//! - 条目文本为 wiki 英文原文（清洗掉标记），暂无本地化
+//! - wiki 页面结构变化会导致解析退化为空（有日志，不会 panic）
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// 快照有效期：24 小时（补丁页发布初期常有编辑补充）。
+pub const TTL_SECS: i64 = 24 * 60 * 60;
+
+/// 改动整体方向。
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ChangeDirection {
+    /// 全部条目判定为加强
+    Buff,
+    /// 全部条目判定为削弱
+    Nerf,
+    /// 混合改动或无法判定
+    Adjusted,
+}
+
+/// 单个英雄在某版本的改动。
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChampionPatchNote {
+    /// wiki 展示名（英文，如 "Aatrox"）
+    pub champion: String,
+    pub direction: ChangeDirection,
+    /// 清洗后的改动条目（英文原文）
+    pub lines: Vec<String>,
+}
+
+/// 一个版本的全部英雄改动快照。
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchNotesSnapshot {
+    /// 版本号（如 "16.14"）
+    pub patch: String,
+    /// 拉取时刻（Unix 秒）
+    pub fetched_at: i64,
+    /// 归一化英文名（见 [`normalize_champion_name`]）→ 改动
+    pub champions: HashMap<String, ChampionPatchNote>,
+}
+
+/// 归一化英雄名：小写 + 仅保留字母数字。
+///
+/// 让 wiki 展示名（"Kai'Sa" / "Miss Fortune"）与 LCU alias（"Kaisa" / "MissFortune"）
+/// 落到同一键空间。个别展示名与 alias 完全不同的走 [`wiki_name_to_alias_key`] 特例表。
+pub fn normalize_champion_name(name: &str) -> String {
+    name.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+/// wiki 展示名（归一化后）→ LCU alias（归一化后）的特例映射。
+///
+/// 仅收录归一化后仍对不上的名字；其余靠 normalize 天然一致。
+pub fn wiki_name_to_alias_key(normalized_wiki: &str) -> &str {
+    match normalized_wiki {
+        "wukong" => "monkeyking",
+        "nunuwillump" => "nunu",
+        "renataglasc" => "renata",
+        other => other,
+    }
+}
+
+/// 冷却/消耗类「越低越好」的反向属性关键词（出现即反转加强/削弱判定）。
+const INVERTED_STAT_WORDS: [&str; 7] = [
+    "cooldown",
+    "cost",
+    "cast time",
+    "delay",
+    "recharge time",
+    "channel time",
+    "windup",
+];
+
+/// 判定单条改动方向。
+///
+/// # 返回值
+/// - `Some(true)` 加强 / `Some(false)` 削弱 / `None` 无法判定（新效果、重做等）
+pub fn classify_line(line: &str) -> Option<bool> {
+    let l = line.to_ascii_lowercase();
+    let up = l.contains("increased") || l.contains("increase");
+    let down = l.contains("decreased")
+        || l.contains("reduced")
+        || l.contains("lowered")
+        || l.contains("decrease");
+    if up == down {
+        // 同现或都没有：句式无法判定
+        return None;
+    }
+    let inverted = INVERTED_STAT_WORDS.iter().any(|w| l.contains(w));
+    Some(if inverted { down } else { up })
+}
+
+/// 按条目集合聚合整体方向。
+fn aggregate_direction(lines: &[String]) -> ChangeDirection {
+    let mut buffs = 0;
+    let mut nerfs = 0;
+    for line in lines {
+        match classify_line(line) {
+            Some(true) => buffs += 1,
+            Some(false) => nerfs += 1,
+            None => {}
+        }
+    }
+    match (buffs, nerfs) {
+        (b, 0) if b > 0 => ChangeDirection::Buff,
+        (0, n) if n > 0 => ChangeDirection::Nerf,
+        _ => ChangeDirection::Adjusted,
+    }
+}
+
+/// 去除 wikitext 行内标记：模板、内链、加粗斜体。
+///
+/// 模板处理策略：`{{ai|技能名|英雄}}` / `{{ci|英雄}}` 等取第一个参数（即人眼要看的
+/// 文本），未知模板整体丢弃——宁缺勿乱。嵌套模板做一层展开即可满足补丁页实际结构。
+pub fn strip_wiki_markup(raw: &str) -> String {
+    let mut s = raw.to_string();
+    // 模板：最多迭代几轮处理一层嵌套
+    for _ in 0..3 {
+        let Some(start) = s.find("{{") else { break };
+        let Some(rel_end) = s[start..].find("}}") else {
+            break;
+        };
+        let end = start + rel_end + 2;
+        let inner = &s[start + 2..end - 2];
+        let mut parts = inner.split('|');
+        let name = parts.next().unwrap_or("").trim().to_ascii_lowercase();
+        let keep = matches!(
+            name.as_str(),
+            "ai" | "ci" | "cai" | "ii" | "si" | "sti" | "tip" | "pp" | "as" | "ap" | "ad"
+        );
+        let replacement = if keep {
+            parts.next().unwrap_or("").trim().to_string()
+        } else {
+            String::new()
+        };
+        s.replace_range(start..end, &replacement);
+    }
+    // 内链 [[a|b]] → b、[[a]] → a
+    while let (Some(start), Some(rel_end)) = (s.find("[["), s.find("]]")) {
+        if rel_end < start {
+            break;
+        }
+        let inner = s[start + 2..rel_end].to_string();
+        let text = inner.rsplit('|').next().unwrap_or("").trim().to_string();
+        s.replace_range(start..rel_end + 2, &text);
+    }
+    s.replace("'''", "").replace("''", "").trim().to_string()
+}
+
+/// 从 `=== 标题 ===` 行提取英雄名。
+fn heading_champion_name(line: &str) -> Option<String> {
+    let inner = line.trim().trim_matches('=').trim();
+    let name = strip_wiki_markup(inner);
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+/// 解析补丁页 wikitext 的 Champions 段。
+///
+/// # 返回值
+/// 归一化英文名 → [`ChampionPatchNote`]；页面无 Champions 段返回空表
+pub fn parse_patch_champions(wikitext: &str) -> HashMap<String, ChampionPatchNote> {
+    let mut result = HashMap::new();
+    let mut in_champions = false;
+    let mut current: Option<(String, Vec<String>)> = None;
+
+    let flush = |current: &mut Option<(String, Vec<String>)>,
+                 result: &mut HashMap<String, ChampionPatchNote>| {
+        if let Some((name, lines)) = current.take() {
+            if !lines.is_empty() {
+                result.insert(
+                    normalize_champion_name(&name),
+                    ChampionPatchNote {
+                        champion: name,
+                        direction: aggregate_direction(&lines),
+                        lines,
+                    },
+                );
+            }
+        }
+    };
+
+    for line in wikitext.lines() {
+        let trimmed = line.trim();
+        // 二级标题：进入/离开 Champions 段
+        if trimmed.starts_with("==") && !trimmed.starts_with("===") {
+            flush(&mut current, &mut result);
+            let title = trimmed.trim_matches('=').trim().to_ascii_lowercase();
+            in_champions = title == "champions";
+            continue;
+        }
+        if !in_champions {
+            continue;
+        }
+        if trimmed.starts_with("===") {
+            flush(&mut current, &mut result);
+            current = heading_champion_name(trimmed).map(|n| (n, Vec::new()));
+            continue;
+        }
+        if let Some((_, lines)) = current.as_mut() {
+            if let Some(item) = trimmed.strip_prefix('*') {
+                let text = strip_wiki_markup(item.trim_start_matches('*').trim());
+                if !text.is_empty() {
+                    lines.push(text);
+                }
+            }
+        }
+    }
+    flush(&mut current, &mut result);
+    result
+}
+
+/// 磁盘缓存路径（工作目录相对，与 opgg 缓存同约定；单文件存最近一个 patch）。
+pub fn default_path() -> PathBuf {
+    PathBuf::from("patch_notes_cache.json")
+}
+
+/// 快照是否命中给定 patch 且未过期。
+pub fn is_valid(snapshot: &PatchNotesSnapshot, patch: &str, now: i64) -> bool {
+    snapshot.patch == patch && now - snapshot.fetched_at < TTL_SECS
+}
+
+/// 从磁盘读取快照；缺失/损坏返回 None。
+pub fn load_from_path(path: &Path) -> Option<PatchNotesSnapshot> {
+    let content = std::fs::read_to_string(path).ok()?;
+    match serde_json::from_str(&content) {
+        Ok(snap) => Some(snap),
+        Err(e) => {
+            log::warn!("patch notes cache corrupt at {}: {}", path.display(), e);
+            None
+        }
+    }
+}
+
+/// 快照写盘（失败仅告警，不阻塞主流程）。
+pub fn save_to_path(snapshot: &PatchNotesSnapshot, path: &Path) {
+    match serde_json::to_string(snapshot) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(path, json) {
+                log::warn!("patch notes cache write {}: {}", path.display(), e);
+            }
+        }
+        Err(e) => log::warn!("patch notes cache serialize: {}", e),
+    }
+}
+
+/// 拉取 `V{patch}` 页 wikitext；页面不存在返回 `Ok(None)`。
+async fn fetch_patch_wikitext(
+    patch: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let url = format!(
+        "https://leagueoflegends.fandom.com/api.php?action=query&format=json&prop=revisions&titles=V{}&rvprop=content&rvslots=main",
+        patch
+    );
+    let client = reqwest::Client::builder()
+        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+        .build()?;
+    log::info!("Fetching patch notes: {}", url);
+    // 尽量贴近真实浏览器请求头：Fandom 前面有 Cloudflare，请求特征太"裸"容易吃挑战页
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json, text/plain, */*")
+        .header("Accept-Language", "en-US,en;q=0.9")
+        .header("Referer", "https://leagueoflegends.fandom.com/")
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    let pages = resp
+        .get("query")
+        .and_then(|q| q.get("pages"))
+        .and_then(|p| p.as_object())
+        .ok_or("no pages in response")?;
+    let page = pages.values().next().ok_or("empty pages")?;
+    if page.get("missing").is_some() {
+        return Ok(None);
+    }
+    let content = page
+        .get("revisions")
+        .and_then(|r| r.get(0))
+        .and_then(|r| r.get("slots"))
+        .and_then(|s| s.get("main"))
+        .and_then(|m| m.get("*"))
+        .and_then(|c| c.as_str())
+        .ok_or("no content in revision")?;
+    Ok(Some(content.to_string()))
+}
+
+/// 内存缓存 + 单飞锁：同一时间只有一个网络拉取。
+static SNAPSHOT: tokio::sync::Mutex<Option<Arc<PatchNotesSnapshot>>> =
+    tokio::sync::Mutex::const_new(None);
+
+/// 取指定 patch 的快照：内存 → 磁盘 → 网络。
+///
+/// 网络失败时若有同 patch 的过期缓存则降级使用；完全失败返回空快照（负缓存，
+/// 由内存持有避免每次选人反复打请求）。
+pub async fn get_or_fetch(patch: &str) -> Arc<PatchNotesSnapshot> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let mut guard = SNAPSHOT.lock().await;
+
+    if let Some(snap) = guard.as_ref() {
+        if is_valid(snap, patch, now) {
+            return snap.clone();
+        }
+    }
+    if let Some(disk) = load_from_path(&default_path()) {
+        if is_valid(&disk, patch, now) {
+            let arc = Arc::new(disk);
+            *guard = Some(arc.clone());
+            return arc;
+        }
+    }
+
+    let snapshot = match fetch_patch_wikitext(patch).await {
+        Ok(Some(wikitext)) => {
+            let champions = parse_patch_champions(&wikitext);
+            log::info!(
+                "patch notes V{}: parsed {} champions",
+                patch,
+                champions.len()
+            );
+            PatchNotesSnapshot {
+                patch: patch.to_string(),
+                fetched_at: now,
+                champions,
+            }
+        }
+        Ok(None) => {
+            log::warn!("patch notes page V{} missing", patch);
+            PatchNotesSnapshot {
+                patch: patch.to_string(),
+                fetched_at: now,
+                champions: HashMap::new(),
+            }
+        }
+        Err(e) => {
+            log::warn!("patch notes fetch V{} failed: {}", patch, e);
+            // 降级：同 patch 过期缓存仍可用
+            if let Some(stale) = load_from_path(&default_path()).filter(|s| s.patch == patch) {
+                let arc = Arc::new(stale);
+                *guard = Some(arc.clone());
+                return arc;
+            }
+            // 拉取失败只做内存负缓存（本次会话不再重试），不写盘——
+            // 否则一次瞬时网络故障会把空快照钉死 24h
+            let arc = Arc::new(PatchNotesSnapshot {
+                patch: patch.to_string(),
+                fetched_at: now,
+                champions: HashMap::new(),
+            });
+            *guard = Some(arc.clone());
+            return arc;
+        }
+    };
+    save_to_path(&snapshot, &default_path());
+    let arc = Arc::new(snapshot);
+    *guard = Some(arc.clone());
+    arc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"
+== Items ==
+=== [[Infinity Edge]] ===
+* Damage increased.
+== Champions ==
+=== {{ci|Aatrox}} ===
+* {{ai|The Darkin Blade|Aatrox}}
+** Damage increased to 70 from 60.
+** Cooldown reduced to 12 seconds from 14.
+=== {{ci|Miss Fortune}} ===
+* Base stats
+** Base armor reduced to 28 from 30.
+=== {{ci|Wukong}} ===
+* {{ai|Cyclone|Wukong}}
+** New Effect: Now knocks up enemies twice.
+== Runes ==
+=== Lethal Tempo ===
+* Attack speed reduced.
+"#;
+
+    #[test]
+    fn should_parse_champions_section_only() {
+        let map = parse_patch_champions(FIXTURE);
+        assert_eq!(map.len(), 3);
+        assert!(map.contains_key("aatrox"));
+        assert!(map.contains_key("missfortune"));
+        assert!(map.contains_key("wukong"));
+        // Items/Runes 段不进结果
+        assert!(!map.contains_key("infinityedge"));
+        assert!(!map.contains_key("lethaltempo"));
+    }
+
+    #[test]
+    fn should_aggregate_direction_per_champion() {
+        let map = parse_patch_champions(FIXTURE);
+        // 伤害提高 + 冷却降低 → 全加强
+        assert_eq!(map["aatrox"].direction, ChangeDirection::Buff);
+        // 护甲降低 → 削弱
+        assert_eq!(map["missfortune"].direction, ChangeDirection::Nerf);
+        // 新效果无法判定 → 调整
+        assert_eq!(map["wukong"].direction, ChangeDirection::Adjusted);
+    }
+
+    #[test]
+    fn should_strip_wiki_markup_in_lines() {
+        let map = parse_patch_champions(FIXTURE);
+        let lines = &map["aatrox"].lines;
+        assert_eq!(lines[0], "The Darkin Blade");
+        assert_eq!(lines[1], "Damage increased to 70 from 60.");
+    }
+
+    #[test]
+    fn classify_should_invert_cooldown_like_stats() {
+        assert_eq!(classify_line("Damage increased to 70 from 60."), Some(true));
+        assert_eq!(
+            classify_line("Base armor reduced to 28 from 30."),
+            Some(false)
+        );
+        assert_eq!(
+            classify_line("Cooldown reduced to 12 seconds from 14."),
+            Some(true)
+        );
+        assert_eq!(
+            classify_line("Mana cost increased to 60 from 40."),
+            Some(false)
+        );
+        assert_eq!(classify_line("New Effect: Now knocks up twice."), None);
+    }
+
+    #[test]
+    fn should_map_wiki_special_names_to_alias_keys() {
+        assert_eq!(wiki_name_to_alias_key("wukong"), "monkeyking");
+        assert_eq!(wiki_name_to_alias_key("nunuwillump"), "nunu");
+        assert_eq!(wiki_name_to_alias_key("renataglasc"), "renata");
+        assert_eq!(wiki_name_to_alias_key("aatrox"), "aatrox");
+        assert_eq!(normalize_champion_name("Kai'Sa"), "kaisa");
+        assert_eq!(normalize_champion_name("Miss Fortune"), "missfortune");
+    }
+
+    #[test]
+    fn snapshot_validity_should_check_patch_and_ttl() {
+        let snap = PatchNotesSnapshot {
+            patch: "16.14".into(),
+            fetched_at: 1_000,
+            champions: HashMap::new(),
+        };
+        assert!(is_valid(&snap, "16.14", 1_000 + TTL_SECS - 1));
+        assert!(!is_valid(&snap, "16.14", 1_000 + TTL_SECS));
+        assert!(!is_valid(&snap, "16.15", 1_000));
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -147,6 +147,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::session::get_session_data,
             command::fandom::update_fandom_data,
             command::fandom::get_aram_balance,
+            command::fandom::get_champion_patch_note,
             command::opgg::update_opgg_data,
             command::opgg::get_champion_meta,
             command::opgg::get_lane_counters,

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
@@ -46,6 +46,8 @@ struct RawStats {
 struct RawTierData {
     tier: Option<i32>,
     rank: Option<i32>,
+    /// 上一 patch 的排名（OP.GG 白送的跨版本趋势，驱动「版本走强/走弱」徽章）
+    rank_prev_patch: Option<i32>,
 }
 
 #[derive(Deserialize)]
@@ -154,6 +156,7 @@ pub fn parse_snapshot(mode: &str, body: &str, fetched_at: i64) -> Result<OpggSna
                         position: position.clone(),
                         tier: tier_data.and_then(|t| t.tier).or(stats.tier).unwrap_or(0),
                         rank: tier_data.and_then(|t| t.rank).or(stats.rank).unwrap_or(0),
+                        rank_prev_patch: tier_data.and_then(|t| t.rank_prev_patch).unwrap_or(0),
                         win_rate: stats.win_rate.unwrap_or(0.0),
                         pick_rate: stats.pick_rate.unwrap_or(0.0),
                         ban_rate: stats.ban_rate.unwrap_or(0.0),
@@ -185,6 +188,11 @@ pub fn parse_snapshot(mode: &str, body: &str, fetched_at: i64) -> Result<OpggSna
                     position: String::new(),
                     tier: stats.tier.unwrap_or(0),
                     rank: stats.rank.unwrap_or(0),
+                    rank_prev_patch: stats
+                        .tier_data
+                        .as_ref()
+                        .and_then(|t| t.rank_prev_patch)
+                        .unwrap_or(0),
                     win_rate: stats.win_rate.unwrap_or(0.0),
                     pick_rate: stats.pick_rate.unwrap_or(0.0),
                     ban_rate: stats.ban_rate.unwrap_or(0.0),
@@ -227,6 +235,8 @@ mod tests {
         assert_eq!(garen.len(), 1);
         assert_eq!(garen[0].position, "TOP");
         assert_eq!(garen[0].tier, 1);
+        // 跨版本趋势字段：来自 tier_data.rank_prev_patch
+        assert_eq!(garen[0].rank_prev_patch, 1);
         assert!((garen[0].win_rate - 0.517991).abs() < 1e-6);
         assert!(garen[0].is_main_position);
 

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/data.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/data.rs
@@ -18,6 +18,9 @@ pub struct ChampionMeta {
     pub tier: i32,
     /// 同分路排名（无数据为 0）
     pub rank: i32,
+    /// 上一 patch 的同分路排名（无数据为 0；serde 默认兼容旧磁盘缓存）
+    #[serde(default)]
+    pub rank_prev_patch: i32,
     /// 胜率（0~1）
     pub win_rate: f64,
     /// 登场率（0~1）

--- a/lol-record-analysis-tauri/src/components/Framework.vue
+++ b/lol-record-analysis-tauri/src/components/Framework.vue
@@ -51,6 +51,7 @@ import ErrorReportingConsentDialog from '@renderer/components/common/ErrorReport
 import CloudSyncNoticeDialog from '@renderer/components/common/CloudSyncNoticeDialog.vue'
 import CloudConfigPullDialog from './common/CloudConfigPullDialog.vue'
 import { useGameState } from '@renderer/composables/useGameState'
+import { useZoom } from '@renderer/composables/useZoom'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { CONFIG_KEYS } from '@renderer/services/configKeys'
 import { useCloudSyncStore } from '@renderer/pinia/cloudSync'
@@ -93,6 +94,9 @@ const isStandaloneDetailWindow = computed(() => currentWindow.label.startsWith('
  * 包含自动跳转逻辑：当检测到游戏开始时自动切换到对局页面
  */
 const { isConnected } = useGameState()
+
+// 浏览器式缩放（Ctrl+滚轮 / Ctrl±0）：Framework 是所有窗口的根，详情窗一并生效
+useZoom()
 
 const message = useMessage()
 

--- a/lol-record-analysis-tauri/src/components/Header.vue
+++ b/lol-record-analysis-tauri/src/components/Header.vue
@@ -9,7 +9,7 @@
         class="input-lolid header-search"
         type="text"
         size="small"
-        placeholder="输入召唤师"
+        placeholder="召唤师名#Tag"
         v-model:value="searchValue"
         @keyup.enter="onClinkSearch"
       >
@@ -254,12 +254,13 @@ const closeWindow = (): void => {
 }
 </script>
 <style lang="css" scoped>
+/* 不加 backdrop-filter：顶栏底色近实色，模糊毫无视觉贡献；且透明窗口
+   （tauri transparent:true）+ backdrop-filter 会诱发 WebView2 合成层
+   冻结——运行时切主题后顶栏卡死在旧主题配色，整页刷新才恢复 */
 .header-inner {
   width: 100%;
   height: 100%;
   align-items: center;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
 }
 
 .header-left {

--- a/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/ChampionIntelCard.vue
@@ -31,6 +31,7 @@
           <span class="intel-winrate" :class="winRateClass">{{
             formatWinRate(meta?.winRate)
           }}</span>
+          <PatchNoteBadge :champion-id="championId" :mode="mode" />
         </div>
         <div class="intel-row intel-sub">
           <span v-if="pickState === 'intent'" class="intel-state-tag">意向</span>
@@ -61,6 +62,7 @@ import { getChampionName, loadChampionNames } from '@renderer/services/ai/champi
 import { getChampionMeta, getLaneCounters, findCounterHints } from '@renderer/services/opgg'
 import type { ChampionMeta, CounterHint, OpggMode } from '@renderer/services/opgg'
 import { pickStateClass, tierBadge, formatWinRate, isChampionSwap } from './championIntel'
+import PatchNoteBadge from './PatchNoteBadge.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -344,26 +346,26 @@ watch(
   }
 }
 
-/* 禁用中：红色粗边框 + 外扩 ring 呼吸（威胁感），类比 intel-picking 但复用
-   --semantic-loss 色系，与「选择中」形成正/负两极的视觉对比 */
+/* 禁用中：ban 阶段全队（含对面 5 个占位）同时点亮，红色必须克制——
+   1px 半透明边框 + 慢速微呼吸，仅提示状态；威胁感交给文案「禁用中…」 */
 .intel-banning {
-  border: 2px solid var(--semantic-loss, #d03050);
-  background: rgba(208, 48, 80, 0.06);
+  border: 1px solid color-mix(in srgb, var(--semantic-loss, #d03050) 45%, transparent);
+  background: rgba(208, 48, 80, 0.04);
   animation:
     intel-enter 0.32s var(--ease-expo) both,
-    intel-ban-pulse 1.1s ease-in-out infinite;
+    intel-ban-pulse 2s ease-in-out infinite;
   animation-delay: calc(55ms * var(--stagger-i, 0)), 0s;
 }
 .intel-banning .intel-avatar {
-  border-color: var(--semantic-loss, #d03050);
+  border-color: color-mix(in srgb, var(--semantic-loss, #d03050) 55%, transparent);
 }
 @keyframes intel-ban-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(208, 48, 80, 0.1);
+    box-shadow: 0 0 0 0 rgba(208, 48, 80, 0.08);
   }
   50% {
-    box-shadow: 0 0 0 3px rgba(208, 48, 80, 0.1);
+    box-shadow: 0 0 0 2px rgba(208, 48, 80, 0.08);
   }
 }
 

--- a/lol-record-analysis-tauri/src/components/gaming/PatchNoteBadge.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PatchNoteBadge.vue
@@ -1,0 +1,161 @@
+<!-- 版本趋势/补丁改动徽章（双数据源）：
+     1. 保底：OP.GG 跨版本排名变化（国内网络常年可用）——「版本走强/走弱」
+     2. 增强：LoL Wiki 官方补丁条目（网络可达时）——方向改为官方改动判定，
+        popover 追加改动明细
+     两者都无 → 不渲染（零占位）。 -->
+<template>
+  <n-popover v-if="display" trigger="hover" placement="top" :style="{ maxWidth: '340px' }">
+    <template #trigger>
+      <span class="patch-badge" :class="`patch-badge-${display.kind}`">
+        {{ display.label }}
+      </span>
+    </template>
+    <div class="patch-pop">
+      <div class="patch-pop-title">{{ display.title }}</div>
+      <div v-if="display.trendText" class="patch-pop-trend">{{ display.trendText }}</div>
+      <ul v-if="note?.lines.length" class="patch-pop-lines">
+        <li v-for="(line, i) in note.lines" :key="i">{{ line }}</li>
+      </ul>
+    </div>
+  </n-popover>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { NPopover } from 'naive-ui'
+import {
+  getChampionPatchNote,
+  getCurrentPatch,
+  type ChampionPatchNote
+} from '@renderer/services/patchNotes'
+import { getChampionMeta, type ChampionMeta, type OpggMode } from '@renderer/services/opgg'
+
+const props = withDefaults(
+  defineProps<{
+    championId: number
+    /** OP.GG 模式（趋势保底数据源用），默认 ranked */
+    mode?: OpggMode
+  }>(),
+  { mode: 'ranked' }
+)
+
+/** 排名变动超过该幅度才视为「版本走强/走弱」（同分路约 60~160 个英雄） */
+const RANK_DELTA_THRESHOLD = 10
+
+const note = ref<ChampionPatchNote | null>(null)
+const meta = ref<ChampionMeta | null>(null)
+const patch = ref('')
+
+async function load() {
+  const id = props.championId
+  if (!id || id <= 0) {
+    note.value = null
+    meta.value = null
+    return
+  }
+  const [n, m, p] = await Promise.all([
+    getChampionPatchNote(id),
+    getChampionMeta(props.mode, id),
+    getCurrentPatch()
+  ])
+  // 防竞态：选人期换英雄时丢弃过期结果
+  if (id === props.championId) {
+    note.value = n
+    meta.value = m
+    patch.value = p ?? ''
+  }
+}
+
+watch(() => props.championId, load)
+onMounted(load)
+
+/** OP.GG 排名变动：负数 = 排名上升（走强） */
+const rankDelta = computed(() => {
+  const m = meta.value
+  if (!m || !m.rank || !m.rankPrevPatch) return 0
+  return m.rank - m.rankPrevPatch
+})
+
+interface DisplayState {
+  kind: 'buff' | 'nerf' | 'adjusted'
+  label: string
+  title: string
+  trendText: string
+}
+
+const display = computed<DisplayState | null>(() => {
+  const v = patch.value ? `V${patch.value}` : '本版本'
+  const trendText =
+    rankDelta.value !== 0 && meta.value
+      ? `OP.GG 排名 ${meta.value.rankPrevPatch} → ${meta.value.rank}（较上版本）`
+      : ''
+
+  // 官方补丁条目优先：方向可信度更高，popover 带明细
+  if (note.value) {
+    const kind = note.value.direction
+    const label = kind === 'buff' ? '版本↑' : kind === 'nerf' ? '版本↓' : '版本改动'
+    return { kind, label, title: `${v} · ${note.value.champion} · 官方改动`, trendText }
+  }
+
+  // 保底：OP.GG 跨版本排名趋势
+  if (Math.abs(rankDelta.value) >= RANK_DELTA_THRESHOLD) {
+    const stronger = rankDelta.value < 0
+    return {
+      kind: stronger ? 'buff' : 'nerf',
+      label: stronger ? '版本走强' : '版本走弱',
+      title: `${v} · 强度趋势`,
+      trendText
+    }
+  }
+  return null
+})
+</script>
+
+<style scoped>
+.patch-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-4);
+  height: 16px;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  cursor: default;
+}
+
+.patch-badge-buff {
+  color: var(--semantic-win);
+  background: color-mix(in srgb, var(--semantic-win) 14%, transparent);
+}
+
+.patch-badge-nerf {
+  color: var(--semantic-loss);
+  background: color-mix(in srgb, var(--semantic-loss) 12%, transparent);
+}
+
+.patch-badge-adjusted {
+  color: var(--semantic-warn);
+  background: color-mix(in srgb, var(--semantic-warn) 14%, transparent);
+}
+
+.patch-pop-title {
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--space-4);
+}
+
+.patch-pop-trend {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-4);
+}
+
+.patch-pop-lines {
+  margin: 0;
+  padding-left: var(--space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -73,6 +73,9 @@
                     {{ sessionSummoner?.summoner.gameName }}
                   </n-ellipsis>
                 </n-button>
+                <n-tag v-if="isSelf" size="small" type="success" round :bordered="false">
+                  我
+                </n-tag>
                 <n-button
                   text
                   size="tiny"
@@ -102,17 +105,23 @@
                   <span class="tier-text">{{ tierCn }}</span>
                 </n-flex>
                 <!-- 当前英雄的 OP.GG T 级/胜率 chip：opggMode 未传或无数据时不渲染（无占位） -->
-                <span v-if="opggMeta" class="opgg-chip">
-                  <span
-                    v-if="opggBadge.label"
-                    class="opgg-chip-tier"
-                    :style="{ color: opggBadge.color, backgroundColor: opggBadge.bg }"
-                    >{{ opggBadge.label }}</span
-                  >
-                  <span class="opgg-chip-rate" :class="opggWinRateClass">{{
-                    formatWinRate(opggMeta.winRate)
-                  }}</span>
-                </span>
+                <n-tooltip v-if="opggMeta" trigger="hover">
+                  <template #trigger>
+                    <span class="opgg-chip">
+                      <span
+                        v-if="opggBadge.label"
+                        class="opgg-chip-tier"
+                        :style="{ color: opggBadge.color, backgroundColor: opggBadge.bg }"
+                        >{{ opggBadge.label }}</span
+                      >
+                      <span class="opgg-chip-rate" :class="opggWinRateClass">{{
+                        formatWinRate(opggMeta.winRate)
+                      }}</span>
+                    </span>
+                  </template>
+                  OP.GG：该英雄在当前模式的梯度与全球胜率（非玩家个人胜率）
+                </n-tooltip>
+                <PatchNoteBadge :champion-id="sessionSummoner.championId" :mode="opggMode" />
                 <!-- ARAM Balance Status -->
                 <n-popover
                   v-if="balanceTags.length > 0 && isAramMode"
@@ -146,16 +155,17 @@
             </div>
 
             <div class="profile-tags">
-              <n-tag
-                v-if="sessionSummoner.preGroupMarkers?.name"
-                size="small"
-                :type="sessionSummoner.preGroupMarkers.type as any"
-              >
-                {{ sessionSummoner.preGroupMarkers.name }}
-              </n-tag>
+              <n-tooltip v-if="sessionSummoner.preGroupMarkers?.name" trigger="hover">
+                <template #trigger>
+                  <n-tag size="small" :type="sessionSummoner.preGroupMarkers.type as any">
+                    {{ sessionSummoner.preGroupMarkers.name }}
+                  </n-tag>
+                </template>
+                预组队：近期多次同队，大概率一起排的；编号仅区分不同组
+              </n-tooltip>
               <n-tag v-if="sessionSummoner.meetGames?.length > 0" type="warning" size="small" round>
                 <n-popover trigger="hover">
-                  <template #trigger>遇见过</template>
+                  <template #trigger>遇见过 ×{{ sessionSummoner.meetGames.length }}</template>
                   <MettingPlayersCard :meet-games="sessionSummoner.meetGames"></MettingPlayersCard>
                 </n-popover>
               </n-tag>
@@ -183,7 +193,18 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, ref, toRef, watch } from 'vue'
-import { NCard, NFlex, NAvatar, NImage, NButton, NIcon, NEllipsis, NPopover, NTag } from 'naive-ui'
+import {
+  NCard,
+  NFlex,
+  NAvatar,
+  NImage,
+  NButton,
+  NIcon,
+  NEllipsis,
+  NPopover,
+  NTag,
+  NTooltip
+} from 'naive-ui'
 import { CopyOutline, HelpCircleOutline } from '@vicons/ionicons5'
 import MettingPlayersCard from './MettingPlayersCard.vue'
 import { useCopy } from '@renderer/composables/useCopy'
@@ -198,6 +219,7 @@ import PlayerHistoryGrid from './PlayerHistoryGrid.vue'
 import PlayerStatsCard from './PlayerStatsCard.vue'
 import LazyImg from '@renderer/components/common/LazyImg.vue'
 import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
+import PatchNoteBadge from './PatchNoteBadge.vue'
 import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
 import { getChampionMeta, type ChampionMeta, type OpggMode } from '@renderer/services/opgg'
 import { tierBadge, formatWinRate, playerCardPickStateClass, isChampionSwap } from './championIntel'
@@ -223,12 +245,15 @@ interface Props {
    * 非选人期（对局中等）恒为空，PlayerCard 不带任何选人态修饰。
    */
   pickState?: string
+  /** 是否是自己：名字旁标「我」，与战绩详情窗口的约定一致 */
+  isSelf?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   team: undefined,
   density: 'normal',
-  pickState: ''
+  pickState: '',
+  isSelf: false
 })
 
 /** n-card content-style：用 token 控制内边距（P0 收紧为 --space-4 让 4 场 1 屏装下） */
@@ -691,12 +716,14 @@ watch(
   }
 }
 
+/* 禁用阶段是全队同时进行的——ban 时 5 张卡（加敌方 5 个占位）一起变红，
+   所以这里刻意比 pc-picking 克制：1px 半透明边框 + 更慢更弱的呼吸，只做状态提示不抢焦点 */
 .player-card.pc-banning {
-  border-width: 2px !important;
-  border-color: var(--semantic-loss) !important;
+  border-width: 1px !important;
+  border-color: color-mix(in srgb, var(--semantic-loss) 45%, transparent) !important;
   animation:
     fade-up var(--dur-normal) var(--ease-expo) both,
-    pc-ban-pulse 1.1s ease-in-out infinite;
+    pc-ban-pulse 2s ease-in-out infinite;
   animation-delay: calc(var(--stagger) * var(--stagger-i, 0)), 0s;
 }
 @keyframes pc-ban-pulse {
@@ -705,7 +732,7 @@ watch(
     filter: drop-shadow(0 0 0 rgba(239, 68, 68, 0));
   }
   50% {
-    filter: drop-shadow(0 0 5px rgba(239, 68, 68, 0.25));
+    filter: drop-shadow(0 0 3px rgba(239, 68, 68, 0.12));
   }
 }
 

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerHistoryGrid.vue
@@ -15,10 +15,13 @@
           alt="champion"
           class="history-champ-img"
         />
-        <div class="kda-text">
-          <span class="kill">{{ game.participants[0].stats?.kills }}</span>
-          / <span class="death">{{ game.participants[0].stats?.deaths }}</span> /
-          <span class="assist">{{ game.participants[0].stats?.assists }}</span>
+        <!-- font-number: 与战绩页 RecordCard 同款 Oswald 数字字体；分隔符弱化不抢数字 -->
+        <div class="kda-text font-number">
+          <span class="kill">{{ game.participants[0].stats?.kills }}</span
+          ><span class="kda-sep">/</span
+          ><span class="death">{{ game.participants[0].stats?.deaths }}</span
+          ><span class="kda-sep">/</span
+          ><span class="assist">{{ game.participants[0].stats?.assists }}</span>
         </div>
         <n-tooltip trigger="hover">
           <template #trigger>
@@ -80,16 +83,12 @@ defineProps<{ games: Game[] }>()
   border-left-color: color-mix(in srgb, var(--semantic-win) 70%, transparent);
 }
 
-/* 固定列宽 grid：胜负 / 头像 / KDA / 模式 —— 跨行跨卡片严格对齐 */
-/* 模式列宽也随 viewport 平滑放大 (60→80px), 配合 queue-name 字号 10→14px 容纳 5 字"海克斯乱斗" */
-/* minmax(0, 1fr) 阻止 KDA 大数字 (15/10/33) 把 1fr 列撑大挤掉 queue 列 */
+/* 列宽策略：胜负(定宽) / 头像(自适应图) / KDA(max-content 永不裁数字) / 模式(弹性+省略号)。
+   旧版 KDA 用 minmax(0,1fr)+nowrap，KDA 大数字(27/10/19)超出列宽时直接压到模式列上
+  （「海克斯乱斗」等长模式名尤其明显）；数字必须完整，模式名可省略（有 hover tooltip 兜底） */
 .history-row {
   display: grid;
-  grid-template-columns: 18px 24px minmax(0, 1fr) clamp(
-      60px,
-      calc(60px + (100vw - 900px) * 20 / 2100),
-      80px
-    );
+  grid-template-columns: 18px auto max-content minmax(0, 1fr);
   align-items: center;
   gap: var(--space-6);
 }
@@ -127,6 +126,16 @@ defineProps<{ games: Game[] }>()
   white-space: nowrap;
 }
 
+/* 每个数字占 2ch 槽位居中：K/D/A 位数不同（4 vs 46）时斜杠位置仍逐行对齐，
+   三位数极端值靠 min-width 自然撑开（只影响该行） */
+.kill,
+.death,
+.assist {
+  display: inline-block;
+  min-width: 2ch;
+  text-align: center;
+}
+
 .kill {
   color: var(--semantic-win);
 }
@@ -137,6 +146,12 @@ defineProps<{ games: Game[] }>()
 
 .assist {
   color: var(--text-secondary);
+}
+
+.kda-sep {
+  color: var(--text-tertiary);
+  font-weight: var(--font-weight-normal, 400);
+  margin: 0 1px;
 }
 
 .queue-name {

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerStatsCard.vue
@@ -11,6 +11,7 @@
       </div>
 
       <!-- Compact Content -->
+      <!-- 该模式 0 场时显示中性「暂无」——0 红字会被误读成惨烈战绩（实际是没打过） -->
       <div v-if="!showStats" class="stats-compact" @click="showStats = true">
         <div class="compact-row">
           <span class="label">模式</span>
@@ -18,14 +19,20 @@
         </div>
         <div class="compact-row">
           <span class="label">KDA</span>
-          <span class="value" :style="{ color: kdaColor(recent.kda, isDark) }">
-            {{ recent.kda }}
+          <span
+            class="value"
+            :style="hasGames ? { color: kdaColor(recent.kda, isDark) } : undefined"
+          >
+            {{ hasGames ? recent.kda : '—' }}
           </span>
         </div>
         <div class="compact-row">
           <span class="label">胜率</span>
-          <span class="value" :style="{ color: winRateColor(selectWinRate, isDark) }">
-            {{ selectWinRate }}%
+          <span
+            class="value"
+            :style="hasGames ? { color: winRateColor(selectWinRate, isDark) } : undefined"
+          >
+            {{ hasGames ? `${selectWinRate}%` : '暂无' }}
           </span>
         </div>
       </div>
@@ -98,6 +105,11 @@ const props = defineProps<{
 const showStats = ref(false)
 
 const selectWinRate = computed(() => winRate(props.recent.selectWins, props.recent.selectLosses))
+
+/** 当前统计模式下是否打过对局：0 场时 KDA/胜率显示中性占位而非红色 0 */
+const hasGames = computed(
+  () => (props.recent.selectWins ?? 0) + (props.recent.selectLosses ?? 0) > 0
+)
 </script>
 
 <style scoped>

--- a/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/SubteamCard.vue
@@ -31,6 +31,7 @@
           :density="density"
           :opgg-mode="opggMode"
           :pick-state="phase === 'ChampSelect' ? p.pickState : ''"
+          :is-self="!!myPuuid && p.summoner.puuid === myPuuid"
           :style="{ '--stagger-i': i }"
         />
       </template>
@@ -73,13 +74,16 @@ interface Props {
   opggMode?: OpggMode
   /** 我方已亮出的英雄 id 列表，仅敌方情报卡用于克制提示 */
   myChampionIds?: number[]
+  /** 自己的 puuid，用于在对应玩家卡上标「我」（空 = 不标） */
+  myPuuid?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   density: 'normal',
   phase: '',
   opggMode: 'ranked',
-  myChampionIds: () => []
+  myChampionIds: () => [],
+  myPuuid: ''
 })
 const placeholderCount = computed(() =>
   Math.max(0, props.expectedSize - props.subteam.players.length)

--- a/lol-record-analysis-tauri/src/components/record/RankCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RankCard.vue
@@ -10,11 +10,13 @@
         <span class="rank-card-type-label">{{ label }}</span>
         <img :src="tierImage(queueInfo.tier)" class="rank-card-img" />
         <div class="rank-card-tier-text">
-          {{ queueInfo.tierCn }} {{ divisionOrPoint(queueInfo) }}
+          {{ formatTierText(queueInfo) }}
         </div>
       </div>
       <div class="rank-card-stats">
-        <div class="rank-card-win-badge" :class="badgeClass">胜率 {{ recent.winRate }}%</div>
+        <div class="rank-card-win-badge" :class="badgeClass">
+          {{ hasGames ? `胜率 ${recent.winRate}%` : '暂无对局' }}
+        </div>
         <n-flex justify="space-between" size="small" class="rank-card-stats-row">
           <span class="rank-card-stat-text">胜场: {{ recent.wins }}</span>
           <span class="rank-card-stat-text">负场: {{ recent.losses }}</span>
@@ -29,7 +31,7 @@ import { computed } from 'vue'
 import { NCard, NFlex } from 'naive-ui'
 import type { QueueInfo } from '@renderer/types/domain/player'
 import type { RecentWinRate } from '@renderer/types/domain/player'
-import { divisionOrPoint } from '@renderer/utils/rank'
+import { formatTierText } from '@renderer/utils/rank'
 import { tierImage } from '@renderer/utils/tier-image'
 
 const props = defineProps<{
@@ -38,7 +40,11 @@ const props = defineProps<{
   recent: RecentWinRate
 }>()
 
+/** 0 胜 0 负说明该队列没打过，红色「胜率 0%」会被误读成连败 */
+const hasGames = computed(() => props.recent.wins + props.recent.losses > 0)
+
 const badgeClass = computed(() => {
+  if (!hasGames.value) return 'normal'
   if (props.recent.winRate >= 58) return 'good'
   if (props.recent.winRate <= 49) return 'bad'
   return 'normal'

--- a/lol-record-analysis-tauri/src/components/record/RecordCard.vue
+++ b/lol-record-analysis-tauri/src/components/record/RecordCard.vue
@@ -43,12 +43,17 @@
 
       <n-flex vertical class="record-card-queue-block">
         <span class="font-number record-card-queue">{{ games.queueName }}</span>
-        <span class="record-card-meta">
-          <n-icon class="record-card-meta-icon">
-            <CalendarNumber />
-          </n-icon>
-          {{ formattedDate }}
-        </span>
+        <n-tooltip trigger="hover" placement="top">
+          <template #trigger>
+            <span class="record-card-meta">
+              <n-icon class="record-card-meta-icon">
+                <CalendarNumber />
+              </n-icon>
+              {{ formattedDate }}
+            </span>
+          </template>
+          {{ fullDateTime }}
+        </n-tooltip>
       </n-flex>
 
       <n-flex justify="space-between" vertical class="record-card-kda-block">
@@ -163,7 +168,7 @@
       <div class="record-card-stats-block">
         <StatDots
           :icon="FlameOutline"
-          tooltip="对英雄伤害占比"
+          tooltip="对英雄伤害 · 百分比 = 占全队伤害的比例"
           :color="otherColor(games.participants[0].stats?.damageDealtToChampionsRate, isDark)"
           :icon-background="isDark ? 'rgba(229, 167, 50, 0.18)' : 'rgba(229, 167, 50, 0.14)'"
           :value="
@@ -173,7 +178,7 @@
         />
         <StatDots
           :icon="ShieldOutline"
-          tooltip="承伤占比"
+          tooltip="承受伤害 · 百分比 = 占全队承伤的比例"
           :color="healColorAndTaken(games.participants[0].stats?.damageTakenRate, isDark)"
           :icon-background="isDark ? 'rgba(92, 163, 234, 0.2)' : 'rgba(92, 163, 234, 0.12)'"
           :value="formatCompactNumber(games.participants[0].stats?.totalDamageTaken ?? 0)"
@@ -181,7 +186,7 @@
         />
         <StatDots
           :icon="HeartOutline"
-          tooltip="治疗占比"
+          tooltip="治疗量 · 百分比 = 占全队治疗的比例"
           :color="healColorAndTaken(games.participants[0].stats?.healRate, isDark)"
           :icon-background="isDark ? 'rgba(88, 182, 109, 0.2)' : 'rgba(88, 182, 109, 0.14)'"
           :value="formatCompactNumber(games.participants[0].stats?.totalHeal ?? 0)"
@@ -325,6 +330,9 @@ const formattedDate = computed(() => {
   return `${month}/${day}`
 })
 
+/** 完整开局时间（hover 展示）：MM/DD 无法区分同日多局，也缺年份 */
+const fullDateTime = computed(() => new Date(props.games.gameCreationDate).toLocaleString())
+
 const currentPlayerKey = computed(() => {
   const p = props.games.participantIdentities[0].player
   return `${p.gameName}#${p.tagLine}`
@@ -412,6 +420,8 @@ function openDetail() {
     var(--glass-bg-mid) !important;
 }
 
+/* 浅色：底必须是白纸（bg-elevated）而非灰玻璃——灰底叠胜负色渐变会发浊，
+   白底上的色彩 wash 才干净（同报纸彩色套印的道理） */
 .theme-light .record-card-win {
   background:
     linear-gradient(
@@ -419,7 +429,7 @@ function openDetail() {
       color-mix(in srgb, var(--semantic-win) 7%, transparent),
       transparent 55%
     ),
-    var(--glass-bg-mid) !important;
+    var(--bg-elevated) !important;
 }
 
 .theme-light .record-card-loss {
@@ -429,7 +439,20 @@ function openDetail() {
       color-mix(in srgb, var(--semantic-loss) 6%, transparent),
       transparent 55%
     ),
-    var(--glass-bg-mid) !important;
+    var(--bg-elevated) !important;
+}
+
+/* 浅色：卡内嵌套容器（指标盒/队伍胶囊）用白色 scrim 而非灰玻璃——
+   灰色压在胜负色调的卡面上是「脏」感的主要来源；白 scrim 读作磨砂纸层。
+   另外内嵌层不该有投影（海拔语法：只有卡片本体浮起） */
+.theme-light .record-card-stats-block {
+  background: rgba(255, 255, 255, 0.6);
+  border-color: rgba(20, 30, 35, 0.07);
+  box-shadow: none;
+}
+
+.theme-light .record-card-teams .n-tag {
+  background-color: rgba(255, 255, 255, 0.6);
 }
 
 .record-card:hover {

--- a/lol-record-analysis-tauri/src/components/record/StatDots.vue
+++ b/lol-record-analysis-tauri/src/components/record/StatDots.vue
@@ -1,38 +1,33 @@
+<!-- tooltip 触发区是整行而非 18px 小图标：数值/百分比含义不直观，hover 哪里都该有解释。
+     注释放模板外：dev 下模板根层级的注释会保留成 vnode，把根变成 Fragment。 -->
 <template>
-  <div class="stat-dots-row" :class="{ 'stat-dots-row-compact': props.compact }">
-    <n-tooltip v-if="tooltip" trigger="hover" placement="top">
-      <template #trigger>
+  <n-tooltip trigger="hover" placement="top" :disabled="!tooltip">
+    <template #trigger>
+      <div class="stat-dots-row" :class="{ 'stat-dots-row-compact': props.compact }">
         <div class="stat-dots-icon-wrap" :style="iconStyle">
           <n-icon v-if="icon" :size="iconSize">
             <component :is="icon" />
           </n-icon>
           <span v-else class="stat-dots-short-label">{{ shortLabel }}</span>
         </div>
-      </template>
-      {{ tooltip }}
-    </n-tooltip>
 
-    <div v-else class="stat-dots-icon-wrap" :style="iconStyle">
-      <n-icon v-if="icon" :size="iconSize">
-        <component :is="icon" />
-      </n-icon>
-      <span v-else class="stat-dots-short-label">{{ shortLabel }}</span>
-    </div>
+        <div class="stat-dots-track" :style="{ '--stat-dot-color': color }">
+          <span
+            v-for="i in 5"
+            :key="i"
+            class="stat-dot"
+            :class="{ 'stat-dot-filled': i <= filledCount }"
+          />
+        </div>
 
-    <div class="stat-dots-track" :style="{ '--stat-dot-color': color }">
-      <span
-        v-for="i in 5"
-        :key="i"
-        class="stat-dot"
-        :class="{ 'stat-dot-filled': i <= filledCount }"
-      />
-    </div>
-
-    <div class="stat-dots-values">
-      <span class="font-number stat-dots-value-main">{{ displayValue }}</span>
-      <span class="font-number stat-dots-value-percent" :style="{ color }">{{ percent }}%</span>
-    </div>
-  </div>
+        <div class="stat-dots-values">
+          <span class="font-number stat-dots-value-main">{{ displayValue }}</span>
+          <span class="font-number stat-dots-value-percent" :style="{ color }">{{ percent }}%</span>
+        </div>
+      </div>
+    </template>
+    {{ tooltip }}
+  </n-tooltip>
 </template>
 
 <script lang="ts" setup>
@@ -111,7 +106,8 @@ const iconStyle = computed<CSSProperties>(() => ({
 }
 
 .theme-light .stat-dot {
-  background: rgba(0, 0, 0, 0.24);
+  /* 冷墨基调，避免纯黑 alpha 在彩色卡面上发灰发脏 */
+  background: rgba(20, 30, 35, 0.2);
 }
 
 .stat-dot-filled {

--- a/lol-record-analysis-tauri/src/components/record/UserRecord.vue
+++ b/lol-record-analysis-tauri/src/components/record/UserRecord.vue
@@ -82,8 +82,8 @@
       </n-text>
     </n-card>
 
-    <!-- Friends & Rivals -->
-    <n-flex v-if="!isCrossRegion" :wrap="false" align="stretch" :size="12">
+    <!-- Friends & Rivals：双空时收成一行，不让两块空态占据侧栏黄金位置 -->
+    <n-flex v-if="!isCrossRegion && hasRelations" :wrap="false" align="stretch" :size="12">
       <RelationshipPanel
         variant="friend"
         :summoners="recentData.friendAndDispute.friendsSummoner"
@@ -95,6 +95,14 @@
         :is-dark="isDark"
       />
     </n-flex>
+    <div v-else-if="!isCrossRegion" class="relationship-empty-row">
+      <span class="relationship-empty-label">
+        <span class="relationship-empty-dot relationship-empty-dot-win"></span>好友
+        <span class="relationship-empty-sep">/</span>
+        <span class="relationship-empty-dot relationship-empty-dot-loss"></span>宿敌
+      </span>
+      <span class="relationship-empty-text">近 20 场没有重复同排的玩家</span>
+    </div>
 
     <!-- Rank Cards -->
     <n-flex v-if="!isCrossRegion" vertical :size="12">
@@ -185,6 +193,13 @@ const rank = ref<Rank>(defaultRank())
 const solo5v5RecentWinRate = ref<RecentWinRate>(defaultRecentWinRate())
 const flexRecentWinRate = ref<RecentWinRate>(defaultRecentWinRate())
 const recentData = ref<RecentData>(defaultRecentData())
+
+/** 好友/宿敌任一有数据才铺开双栏，双空时用单行占位（见模板注释） */
+const hasRelations = computed(
+  () =>
+    (recentData.value.friendAndDispute?.friendsSummoner?.length ?? 0) > 0 ||
+    (recentData.value.friendAndDispute?.disputeSummoner?.length ?? 0) > 0
+)
 
 const route = useRoute()
 /** 跨区查询目标大区 platformId（空 = 当前区，走本地 LCU） */
@@ -363,5 +378,51 @@ const copyName = () => {
   background: transparent !important;
   border: 1px solid var(--border-subtle) !important;
   box-shadow: none !important;
+}
+
+/* 好友/宿敌双空时的单行占位：虚线轻容器，明示「没有」而不是占两块空面板 */
+.relationship-empty-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-8);
+  padding: var(--space-8) var(--space-10);
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border-subtle);
+  font-size: var(--font-size-sm);
+}
+
+.relationship-empty-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.relationship-empty-sep {
+  color: var(--text-tertiary);
+}
+
+.relationship-empty-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.relationship-empty-dot-win {
+  background: var(--semantic-win);
+  opacity: 0.6;
+}
+
+.relationship-empty-dot-loss {
+  background: var(--semantic-loss);
+  opacity: 0.6;
+}
+
+.relationship-empty-text {
+  color: var(--text-tertiary);
 }
 </style>

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.spec.ts
@@ -17,6 +17,19 @@ function enemy(championId: number, pickState: string): SessionSummoner {
   }
 }
 
+/** 造一个已识别玩家（带 puuid），可选携带近期数据 */
+function player(puuid: string, recentKda?: number): SessionSummoner {
+  const p = enemy(10, 'none')
+  p.summoner = { puuid } as SessionSummoner['summoner']
+  if (recentKda !== undefined) {
+    p.userTag = {
+      tag: [],
+      recentData: { kda: recentKda, selectMode: 420, selectWins: 6, selectLosses: 4 }
+    } as unknown as SessionSummoner['userTag']
+  }
+  return p
+}
+
 describe('选人期 pickState 合并', () => {
   it('basic 合并应更新同位置空 puuid 敌人的 pickState 与 championId', () => {
     const current = [enemy(0, 'none')]
@@ -32,5 +45,33 @@ describe('选人期 pickState 合并', () => {
     const current = [a]
     syncPlayers(current, [b], 'full')
     expect(current[0].pickState).toBe('locked')
+  })
+})
+
+describe('full 合并防闪烁与数据完整性', () => {
+  it('仅 recentData 补算完成的包不能被签名跳过（回归：近期数据面板停在 0）', () => {
+    const before = player('p1')
+    const after = player('p1', 3.2)
+    expect(playerSignature(before)).not.toBe(playerSignature(after))
+    const current = [before]
+    syncPlayers(current, [after], 'full')
+    expect(current[0].userTag?.recentData?.kda).toBe(3.2)
+  })
+
+  it('同 puuid 更新应原位合并、保持对象身份（避免 PlayerCard 整卡重渲染）', () => {
+    const before = player('p1')
+    const current = [before]
+    syncPlayers(current, [player('p1', 3.2)], 'full')
+    expect(current[0]).toBe(before)
+  })
+
+  it('已加载玩家不被无身份加载占位回退（避免 内容→转圈→内容 闪烁）', () => {
+    const loaded = player('p1', 3.2)
+    const placeholder = enemy(0, '')
+    placeholder.isLoading = true
+    const current = [loaded]
+    syncPlayers(current, [placeholder], 'full')
+    expect(current[0]).toBe(loaded)
+    expect(current[0].isLoading).toBeFalsy()
   })
 })

--- a/lol-record-analysis-tauri/src/composables/useSessionSync.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionSync.ts
@@ -52,6 +52,10 @@ function updatePreGroupMarkers(subteams: Subteam[], markers: Record<string, PreG
  */
 export function playerSignature(p: SessionSummoner): string {
   const solo = p.rank?.queueMap?.RANKED_SOLO_5x5
+  // recentData（近期数据面板的模式/KDA/胜率等）必须参与签名：
+  // 玩家常先以「战绩已到、近期数据未算好」的包到达，若签名不含这些字段，
+  // 补算完成的包会被当成「无变化」跳过，面板就永远停在 KDA 0 / 胜率 0%
+  const r = p.userTag?.recentData
   return [
     p.summoner.puuid,
     p.championId,
@@ -62,12 +66,41 @@ export function playerSignature(p: SessionSummoner): string {
     solo?.tier ?? '',
     solo?.leaguePoints ?? -1,
     p.preGroupMarkers?.name ?? '',
-    p.pickState ?? ''
+    p.pickState ?? '',
+    r?.selectMode ?? -1,
+    r?.selectWins ?? -1,
+    r?.selectLosses ?? -1,
+    r?.kda ?? -1,
+    r?.kills ?? -1,
+    r?.deaths ?? -1,
+    r?.assists ?? -1,
+    r?.groupRate ?? -1,
+    r?.damageDealtToChampionsRate ?? -1
   ].join('|')
 }
 
 function findSubteam(subteams: Subteam[], subteamId: number): Subteam | undefined {
   return subteams.find(s => s.subteamId === subteamId)
+}
+
+/**
+ * 原位合并玩家数据：保持数组槽位里的对象身份不变。
+ * 整体替换对象会让 PlayerCard 的 props 引用变化 → 内部 watcher（OP.GG chip 拉取等）
+ * 全部重跑，选人期 pickState 高频变化时表现为卡片抖动/闪烁。
+ * @param preserveLocalFields - 保留旧对象的 meetGames/preGroupMarkers
+ *（session-player-update 单玩家事件不带这两个字段的有效值，由独立事件维护）
+ */
+function mergePlayerInPlace(
+  oldPlayer: SessionSummoner,
+  newPlayer: SessionSummoner,
+  preserveLocalFields: boolean
+) {
+  const { meetGames, preGroupMarkers } = oldPlayer
+  Object.assign(oldPlayer, newPlayer)
+  if (preserveLocalFields) {
+    oldPlayer.meetGames = meetGames
+    oldPlayer.preGroupMarkers = preGroupMarkers
+  }
 }
 
 function updatePlayerInSubteam(
@@ -82,6 +115,11 @@ function updatePlayerInSubteam(
   if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
     newPlayer.meetGames = oldPlayer.meetGames
     newPlayer.preGroupMarkers = oldPlayer.preGroupMarkers
+    // 防闪烁守卫：加载占位不回退已加载内容、签名一致视为无变化直接跳过
+    if (newPlayer.isLoading && !oldPlayer.isLoading) return
+    if (playerSignature(newPlayer) === playerSignature(oldPlayer)) return
+    mergePlayerInPlace(oldPlayer, newPlayer, true)
+    return
   }
   st.players[index] = newPlayer
 }
@@ -127,12 +165,18 @@ export function syncPlayers(
           currentTeam[i] = newPlayer
         }
       } else {
-        let shouldUpdate = true
         if (oldPlayer && oldPlayer.summoner.puuid === newPlayer.summoner.puuid) {
-          if (newPlayer.isLoading && !oldPlayer.isLoading) shouldUpdate = false
-          else if (playerSignature(newPlayer) === playerSignature(oldPlayer)) shouldUpdate = false
+          // 同一玩家：加载占位不回退、签名一致跳过，有变化则原位合并（保持对象身份，
+          // full 事件带权威的 meetGames/preGroupMarkers，不保留旧值）
+          if (newPlayer.isLoading && !oldPlayer.isLoading) continue
+          if (playerSignature(newPlayer) === playerSignature(oldPlayer)) continue
+          mergePlayerInPlace(oldPlayer, newPlayer, false)
+        } else if (oldPlayer && !oldPlayer.isLoading && newPlayer.isLoading) {
+          // 同一格位从「已加载的玩家」被刷成「无身份的加载占位」（puuid 对不上）：
+          // 保留旧内容等真实数据到达，避免 内容→转圈→内容 的闪烁
+        } else {
+          currentTeam[i] = newPlayer
         }
-        if (shouldUpdate) currentTeam[i] = newPlayer
       }
     } else {
       currentTeam.push(newPlayer)

--- a/lol-record-analysis-tauri/src/composables/useSessionTiers.ts
+++ b/lol-record-analysis-tauri/src/composables/useSessionTiers.ts
@@ -6,7 +6,7 @@
 import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 import type { SessionData, SessionSummoner } from '@renderer/types/domain/gaming'
 import { tierImage } from '@renderer/utils/tier-image'
-import { divisionOrPoint } from '@renderer/utils/rank'
+import { formatTierText } from '@renderer/utils/rank'
 
 export interface TierDisplay {
   imgUrl: string
@@ -22,8 +22,7 @@ function pickQueueInfo(player: SessionSummoner, queueType: string) {
 
 function toDisplay(player: SessionSummoner, queueType: string): TierDisplay {
   const q = pickQueueInfo(player, queueType)
-  const tierCn = q.tierCn ? `${q.tierCn.slice(-2)} ${divisionOrPoint(q)}` : '无'
-  return { imgUrl: tierImage(q.tier), tierCn }
+  return { imgUrl: tierImage(q.tier), tierCn: formatTierText(q, { short: true }) }
 }
 
 /** 返回 subteamId → TierDisplay[]（按玩家在小队中的顺序） */

--- a/lol-record-analysis-tauri/src/composables/useZoom.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useZoom.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({ setZoom: vi.fn() })
+}))
+vi.mock('@renderer/services/ipc', () => ({
+  getConfigByIpc: vi.fn(),
+  putConfigByIpc: vi.fn()
+}))
+
+import { nextZoomFactor, ZOOM_MIN, ZOOM_MAX } from './useZoom'
+
+describe('nextZoomFactor', () => {
+  it('should zoom in by one step', () => {
+    expect(nextZoomFactor(1, 1)).toBe(1.1)
+  })
+
+  it('should zoom out by one step', () => {
+    expect(nextZoomFactor(1.1, -1)).toBe(1)
+  })
+
+  it('should clamp at max', () => {
+    expect(nextZoomFactor(ZOOM_MAX, 1)).toBe(ZOOM_MAX)
+  })
+
+  it('should clamp at min', () => {
+    expect(nextZoomFactor(ZOOM_MIN, -1)).toBe(ZOOM_MIN)
+  })
+
+  it('should reset to 1 with direction 0', () => {
+    expect(nextZoomFactor(1.4, 0)).toBe(1)
+  })
+
+  it('should keep two decimals to avoid float drift', () => {
+    const zoomed = nextZoomFactor(nextZoomFactor(1, 1), 1)
+    expect(String(zoomed).length).toBeLessThanOrEqual(4)
+  })
+})

--- a/lol-record-analysis-tauri/src/composables/useZoom.ts
+++ b/lol-record-analysis-tauri/src/composables/useZoom.ts
@@ -1,0 +1,96 @@
+/**
+ * 浏览器式页面缩放：Ctrl+滚轮、Ctrl+加减号、Ctrl+0 复位
+ *
+ * 走 WebView2 的布局缩放（webview.setZoom）而非 CSS transform——与 Chrome 缩放
+ * 行为一致：CSS 视口宽度随缩放变化，既有的 clamp(100vw) 自适应会自动重算。
+ *
+ * 比例持久化到 config（settings.ui.zoomFactor），窗口打开时恢复；
+ * 各窗口（主窗口 / match-detail-*）独立挂载本 composable，新开窗口
+ * 以最近保存的比例启动。已开窗口之间不做实时同步（各自缩各自的）。
+ */
+import { onMounted, onUnmounted } from 'vue'
+import { getCurrentWebview } from '@tauri-apps/api/webview'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { CONFIG_KEYS } from '@renderer/services/configKeys'
+
+export const ZOOM_MIN = 0.7
+export const ZOOM_MAX = 1.5
+/** 每格滚轮/每次按键的缩放乘数（浏览器同款手感的近似值） */
+export const ZOOM_STEP = 1.1
+
+const CONFIG_KEY = CONFIG_KEYS.zoomFactor
+/** 连续滚动只在停下后落盘一次 */
+const SAVE_DEBOUNCE_MS = 600
+
+/**
+ * 计算下一档缩放比例（纯函数，便于单测）
+ * @param current - 当前比例
+ * @param direction - 1 放大 / -1 缩小 / 0 复位到 1
+ * @returns 夹取在 [ZOOM_MIN, ZOOM_MAX] 的两位小数比例
+ */
+export function nextZoomFactor(current: number, direction: 1 | -1 | 0): number {
+  if (direction === 0) return 1
+  const raw = direction > 0 ? current * ZOOM_STEP : current / ZOOM_STEP
+  const clamped = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, raw))
+  return Math.round(clamped * 100) / 100
+}
+
+export function useZoom() {
+  let factor = 1
+  let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+  async function apply(next: number) {
+    factor = next
+    try {
+      await getCurrentWebview().setZoom(factor)
+    } catch (e) {
+      console.warn('setZoom failed:', e)
+      return
+    }
+    if (saveTimer) clearTimeout(saveTimer)
+    saveTimer = setTimeout(() => {
+      void putConfigByIpc(CONFIG_KEY, factor)
+    }, SAVE_DEBOUNCE_MS)
+  }
+
+  function onWheel(e: WheelEvent) {
+    if (!e.ctrlKey) return
+    e.preventDefault()
+    void apply(nextZoomFactor(factor, e.deltaY < 0 ? 1 : -1))
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (!e.ctrlKey || e.altKey || e.metaKey) return
+    // '=' 兼容不按 shift 的主键盘 '+'
+    if (e.key === '=' || e.key === '+') {
+      e.preventDefault()
+      void apply(nextZoomFactor(factor, 1))
+    } else if (e.key === '-') {
+      e.preventDefault()
+      void apply(nextZoomFactor(factor, -1))
+    } else if (e.key === '0') {
+      e.preventDefault()
+      void apply(1)
+    }
+  }
+
+  onMounted(async () => {
+    try {
+      const saved = await getConfigByIpc<number>(CONFIG_KEY)
+      if (typeof saved === 'number' && saved >= ZOOM_MIN && saved <= ZOOM_MAX && saved !== 1) {
+        await apply(saved)
+      }
+    } catch {
+      // 无保存值：保持 1.0
+    }
+    // wheel 需 passive:false 才能 preventDefault 掉 WebView2 的默认行为
+    window.addEventListener('wheel', onWheel, { passive: false })
+    window.addEventListener('keydown', onKeydown)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('wheel', onWheel)
+    window.removeEventListener('keydown', onKeydown)
+    if (saveTimer) clearTimeout(saveTimer)
+  })
+}

--- a/lol-record-analysis-tauri/src/global.css
+++ b/lol-record-analysis-tauri/src/global.css
@@ -121,37 +121,43 @@
   --loss-bar-gradient: linear-gradient(180deg, #e57878, #8a3232);
 }
 
-/* 浅色主题 Token */
+/* 浅色主题 Token —— 冷瓷（porcelain）
+   经真机 A/B 调色实验（近白 vs 冷瓷）后定稿：画布是明亮的冷中性近白，
+   卡片纯白靠细投影+发丝边分离；身份绿只活在点缀（胜负色/激活态/标签）里，
+   不给世界罩色——冷中性底反而让绿色点缀更突出。
+   墨色统一用冷墨（20,30,35），纯黑 alpha 在浅色下显脏 */
 .theme-light {
-  --bg-base: #f0f2f5;
-  --bg-surface: #f6f9f8;
+  --bg-base: #eff1f3;
+  --bg-surface: #fafbfc;
   --bg-elevated: #ffffff;
-  --border-subtle: rgba(0, 0, 0, 0.08);
-  --text-primary: rgba(0, 0, 0, 0.88);
-  --text-secondary: rgba(0, 0, 0, 0.6);
-  --text-tertiary: rgba(0, 0, 0, 0.45);
+  --border-subtle: rgba(20, 30, 35, 0.09);
+  --text-primary: rgba(20, 30, 35, 0.94);
+  --text-secondary: rgba(20, 30, 35, 0.6);
+  --text-tertiary: rgba(20, 30, 35, 0.42);
   --semantic-win: #2d8a6c;
   --semantic-loss: #b84242;
   /* 浅色主题琥珀，加深以保证对比度 */
   --semantic-warn: #b8842f;
   --team-blue: rgba(59, 130, 246, 0.25);
   --team-red: rgba(239, 68, 68, 0.25);
-  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-card-hover: 0 2px 8px rgba(0, 0, 0, 0.12);
-  --glass-bg-low: rgba(0, 0, 0, 0.02);
-  --glass-bg-mid: rgba(0, 0, 0, 0.035);
-  --glass-bg-high: rgba(0, 0, 0, 0.06);
-  --glass-border: rgba(0, 0, 0, 0.08);
+  /* 双层投影：1px 贴地暗缝 + 短距柔影，白卡从瓷底上「浮」起来 */
+  --shadow-card: 0 1px 2px rgba(20, 30, 35, 0.06), 0 2px 6px rgba(20, 30, 35, 0.05);
+  --shadow-card-hover: 0 6px 16px rgba(20, 30, 35, 0.1);
+  --glass-bg-low: rgba(20, 30, 35, 0.025);
+  --glass-bg-mid: rgba(20, 30, 35, 0.04);
+  --glass-bg-high: rgba(20, 30, 35, 0.06);
+  --glass-border: rgba(20, 30, 35, 0.09);
   --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-  --glow-win: 0 0 10px rgba(45, 138, 108, 0.22);
-  --glow-loss: 0 0 10px rgba(184, 66, 66, 0.18);
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
-  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.12);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.15);
+  /* 浅色不做发光：白底上的彩色光晕读作污渍而非氛围 */
+  --glow-win: 0 0 0 rgba(0, 0, 0, 0);
+  --glow-loss: 0 0 0 rgba(0, 0, 0, 0);
+  --shadow-sm: 0 1px 2px rgba(20, 30, 35, 0.07);
+  --shadow-md: 0 4px 10px rgba(20, 30, 35, 0.09);
+  --shadow-lg: 0 12px 32px rgba(20, 30, 35, 0.14);
   --win-bar-gradient: linear-gradient(180deg, #4abd92, #2d8a6c);
   --loss-bar-gradient: linear-gradient(180deg, #d96565, #a33b3b);
-  --border-control: rgba(0, 0, 0, 0.18);
-  --border-control-hover: rgba(0, 0, 0, 0.38);
+  --border-control: rgba(20, 30, 35, 0.2);
+  --border-control-hover: rgba(20, 30, 35, 0.4);
   --focus-ring-color: rgba(45, 138, 108, 0.85);
   --accent-gold: #b8862a;
   --accent-gold-deep: #9c6f1e;
@@ -164,6 +170,36 @@
 .font-number {
   font-family: 'Oswald', sans-serif;
   letter-spacing: 0.5px;
+}
+
+/* ========== 浅色主题材质补丁 ==========
+   深色的「玻璃面板」（透明底+细边）在白底上退化成线框，掉价的主因。
+   浅色统一升级为「纸面」：白底 + ink 细边 + 低层投影。
+   组件侧的 .panel-glass 用了 !important，这里以更高特异度覆盖 */
+.theme-light .panel-glass {
+  background: var(--bg-elevated) !important;
+  border: 1px solid var(--border-subtle) !important;
+  box-shadow: var(--shadow-card) !important;
+}
+
+/* 对局页队伍容器/玩家迷你战绩：同款纸面处理（组件侧无 !important，特异度即可覆盖） */
+.theme-light .subteam-card {
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-card);
+}
+
+/* 机体壳统一：顶栏 + 左侧导航共用 surface 面，内容画布用更深的玉青底，
+   「壳浅于画布」让内容区像嵌进机体的一块屏（Framework 侧写了 !important，
+   这里用更高特异度 + !important 覆盖，仅浅色生效） */
+.theme-light .n-layout-header.header {
+  background-color: var(--bg-surface) !important;
+  border-bottom: 1px solid var(--border-subtle) !important;
+  box-shadow: none;
+}
+
+.theme-light .n-layout-sider.left {
+  background-color: var(--bg-surface) !important;
+  border-right: 1px solid var(--border-subtle) !important;
 }
 
 /* JB 风格实心 focus ring：键盘聚焦时 2px 实心环 + 1px 间隙，替代光晕 */

--- a/lol-record-analysis-tauri/src/services/configKeys.ts
+++ b/lol-record-analysis-tauri/src/services/configKeys.ts
@@ -35,5 +35,7 @@ export const CONFIG_KEYS = {
    * 由后端在客户端「已连接」时从运行进程反推并自动记忆（见 Rust `command::launcher`），
    * 前端一般无需读写；列在此处以收口该共享键名。
    */
-  gameInstallPath: 'gameInstallPath'
+  gameInstallPath: 'gameInstallPath',
+  /** 页面缩放比例（Ctrl+滚轮调节，0.7~1.5；见 composables/useZoom） */
+  zoomFactor: 'settings.ui.zoomFactor'
 } as const

--- a/lol-record-analysis-tauri/src/services/opgg.ts
+++ b/lol-record-analysis-tauri/src/services/opgg.ts
@@ -14,6 +14,8 @@ export interface ChampionMeta {
   position: string
   tier: number
   rank: number
+  /** 上一 patch 的同分路排名（0 = 无数据），用于「版本走强/走弱」趋势 */
+  rankPrevPatch: number
   winRate: number
   pickRate: number
   banRate: number

--- a/lol-record-analysis-tauri/src/services/patchNotes.ts
+++ b/lol-record-analysis-tauri/src/services/patchNotes.ts
@@ -1,0 +1,68 @@
+/**
+ * 版本补丁英雄改动查询（Rust get_champion_patch_note 的类型安全包装）
+ *
+ * patch 版本号取自 OP.GG 状态（ranked 快照）；网络型失败一律返回 null——
+ * 无补丁信息是常态降级，不阻塞选人页渲染。
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+import { getOpggStatus } from './opgg'
+
+/** 改动整体方向（与 Rust ChangeDirection serde 值一致） */
+export type ChangeDirection = 'buff' | 'nerf' | 'adjusted'
+
+export interface ChampionPatchNote {
+  /** wiki 展示名（英文） */
+  champion: string
+  direction: ChangeDirection
+  /** 改动条目（英文原文，已清洗 wiki 标记） */
+  lines: string[]
+}
+
+/** 当前 patch 版本号，模块级缓存（一次会话内不变） */
+let patchPromise: Promise<string | null> | null = null
+
+/**
+ * 取当前 patch 版本号（如 "16.14"）
+ * @returns OP.GG 状态里的 patch；不可用时 null
+ */
+export function getCurrentPatch(): Promise<string | null> {
+  if (!patchPromise) {
+    patchPromise = getOpggStatus('ranked')
+      .then(s => s?.patch ?? null)
+      .catch(() => {
+        patchPromise = null
+        return null
+      })
+  }
+  return patchPromise
+}
+
+/** championId → 补丁改动 的模块级缓存（同一英雄多卡片共享） */
+const noteCache = new Map<number, Promise<ChampionPatchNote | null>>()
+
+/**
+ * 查询英雄在当前版本的官方改动
+ * @param championId - 英雄 ID
+ * @returns 有改动时返回方向与条目；无改动/不可用返回 null
+ */
+export function getChampionPatchNote(championId: number): Promise<ChampionPatchNote | null> {
+  if (!championId || championId <= 0) return Promise.resolve(null)
+  let cached = noteCache.get(championId)
+  if (!cached) {
+    cached = (async () => {
+      const patch = await getCurrentPatch()
+      if (!patch) return null
+      return await invoke<ChampionPatchNote | null>('get_champion_patch_note', {
+        championId,
+        patch
+      })
+    })().catch(error => {
+      console.warn('[patchNotes] getChampionPatchNote failed:', error)
+      noteCache.delete(championId)
+      return null
+    })
+    noteCache.set(championId, cached)
+  }
+  return cached
+}

--- a/lol-record-analysis-tauri/src/theme/overrides.ts
+++ b/lol-record-analysis-tauri/src/theme/overrides.ts
@@ -28,15 +28,16 @@ export function buildThemeOverrides(isDark: boolean): GlobalThemeOverrides {
   // Theme-dependent values can't go through cssVar() — .theme-light class is on
   // n-config-provider's root, not document.documentElement, so getComputedStyle
   // always returns :root values. Use isDark ternaries directly (matches pre-refactor behavior).
-  const bgBase = isDark ? '#0d0d0f' : '#f0f2f5'
-  const glassMid = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)'
-  const glassBorder = isDark ? 'rgba(255,255,255,0.09)' : 'rgba(0,0,0,0.08)'
-  const shadowMd = isDark ? '0 2px 8px rgba(0,0,0,0.45)' : '0 2px 8px rgba(0,0,0,0.12)'
+  // 浅色值与 global.css .theme-light 的冷瓷基调保持一致（冷墨 20,30,35）
+  const bgBase = isDark ? '#0d0d0f' : '#eff1f3'
+  const glassMid = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(20,30,35,0.04)'
+  const glassBorder = isDark ? 'rgba(255,255,255,0.09)' : 'rgba(20,30,35,0.09)'
+  const shadowMd = isDark ? '0 2px 8px rgba(0,0,0,0.45)' : '0 4px 10px rgba(20,30,35,0.09)'
   const semanticWin = isDark ? '#3d9b7a' : '#2d8a6c'
-  const textPrimary = isDark ? 'rgba(255,255,255,0.92)' : 'rgba(0,0,0,0.88)'
+  const textPrimary = isDark ? 'rgba(255,255,255,0.92)' : 'rgba(20,30,35,0.94)'
   // 镂空描边控件：静默态细边，hover 只提亮边框（不加底色）
-  const controlBorder = isDark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.18)'
-  const controlBorderHover = isDark ? 'rgba(255,255,255,0.34)' : 'rgba(0,0,0,0.38)'
+  const controlBorder = isDark ? 'rgba(255,255,255,0.16)' : 'rgba(20,30,35,0.2)'
+  const controlBorderHover = isDark ? 'rgba(255,255,255,0.34)' : 'rgba(20,30,35,0.4)'
   // 主色统一到应用强调色（semantic-win），hover/pressed 逐级变深（Int UI 惯例，与 macOS 提亮相反）
   const primary = semanticWin
   const primaryHover = isDark ? '#378b6e' : '#28795f'

--- a/lol-record-analysis-tauri/src/utils/__tests__/rank.spec.ts
+++ b/lol-record-analysis-tauri/src/utils/__tests__/rank.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { winRate, formatTierText, hasRealTier } from '../rank'
+import { defaultQueueInfo, type QueueInfo } from '@renderer/types/domain/player'
+
+function queueInfo(partial: Partial<QueueInfo>): QueueInfo {
+  return { ...defaultQueueInfo(), ...partial }
+}
+
+describe('winRate', () => {
+  it('should return zero when no games', () => {
+    expect(winRate(0, 0)).toBe(0)
+  })
+
+  it('should round to nearest integer', () => {
+    expect(winRate(7, 3)).toBe(70)
+    expect(winRate(1, 2)).toBe(33)
+  })
+})
+
+describe('hasRealTier', () => {
+  it('should be false for LCU unranked placeholder (tier=UNRANKED, division=NA)', () => {
+    expect(hasRealTier(queueInfo({ tier: 'UNRANKED', tierCn: '无', division: 'NA' }))).toBe(false)
+  })
+
+  it('should be false for empty tier', () => {
+    expect(hasRealTier(queueInfo({ tier: '' }))).toBe(false)
+  })
+
+  it('should be true for a real tier', () => {
+    expect(hasRealTier(queueInfo({ tier: 'PLATINUM' }))).toBe(true)
+  })
+})
+
+describe('formatTierText', () => {
+  it('should show 无段位 instead of leaking division NA when unranked', () => {
+    expect(formatTierText(queueInfo({ tier: 'UNRANKED', tierCn: '无', division: 'NA' }))).toBe(
+      '无段位'
+    )
+  })
+
+  it('should join tierCn with division for normal tiers', () => {
+    expect(formatTierText(queueInfo({ tier: 'PLATINUM', tierCn: '华贵铂金', division: 'I' }))).toBe(
+      '华贵铂金 I'
+    )
+  })
+
+  it('should shorten tierCn to last two chars with short option', () => {
+    expect(
+      formatTierText(queueInfo({ tier: 'PLATINUM', tierCn: '华贵铂金', division: 'I' }), {
+        short: true
+      })
+    ).toBe('铂金 I')
+  })
+
+  it('should show league points for master and above', () => {
+    expect(
+      formatTierText(queueInfo({ tier: 'MASTER', tierCn: '超凡大师', leaguePoints: 233 }))
+    ).toBe('超凡大师 233')
+  })
+})

--- a/lol-record-analysis-tauri/src/utils/colors.ts
+++ b/lol-record-analysis-tauri/src/utils/colors.ts
@@ -12,7 +12,8 @@ const palette = {
   light: {
     good: '#2d8a6c',
     bad: '#b84242',
-    neutral: 'rgba(0, 0, 0, 0.6)'
+    // 冷墨而非纯黑：纯黑 60% 在浅色卡面上是一根「脏黑棒」
+    neutral: 'rgba(20, 30, 35, 0.55)'
   }
 }
 

--- a/lol-record-analysis-tauri/src/utils/rank.ts
+++ b/lol-record-analysis-tauri/src/utils/rank.ts
@@ -19,3 +19,22 @@ export const divisionOrPoint = (queueInfo: QueueInfo) => {
   }
   return queueInfo.division
 }
+
+/**
+ * 是否有有效段位。
+ * LCU 未定级时 tier 为 "UNRANKED"（或缺失时为空串）、division 为 "NA"，
+ * 直接拼接会渲染出「无 NA」这种半成品文案。
+ */
+export const hasRealTier = (queueInfo: QueueInfo) =>
+  !!queueInfo.tier && queueInfo.tier !== 'UNRANKED' && queueInfo.tier !== 'NONE'
+
+/**
+ * 段位展示文案：`中文段位 分段/胜点`，未定级统一显示「无段位」
+ * @param queueInfo - 单个队列的段位信息
+ * @param opts.short - 中文段位只取后两字（如「华贵铂金」→「铂金」），用于空间紧张的卡片
+ */
+export const formatTierText = (queueInfo: QueueInfo, opts?: { short?: boolean }) => {
+  if (!hasRealTier(queueInfo)) return '无段位'
+  const tier = opts?.short ? queueInfo.tierCn.slice(-2) : queueInfo.tierCn
+  return `${tier} ${divisionOrPoint(queueInfo)}`
+}

--- a/lol-record-analysis-tauri/src/views/Gaming.vue
+++ b/lol-record-analysis-tauri/src/views/Gaming.vue
@@ -1,6 +1,15 @@
+<!--
+  注意：本组件被 Framework 的 <Transition mode="out-in"> 包裹，模板根层级
+  （含各 v-if 分支的直接子级）必须保持单元素——dev 模式下模板注释会保留成
+  vnode，与元素并列会让根变成 Fragment，离场过渡卡死（表现为切页黑屏、点不回去）。
+  要写注释请放元素内部或这里。
+-->
 <template>
   <template v-if="!sessionData.phase">
-    <LoadingComponent>等待加入游戏...</LoadingComponent>
+    <LoadingComponent :hint="isConnected ? '进入英雄选择后这里会自动展示对局分析' : undefined">
+      <!-- 已连接时不提示「启动客户端」——那会跟左下角的绿色连接灯自相矛盾 -->
+      {{ isConnected ? '等待加入游戏...' : '未连接到客户端' }}
+    </LoadingComponent>
   </template>
   <template v-else>
     <div class="gaming-page">
@@ -135,6 +144,7 @@
           :phase="sessionData.phase"
           :opgg-mode="opggMode"
           :my-champion-ids="myChampionIds"
+          :my-puuid="mySummonerPuuid"
         />
       </div>
     </div>
@@ -157,6 +167,7 @@ import {
 import { renderAnalysisReport } from '@renderer/services/ai/matchDetail/renderReport'
 import { useSessionSync } from '@renderer/composables/useSessionSync'
 import { useSessionTiers } from '@renderer/composables/useSessionTiers'
+import { useGameState } from '@renderer/composables/useGameState'
 import { useAssetUrl } from '@renderer/composables/useAssetUrl'
 import {
   ensureOpggData,
@@ -176,6 +187,10 @@ const STAGE_STEPS: Array<{ key: string; label: string }> = [
 const { sessionData, requestSessionData } = useSessionSync()
 const tiersBySubteam = useSessionTiers(sessionData)
 const { getChampionUrl } = useAssetUrl()
+const { isConnected, summoner: mySummoner } = useGameState()
+
+/** 自己的 puuid，用于在玩家卡上标出「我」 */
+const mySummonerPuuid = computed(() => mySummoner.value?.puuid ?? '')
 
 const density = computed<'normal' | 'compact'>(() =>
   sessionData.isMultiTeam ? 'compact' : 'normal'
@@ -313,6 +328,8 @@ onMounted(async () => {
 <style lang="css" scoped>
 .gaming-page {
   padding: var(--space-16);
+  /* 右缘悬浮按钮（设置/AI）占一条竖向通道，多留白避免压在卡片内容上 */
+  padding-right: calc(var(--space-16) + 40px);
   height: 100%;
   box-sizing: border-box;
   position: relative;

--- a/lol-record-analysis-tauri/src/views/settings/Automation.vue
+++ b/lol-record-analysis-tauri/src/views/settings/Automation.vue
@@ -40,71 +40,78 @@
         <n-switch v-model:value="autoPick" @update:value="updatePickSwitch" />
       </template>
 
-      <div class="rules-section">
-        <div class="section-title">
-          规则（按顺序匹配，第一条命中即用）
-          <n-button size="small" type="primary" ghost @click="openPickEdit()">+ 添加规则</n-button>
-        </div>
-        <VueDraggable
-          :model-value="pickRules"
-          @update:model-value="(next: PickRule[]) => savePickRules(next)"
-        >
-          <div v-for="rule in pickRules" :key="rule.id" class="rule-row">
-            <n-checkbox
-              :checked="rule.enabled"
-              @update:checked="(v: boolean) => togglePickRule(rule.id, v)"
-            />
-            <span class="rule-name">{{ rule.name }}</span>
-            <n-avatar
-              :src="assetPrefix + '/champion/' + rule.action.champion_id"
-              :fallback-src="`${assetPrefix}/champion/-1`"
-              :size="24"
-              style="flex-shrink: 0"
-            />
-            <span class="rule-summary">{{ summarize(rule) }}</span>
-            <n-button quaternary size="small" @click="openPickEdit(rule)">编辑</n-button>
-            <n-button quaternary type="error" size="small" @click="deletePickRule(rule.id)"
-              >删除</n-button
+      <!-- 开关关闭时整体降透明度：规则仍可编辑，但一眼能看出当前不生效 -->
+      <div :class="{ 'rules-inactive': !autoPick }">
+        <div class="rules-section">
+          <div class="section-title">
+            规则（按顺序匹配，第一条命中即用）
+            <n-button size="small" type="primary" ghost @click="openPickEdit()"
+              >+ 添加规则</n-button
             >
           </div>
-        </VueDraggable>
-      </div>
-
-      <div class="section-title">兜底（规则都没命中时按顺序选）</div>
-      <n-flex>
-        <VueDraggable ref="el" v-model="myPickData">
-          <n-tag
-            v-for="item in myPickData"
-            :key="item"
-            round
-            closable
-            :bordered="false"
-            @close="deletePickData(item)"
-            style="margin-right: var(--space-16)"
+          <VueDraggable
+            :model-value="pickRules"
+            @update:model-value="(next: PickRule[]) => savePickRules(next)"
           >
-            {{ options.filter(option => option.value === item)?.[0]?.label || `英雄 ${item}` }}
-            <template #avatar>
-              <n-avatar
-                :src="assetPrefix + '/champion/' + item"
-                :fallback-src="`${assetPrefix}/champion/-1`"
+            <div v-for="rule in pickRules" :key="rule.id" class="rule-row">
+              <n-checkbox
+                :checked="rule.enabled"
+                @update:checked="(v: boolean) => togglePickRule(rule.id, v)"
               />
-            </template>
-          </n-tag>
-        </VueDraggable>
-        <n-select
-          v-model:value="selectPickChampionId"
-          filterable
-          :filter="filterChampionFunc"
-          placeholder="添加英雄"
-          :render-tag="renderSingleSelectTag"
-          :render-label="renderLabel"
-          :options="options"
-          size="small"
-          @update:value="addPickData"
-          style="width: 170px"
-        />
-      </n-flex>
-      <n-text depth="3" style="font-size: var(--font-size-sm)">拖动可以改变选择英雄的优先级</n-text>
+              <span class="rule-name">{{ rule.name }}</span>
+              <n-avatar
+                :src="assetPrefix + '/champion/' + rule.action.champion_id"
+                :fallback-src="`${assetPrefix}/champion/-1`"
+                :size="24"
+                style="flex-shrink: 0"
+              />
+              <span class="rule-summary">{{ summarize(rule) }}</span>
+              <n-button quaternary size="small" @click="openPickEdit(rule)">编辑</n-button>
+              <n-button quaternary type="error" size="small" @click="deletePickRule(rule.id)"
+                >删除</n-button
+              >
+            </div>
+          </VueDraggable>
+        </div>
+
+        <div class="section-title">兜底（规则都没命中时按顺序选）</div>
+        <n-flex>
+          <VueDraggable ref="el" v-model="myPickData">
+            <n-tag
+              v-for="item in myPickData"
+              :key="item"
+              round
+              closable
+              :bordered="false"
+              @close="deletePickData(item)"
+              style="margin-right: var(--space-16)"
+            >
+              {{ options.filter(option => option.value === item)?.[0]?.label || `英雄 ${item}` }}
+              <template #avatar>
+                <n-avatar
+                  :src="assetPrefix + '/champion/' + item"
+                  :fallback-src="`${assetPrefix}/champion/-1`"
+                />
+              </template>
+            </n-tag>
+          </VueDraggable>
+          <n-select
+            v-model:value="selectPickChampionId"
+            filterable
+            :filter="filterChampionFunc"
+            placeholder="添加英雄"
+            :render-tag="renderSingleSelectTag"
+            :render-label="renderLabel"
+            :options="options"
+            size="small"
+            @update:value="addPickData"
+            style="width: 170px"
+          />
+        </n-flex>
+        <n-text depth="3" style="font-size: var(--font-size-sm)"
+          >拖动可以改变选择英雄的优先级</n-text
+        >
+      </div>
 
       <RuleEditModal
         v-model:show="pickModalShow"
@@ -129,71 +136,75 @@
         <n-switch v-model:value="autoBan" @update:value="updateBanSwitch" />
       </template>
 
-      <div class="rules-section">
-        <div class="section-title">
-          规则（按顺序匹配，第一条命中即用）
-          <n-button size="small" type="primary" ghost @click="openBanEdit()">+ 添加规则</n-button>
-        </div>
-        <VueDraggable
-          :model-value="banRules"
-          @update:model-value="(next: BanRule[]) => saveBanRules(next)"
-        >
-          <div v-for="rule in banRules" :key="rule.id" class="rule-row">
-            <n-checkbox
-              :checked="rule.enabled"
-              @update:checked="(v: boolean) => toggleBanRule(rule.id, v)"
-            />
-            <span class="rule-name">{{ rule.name }}</span>
-            <n-avatar
-              :src="assetPrefix + '/champion/' + rule.action.champion_id"
-              :fallback-src="`${assetPrefix}/champion/-1`"
-              :size="24"
-              style="flex-shrink: 0"
-            />
-            <span class="rule-summary">{{ summarize(rule) }}</span>
-            <n-button quaternary size="small" @click="openBanEdit(rule)">编辑</n-button>
-            <n-button quaternary type="error" size="small" @click="deleteBanRule(rule.id)"
-              >删除</n-button
-            >
+      <div :class="{ 'rules-inactive': !autoBan }">
+        <div class="rules-section">
+          <div class="section-title">
+            规则（按顺序匹配，第一条命中即用）
+            <n-button size="small" type="primary" ghost @click="openBanEdit()">+ 添加规则</n-button>
           </div>
-        </VueDraggable>
-      </div>
-
-      <div class="section-title">兜底（规则都没命中时按顺序选）</div>
-      <n-flex>
-        <VueDraggable ref="el" v-model="myBanData">
-          <n-tag
-            v-for="item in myBanData"
-            :key="item"
-            round
-            closable
-            @close="deleteBanData(item)"
-            :bordered="false"
-            style="margin-right: var(--space-16)"
+          <VueDraggable
+            :model-value="banRules"
+            @update:model-value="(next: BanRule[]) => saveBanRules(next)"
           >
-            {{ options.filter(option => option.value === item)?.[0]?.label || `英雄 ${item}` }}
-            <template #avatar>
-              <n-avatar
-                :src="assetPrefix + '/champion/' + item"
-                :fallback-src="`${assetPrefix}/champion/-1`"
+            <div v-for="rule in banRules" :key="rule.id" class="rule-row">
+              <n-checkbox
+                :checked="rule.enabled"
+                @update:checked="(v: boolean) => toggleBanRule(rule.id, v)"
               />
-            </template>
-          </n-tag>
-        </VueDraggable>
-        <n-select
-          v-model:value="selectBanChampionId"
-          filterable
-          :filter="filterChampionFunc"
-          placeholder="添加英雄"
-          :render-tag="renderSingleSelectTag"
-          :render-label="renderLabel"
-          :options="options"
-          size="small"
-          @update:value="addBanData"
-          style="width: 170px"
-        />
-      </n-flex>
-      <n-text depth="3" style="font-size: var(--font-size-sm)">拖动可以改变禁用英雄的优先级</n-text>
+              <span class="rule-name">{{ rule.name }}</span>
+              <n-avatar
+                :src="assetPrefix + '/champion/' + rule.action.champion_id"
+                :fallback-src="`${assetPrefix}/champion/-1`"
+                :size="24"
+                style="flex-shrink: 0"
+              />
+              <span class="rule-summary">{{ summarize(rule) }}</span>
+              <n-button quaternary size="small" @click="openBanEdit(rule)">编辑</n-button>
+              <n-button quaternary type="error" size="small" @click="deleteBanRule(rule.id)"
+                >删除</n-button
+              >
+            </div>
+          </VueDraggable>
+        </div>
+
+        <div class="section-title">兜底（规则都没命中时按顺序选）</div>
+        <n-flex>
+          <VueDraggable ref="el" v-model="myBanData">
+            <n-tag
+              v-for="item in myBanData"
+              :key="item"
+              round
+              closable
+              @close="deleteBanData(item)"
+              :bordered="false"
+              style="margin-right: var(--space-16)"
+            >
+              {{ options.filter(option => option.value === item)?.[0]?.label || `英雄 ${item}` }}
+              <template #avatar>
+                <n-avatar
+                  :src="assetPrefix + '/champion/' + item"
+                  :fallback-src="`${assetPrefix}/champion/-1`"
+                />
+              </template>
+            </n-tag>
+          </VueDraggable>
+          <n-select
+            v-model:value="selectBanChampionId"
+            filterable
+            :filter="filterChampionFunc"
+            placeholder="添加英雄"
+            :render-tag="renderSingleSelectTag"
+            :render-label="renderLabel"
+            :options="options"
+            size="small"
+            @update:value="addBanData"
+            style="width: 170px"
+          />
+        </n-flex>
+        <n-text depth="3" style="font-size: var(--font-size-sm)"
+          >拖动可以改变禁用英雄的优先级</n-text
+        >
+      </div>
 
       <RuleEditModal
         v-model:show="banModalShow"
@@ -408,6 +419,12 @@ const addPickData = async (value: any) => {
 
 .rules-section {
   margin-bottom: var(--space-12);
+}
+
+/* 功能开关关闭时的规则区：可编辑但视觉降权，避免被误读成正在生效 */
+.rules-inactive {
+  opacity: 0.45;
+  transition: opacity var(--dur-normal, 0.2s) ease;
 }
 
 .section-title {

--- a/lol-record-analysis-tauri/src/views/settings/DataSync.vue
+++ b/lol-record-analysis-tauri/src/views/settings/DataSync.vue
@@ -102,10 +102,19 @@ const riskAcknowledged = ref(false)
 const syncStatusText = computed(() => {
   if (cloudStore.syncing) return '同步中…'
   if (cloudStore.lastError) return `上次同步失败：${cloudStore.lastError}`
-  if (cloudStore.lastSyncAt)
-    return `上次同步：${new Date(cloudStore.lastSyncAt).toLocaleTimeString()}`
+  if (cloudStore.lastSyncAt) return `上次同步：${formatSyncTime(cloudStore.lastSyncAt)}`
   return '本次启动尚未同步'
 })
+
+/**
+ * 上次同步时间展示：当天只显时间，跨天补日期。
+ * 只显 toLocaleTimeString 会让昨天 22:51 的同步看起来像刚同步过。
+ */
+function formatSyncTime(ts: number): string {
+  const d = new Date(ts)
+  const sameDay = d.toDateString() === new Date().toDateString()
+  return sameDay ? d.toLocaleTimeString() : d.toLocaleString()
+}
 
 /** 导出:系统保存对话框选路径 → Rust export_backup 全量写文件(过滤在 Rust 侧) */
 async function handleExport(): Promise<void> {

--- a/lol-record-analysis-tauri/src/views/settings/PlayerNotes.vue
+++ b/lol-record-analysis-tauri/src/views/settings/PlayerNotes.vue
@@ -112,6 +112,8 @@ const columns = computed<DataTableColumns<Row>>(() => [
   {
     title: '玩家',
     key: 'gameName',
+    // 固定最小宽度 + tag 禁止折行：否则窄窗口下 #12345 会在数字中间断行
+    minWidth: 200,
     render(row) {
       return h(
         'div',
@@ -119,12 +121,15 @@ const columns = computed<DataTableColumns<Row>>(() => [
         [
           h(
             NEllipsis,
-            { style: 'max-width:160px;font-weight:600' },
+            { style: 'max-width:220px;font-weight:600' },
             { default: () => row.gameName || '(未知)' }
           ),
           h(
             'span',
-            { style: 'color:var(--text-tertiary);font-size:var(--font-size-sm)' },
+            {
+              style:
+                'color:var(--text-tertiary);font-size:var(--font-size-sm);white-space:nowrap;flex:none'
+            },
             `#${row.tagLine}`
           )
         ]
@@ -136,7 +141,7 @@ const columns = computed<DataTableColumns<Row>>(() => [
     key: 'note',
     render(row) {
       if (!row.note) return h('span', { style: 'color:var(--text-tertiary)' }, '—')
-      return h(NEllipsis, { style: 'max-width:240px' }, { default: () => row.note })
+      return h(NEllipsis, { style: 'max-width:360px' }, { default: () => row.note })
     }
   },
   {


### PR DESCRIPTION
## Summary
- **对局页修复**：选人期卡片闪烁（同步守卫 + 原位合并 + recentData 签名回归修复）、空闲态切页黑屏（Transition Fragment 根卡死）、段位「无 NA」、禁用态降红、「我」徽章、遇见过 ×N、OP.GG/预组队 tooltip、迷你战绩 KDA 对齐与字体统一
- **战绩/设置页修复**：指标 tooltip 整行触发并注明占比含义、日期完整时间、备注表列宽、同步时间跨天补日期、自动化关闭态降权、顶栏 backdrop-filter 移除（透明窗口合成层冻结）
- **浅色主题重做（冷瓷）**：纸面海拔材质体系、冷墨基调、白 scrim 根除灰压彩、好友/宿敌双空收单行
- **滚轮缩放**：Ctrl+滚轮/±/0，0.7~1.5，持久化+多窗口恢复，WebView2 布局缩放
- **版本趋势徽章（双源）**：OP.GG rank_prev_patch 保底（国服网络可用，V16.14 实测 14 个 |Δ|≥10）+ Wiki 官方明细增强；娱乐标签排位专属（含幂等迁移）

## Test plan
- [x] `npm run check` passes
- [x] `npm run test` passes（570 例，含 9 个新增回归/单元测试）
- [x] `cargo test` passes（251 例，含补丁解析/趋势字段/标签迁移新测试）
- [x] Manual: 真机（Win/国服）验证选人期闪烁与黑屏修复、浅深主题切换、缩放持久化恢复、OP.GG 趋势数据链路