### PR TITLE
feat(record): 战绩详情多杀徽章——修复多杀字段被反序列化丢弃

### DIFF
--- a/docs/superpowers/specs/2026-07-18-multikill-badges-design.md
+++ b/docs/superpowers/specs/2026-07-18-multikill-badges-design.md
@@ -1,0 +1,35 @@
+# 战绩详情多杀徽章（三杀/四杀/五杀）— 设计
+
+日期：2026-07-18
+状态：已口头批准（方案 A 徽章行 + 不显示双杀），本文档为实现依据
+
+## 背景与根因
+
+用户要求战绩详情显示三杀/四杀/五杀。排查发现数据在 Rust 反序列化层就被丢了：
+`lcu/api/model.rs::Stats` 未声明 `doubleKills/tripleKills/quadraKills/pentaKills`。
+连带潜伏 bug：AI 复盘 snapshot 的 `(stats as any).tripleKills ?? 0` 因此恒为 0，
+multiKills 证据从未生效。SGP 兜底源同名扁平字段（`from_value` 直灌 `Stats`），
+Rust 加字段一处两源同修。
+
+## 方案（已选 A）
+
+### 数据层
+- Rust `Stats` += 4 个字段：`#[serde(rename = "doubleKills", default)] pub double_kills: i32`
+  及 triple/quadra/penta 同式。测试构造处均用 `..Default::default()`，无破坏。
+- 前端 `ParticipantStats` += 可选字段 `doubleKills?/tripleKills?/quadraKills?/pentaKills?: number`
+  （旧缓存数据无此字段，可选 + `?? 0` 兜底）。
+- `shared/snapshot.ts` 摘掉 `as any`，改typed访问（行为不变，潜伏 bug 随 Rust 字段修复）。
+
+### UI 层（useMatchDetailPlayers + MatchDetailModal 样式）
+- 新增多杀荣誉徽章，插在"最多"类徽章**前面**，顺序 五杀 > 四杀 > 三杀：
+  - label：次数 1 → "五杀"；次数 >1 → "五杀×2"。
+  - 双杀不出徽章（数据照样透传）。
+  - 图标统一 FlashOutline，配色分档：penta 金 / quadra 紫 / triple 蓝，
+    CSS class `match-detail-badge-penta/quadra/triple` 加在 MatchDetailModal.vue 样式区。
+- 模板零改动（badges v-for 自动渲染）。
+
+## 测试
+- Rust：Stats 反序列化含多杀字段 → 保留；缺失 → 0。
+- useMatchDetailPlayers.spec：pentaKills=1 → "五杀"徽章；tripleKills=2 → "三杀×2"；
+  全 0 → 无多杀徽章；doubleKills>0 不出徽章；多杀徽章排在"最多"类之前。
+- snapshot 测试：stats 带 tripleKills → snapshot.multiKills.triple 取到值。

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/model.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/model.rs
@@ -83,6 +83,16 @@ pub struct Stats {
     pub kills: i32,
     pub deaths: i32,
     pub assists: i32,
+    // 多杀次数（LCU 与 SGP match-v5 同名扁平字段）。default：旧缓存/残缺数据无此字段时为 0。
+    // ⚠️ 曾因未声明被 serde 丢弃，导致前端详情页与 AI snapshot 的 multiKills 恒为 0。
+    #[serde(rename = "doubleKills", default)]
+    pub double_kills: i32,
+    #[serde(rename = "tripleKills", default)]
+    pub triple_kills: i32,
+    #[serde(rename = "quadraKills", default)]
+    pub quadra_kills: i32,
+    #[serde(rename = "pentaKills", default)]
+    pub penta_kills: i32,
     #[serde(rename = "goldEarned")]
     pub gold_earned: i32,
     #[serde(rename = "goldSpent")]
@@ -168,5 +178,39 @@ mod tests {
         let stats: Stats = serde_json::from_str(json).unwrap();
         assert_eq!(stats.player_subteam_id, 0);
         assert_eq!(stats.subteam_placement, 0);
+    }
+
+    /// 多杀字段必须透传——曾因 Stats 未声明这些字段被 serde 丢弃，
+    /// 前端详情页与 AI 复盘 snapshot 的 multiKills 一直拿到 0。
+    #[test]
+    fn should_deserialize_multi_kill_fields() {
+        let json = r#"{
+            "win": true,
+            "item0": 0, "item1": 0, "item2": 0, "item3": 0, "item4": 0, "item5": 0, "item6": 0,
+            "perkPrimaryStyle": 0, "perkSubStyle": 0,
+            "kills": 19, "deaths": 3, "assists": 21,
+            "goldEarned": 25500, "goldSpent": 24000,
+            "totalDamageDealtToChampions": 82700, "totalDamageDealt": 200000,
+            "totalDamageTaken": 35200, "totalHeal": 10300,
+            "totalMinionsKilled": 200,
+            "doubleKills": 3, "tripleKills": 2, "quadraKills": 1, "pentaKills": 1
+        }"#;
+        let stats: Stats = serde_json::from_str(json).unwrap();
+        assert_eq!(stats.double_kills, 3);
+        assert_eq!(stats.triple_kills, 2);
+        assert_eq!(stats.quadra_kills, 1);
+        assert_eq!(stats.penta_kills, 1);
+    }
+
+    /// 旧缓存/SGP 缺字段时默认 0，且序列化输出 camelCase 供前端消费。
+    #[test]
+    fn should_default_and_serialize_multi_kill_fields() {
+        let stats = Stats {
+            penta_kills: 1,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&stats).unwrap();
+        assert!(json.contains("\"pentaKills\":1"));
+        assert!(json.contains("\"tripleKills\":0"));
     }
 }

--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -1265,6 +1265,20 @@ watch(
   background: color-mix(in srgb, var(--accent-blue) 14%, transparent);
 }
 
+/* 多杀荣誉徽章：五杀金（底色更浓一档以示最高荣誉）/ 四杀琥珀 / 三杀蓝 */
+.match-detail-badge-penta {
+  color: var(--accent-gold);
+  background: color-mix(in srgb, var(--accent-gold) 22%, transparent);
+}
+.match-detail-badge-quadra {
+  color: var(--semantic-warn);
+  background: color-mix(in srgb, var(--semantic-warn) 16%, transparent);
+}
+.match-detail-badge-triple {
+  color: var(--accent-sky);
+  background: color-mix(in srgb, var(--accent-sky) 14%, transparent);
+}
+
 .match-detail-build-cell {
   display: flex;
   flex-direction: column;

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.spec.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.spec.ts
@@ -8,6 +8,7 @@ vi.mock('@vicons/ionicons5', () => ({
   CashOutline: {},
   FlagOutline: {},
   FlameOutline: {},
+  FlashOutline: {},
   FootstepsOutline: {},
   PeopleOutline: {},
   ShieldOutline: {},
@@ -261,5 +262,71 @@ describe('useMatchDetailPlayers - 伤害徽章与 WeGame 式 MVP', () => {
     expect(byId(4).mvpTag).toBe('')
     // 评分单调性：carry 分应高于蹭分型
     expect(byId(2).score).toBeGreaterThan(byId(1).score)
+  })
+})
+
+describe('useMatchDetailPlayers - 多杀徽章', () => {
+  function makeGame(statsOverrides: Partial<ParticipantStats>): Game {
+    return {
+      mvp: '',
+      gameDetail: { endOfGameResult: '', participantIdentities: [], participants: [] },
+      gameId: 9,
+      gameCreationDate: '2026-07-18T00:00:00Z',
+      gameDuration: 2400,
+      gameMode: 'CLASSIC',
+      gameType: '',
+      mapId: 11,
+      queueId: 420,
+      queueName: '单双排位',
+      platformId: '',
+      participantIdentities: Array.from({ length: 2 }, (_, i) => ({
+        player: {
+          accountId: 0,
+          platformId: '',
+          gameName: `P${i + 1}`,
+          tagLine: '0001',
+          summonerName: '',
+          summonerId: 0
+        }
+      })),
+      participants: [
+        makeP(1, 100, makeStats({ win: true, kills: 19, ...statsOverrides })),
+        makeP(2, 200, makeStats({ win: false, kills: 2 }))
+      ]
+    }
+  }
+
+  const badgesOf = (game: Game, id: number) => {
+    const { detailPlayers } = useMatchDetailPlayers(ref(game), ref(''))
+    return detailPlayers.value.find(p => p.participantId === id)!.badges
+  }
+
+  it('五杀 1 次 → "五杀" 徽章', () => {
+    const badges = badgesOf(makeGame({ pentaKills: 1 }), 1)
+    const penta = badges.find(b => b.key === 'penta')
+    expect(penta?.label).toBe('五杀')
+  })
+
+  it('三杀 2 次 → "三杀×2" 徽章，且排在"最多"类徽章前面', () => {
+    const badges = badgesOf(makeGame({ tripleKills: 2 }), 1)
+    const triple = badges.find(b => b.key === 'triple')
+    expect(triple?.label).toBe('三杀×2')
+    const tripleIdx = badges.findIndex(b => b.key === 'triple')
+    const killsIdx = badges.findIndex(b => b.key === 'kills')
+    expect(killsIdx).toBeGreaterThan(-1)
+    expect(tripleIdx).toBeLessThan(killsIdx)
+  })
+
+  it('四杀 + 五杀同局 → 两枚徽章，五杀在前', () => {
+    const badges = badgesOf(makeGame({ pentaKills: 1, quadraKills: 1 }), 1)
+    const keys = badges.map(b => b.key)
+    expect(keys.indexOf('penta')).toBeGreaterThan(-1)
+    expect(keys.indexOf('quadra')).toBeGreaterThan(-1)
+    expect(keys.indexOf('penta')).toBeLessThan(keys.indexOf('quadra'))
+  })
+
+  it('无多杀 → 不出多杀徽章；双杀不出徽章', () => {
+    const badges = badgesOf(makeGame({ doubleKills: 3 }), 1)
+    expect(badges.some(b => ['penta', 'quadra', 'triple'].includes(b.key))).toBe(false)
   })
 })

--- a/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
+++ b/lol-record-analysis-tauri/src/composables/useMatchDetailPlayers.ts
@@ -11,6 +11,7 @@ import {
   CashOutline,
   FlagOutline,
   FlameOutline,
+  FlashOutline,
   FootstepsOutline,
   PeopleOutline,
   ShieldOutline,
@@ -100,6 +101,46 @@ export function computeMatchScore(s: ParticipantStats, ctx: ScoreContext): numbe
       0.08 * norm(totalCs(s), ctx.max.cs) +
       0.06 * norm(s.damageDealtToTurrets, ctx.max.turret))
   )
+}
+
+/**
+ * 多杀荣誉徽章：三杀及以上才上榜（双杀太常见，出徽章反而注水），
+ * 次数 >1 时 label 带 "×N"。顺序即展示顺序：五杀 > 四杀 > 三杀，整体排在"最多"类徽章前。
+ */
+const multiKillBadgeConfigs = [
+  {
+    key: 'penta',
+    label: '五杀',
+    className: 'match-detail-badge-penta',
+    value: (s: ParticipantStats) => s.pentaKills ?? 0
+  },
+  {
+    key: 'quadra',
+    label: '四杀',
+    className: 'match-detail-badge-quadra',
+    value: (s: ParticipantStats) => s.quadraKills ?? 0
+  },
+  {
+    key: 'triple',
+    label: '三杀',
+    className: 'match-detail-badge-triple',
+    value: (s: ParticipantStats) => s.tripleKills ?? 0
+  }
+]
+
+/** 单玩家的多杀徽章列表（无多杀时为空数组） */
+function multiKillBadges(stats: ParticipantStats): PlayerBadge[] {
+  return multiKillBadgeConfigs
+    .filter(cfg => cfg.value(stats) > 0)
+    .map(cfg => {
+      const count = cfg.value(stats)
+      return {
+        key: cfg.key,
+        label: count > 1 ? `${cfg.label}×${count}` : cfg.label,
+        icon: FlashOutline,
+        className: cfg.className
+      }
+    })
 }
 
 const badgeConfigs = [
@@ -258,14 +299,17 @@ export function useMatchDetailPlayers(
           tagLine: identity?.player.tagLine ?? '',
           isMe: displayName === toValue(currentPlayerKey),
           win: p.stats.win,
-          badges: badgeConfigs
-            .filter(cfg => badgeWinners.get(cfg.label)?.has(p.participantId))
-            .map(cfg => ({
-              key: cfg.key,
-              label: cfg.label,
-              icon: cfg.icon,
-              className: cfg.className
-            })),
+          badges: [
+            ...multiKillBadges(p.stats),
+            ...badgeConfigs
+              .filter(cfg => badgeWinners.get(cfg.label)?.has(p.participantId))
+              .map(cfg => ({
+                key: cfg.key,
+                label: cfg.label,
+                icon: cfg.icon,
+                className: cfg.className
+              }))
+          ],
           teamRelative: {
             damage: safeRelativePercent(p.stats.totalDamageDealtToChampions, totals.damage),
             taken: safeRelativePercent(p.stats.totalDamageTaken, totals.taken),

--- a/lol-record-analysis-tauri/src/services/ai/shared/__tests__/snapshot.spec.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/__tests__/snapshot.spec.ts
@@ -108,6 +108,26 @@ describe('buildMatchSnapshot', () => {
     expect(snap.players[0].role).toBe('NONE')
   })
 
+  it('passes through multiKills（后端曾丢字段导致恒 0 的回归锚点）', () => {
+    const p = makeParticipant()
+    p.stats.doubleKills = 3
+    p.stats.tripleKills = 2
+    p.stats.quadraKills = 1
+    p.stats.pentaKills = 1
+    const snap = buildMatchSnapshot(makeGame({ participants: [p] }))
+    expect(snap.players[0].multiKills).toEqual({ double: 3, triple: 2, quadra: 1, penta: 1 })
+  })
+
+  it('defaults multiKills to 0 when 旧缓存数据缺字段', () => {
+    const p = makeParticipant()
+    delete (p.stats as any).doubleKills
+    delete (p.stats as any).tripleKills
+    delete (p.stats as any).quadraKills
+    delete (p.stats as any).pentaKills
+    const snap = buildMatchSnapshot(makeGame({ participants: [p] }))
+    expect(snap.players[0].multiKills).toEqual({ double: 0, triple: 0, quadra: 0, penta: 0 })
+  })
+
   it('augment mode → items array is empty', () => {
     const snap = buildMatchSnapshot(makeGame({ queueId: 2400, gameMode: 'ARAM' }))
     expect(snap.players[0].items).toEqual([])

--- a/lol-record-analysis-tauri/src/services/ai/shared/snapshot.ts
+++ b/lol-record-analysis-tauri/src/services/ai/shared/snapshot.ts
@@ -179,11 +179,12 @@ export function buildMatchSnapshot(
       wardScore: (stats as any).visionScore ?? 0,
       controlWardsPlaced: (stats as any).sightWardsBoughtInGame ?? 0,
       visionWardsBought: (stats as any).visionWardsBoughtInGame ?? 0,
+      // 多杀字段已在类型上声明（后端曾丢弃该字段导致这里恒为 0，现已透传）
       multiKills: {
-        double: (stats as any).doubleKills ?? 0,
-        triple: (stats as any).tripleKills ?? 0,
-        quadra: (stats as any).quadraKills ?? 0,
-        penta: (stats as any).pentaKills ?? 0
+        double: stats.doubleKills ?? 0,
+        triple: stats.tripleKills ?? 0,
+        quadra: stats.quadraKills ?? 0,
+        penta: stats.pentaKills ?? 0
       },
       recentProfile: profileMap?.get(puuid) ?? null
     }

--- a/lol-record-analysis-tauri/src/types/domain/match.ts
+++ b/lol-record-analysis-tauri/src/types/domain/match.ts
@@ -36,6 +36,11 @@ export interface ParticipantStats {
   kills: number
   deaths: number
   assists: number
+  /** 多杀次数（LCU/SGP 同名字段；旧缓存数据可能缺失，消费方需 `?? 0` 兜底） */
+  doubleKills?: number
+  tripleKills?: number
+  quadraKills?: number
+  pentaKills?: number
   goldEarned: number
   goldSpent: number
   totalDamageDealtToChampions: number


### PR DESCRIPTION
## Summary
- Rust `Stats` 补上 `doubleKills/tripleKills/quadraKills/pentaKills`（serde default）——此前 LCU/SGP 数据在反序列化层被丢弃，前端拿不到，AI 复盘 snapshot 的 multiKills 也因此恒为 0（潜伏 bug 一并修复）
- 战绩详情荣誉徽章行新增 五杀(金)/四杀(琥珀)/三杀(蓝)，多次显示 ×N；双杀不展示（数据照样透传）
- `snapshot.ts` multiKills 改类型化访问，加回归测试锚点
- 已缓存对局需等缓存刷新才有多杀数据（老缓存序列化时字段已丢）
- 设计文档：`docs/superpowers/specs/2026-07-18-multikill-badges-design.md`

## Test plan
- [x] `npm run check` passes（本分支独立状态）
- [x] `npm run test` passes（576，含 6 个新增用例）
- [x] `cargo test` passes（259，含 2 个反序列化/序列化新用例）
- [ ] Manual: 翻一局有三杀+的对局开详情确认徽章渲染与配色