### PR TITLE
chore(sentry): DSN 改编译期 env 注入，不再硬编码进源码

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,9 @@ jobs:
           # 编译期注入 DashScope 密钥：Rust 侧 option_env!("DASHSCOPE_API_KEY") 在
           # cargo build 时读取并烤进二进制（线上 key）。需在仓库 Secrets 配置。
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          # 同款套路注入 Sentry DSN：observability.rs 的 option_env!("SENTRY_DSN") 烤进二进制。
+          # 不再硬编码进源码，fork 不带此 secret 即不上报。需在仓库 Secrets 配置。
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       # --- 文件重命名、压缩与路径整理 ---
       - name: 📝 Rename, Compress, and Set Paths

--- a/lol-record-analysis-tauri/src-tauri/build.rs
+++ b/lol-record-analysis-tauri/src-tauri/build.rs
@@ -1,5 +1,8 @@
 fn main() {
     emit_app_version();
+    // `SENTRY_DSN` 经 observability.rs 的 option_env! 在编译期烤进二进制；
+    // env 变化时需触发 crate 重编，否则 cargo 会复用旧值。
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN");
     tauri_build::build()
 }
 

--- a/lol-record-analysis-tauri/src-tauri/src/observability.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/observability.rs
@@ -28,17 +28,13 @@
 //! - **debug 构建**：默认开启，方便开发期验证。
 //! - **release 构建**：默认关闭，用户需在「设置 → 常规」中开启 `errorReportingEnabled`
 //!   （opt-in），重启后生效。
+//! - 无论开关如何，未配置 `SENTRY_DSN`（[`dsn`]）时上报静默关闭——fork 自建须自带
+//!   DSN，否则不会误报到上游项目。
 
 use regex::Regex;
 use sentry::protocol::{Event, Log, User, Value};
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
-
-/// Sentry 项目的 DSN（公开 client key，设计上即随客户端分发）。
-///
-/// 可在编译期通过 `SENTRY_DSN` 环境变量覆盖（例如 fork 自建项目）。
-pub const DEFAULT_DSN: &str =
-    "https://4730d54dc96cffafff9dbd30d0699911@o4511465480060928.ingest.us.sentry.io/4511471007825920";
 
 /// 配置中控制是否开启错误上报的键名（以 `Enabled` 结尾 → 默认 `false`）。
 pub const REPORTING_KEY: &str = "errorReportingEnabled";
@@ -46,9 +42,17 @@ pub const REPORTING_KEY: &str = "errorReportingEnabled";
 /// 持久化匿名设备 ID 的文件名（与 `config.yaml` 同目录，相对 CWD）。
 pub const DEVICE_ID_FILE: &str = "device_id";
 
-/// 解析最终使用的 DSN（环境变量优先）。
-fn dsn() -> String {
-    option_env!("SENTRY_DSN").unwrap_or(DEFAULT_DSN).to_string()
+/// 解析最终使用的 Sentry DSN：运行时环境变量（开发/测试）→ `option_env!` 编译期注入（线上 CI）。
+///
+/// **DSN 不再硬编码进源码**：官方构建由 CI 在 `tauri build` 时设 `SENTRY_DSN`
+/// （与 `DASHSCOPE_API_KEY` 同款套路，见 `.github/workflows/release.yml`），明文不进 git。
+/// fork 未配置 `SENTRY_DSN` 时解析为 `None` → 上报直接关闭，崩溃不会误灌到上游项目。
+fn dsn() -> Option<String> {
+    std::env::var("SENTRY_DSN")
+        .ok()
+        .or_else(|| option_env!("SENTRY_DSN").map(str::to_string))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// 判断当前是否应当开启错误上报。
@@ -77,9 +81,17 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
         return None;
     }
 
+    let Some(dsn) = dsn() else {
+        log::info!(
+            "Sentry error reporting disabled: no SENTRY_DSN configured \
+             (set the SENTRY_DSN env var at build time to enable)"
+        );
+        return None;
+    };
+
     let device_id = device_id(Path::new(DEVICE_ID_FILE));
     let guard = sentry::init((
-        dsn(),
+        dsn,
         sentry::ClientOptions {
             release: Some(format!("lol-record-analysis-app@{}", env!("APP_VERSION")).into()),
             send_default_pii: false,


### PR DESCRIPTION
## Summary
- 起因：排查 DAU 时发现 Sentry 里混入 `zko-record-assistant@2.x`——某人 fork 本项目换皮、**没改 Sentry DSN**，其 debug 崩溃全灌进本项目，污染 release 分布 / 配额。根因是 DSN 硬编码在开源仓库里，任何 fork clone 一跑都上报到上游。
- 方案：照抄本仓库既有的 `DASHSCOPE_API_KEY` 套路，把 DSN 挪成**编译期 env 注入**，字面量从源码删除。
  - `observability.rs`：删 `DEFAULT_DSN`；`dsn()` 改为返回 `Option<String>`，解析顺序 运行时 `SENTRY_DSN`(开发/测试) → `option_env!`(CI 编译期烤入) → `None`；`init()` 在 DSN 缺失时打日志并 `return None`（静默关上报）。
  - `build.rs`：加 `cargo:rerun-if-env-changed=SENTRY_DSN`。
  - `release.yml`：build 步 env 注入 `secrets.SENTRY_DSN`（已在仓库 Secrets 配置）。
- 效果：官方发版照常上报；**fork 不带 secret 即不上报**，从根断掉误灌。仅新版生效，不动旧版 / 不 rotate 现有 DSN。

## Test plan
- [x] `vue-tsc --noEmit` 干净（本 PR 无前端改动）
- [x] `cargo fmt --all -- --check` 干净
- [ ] `cargo clippy -Dwarnings`：mac 本地因 `token.rs` winapi 无法编译，**靠 Windows CI 验证**
- [ ] 发版后确认新版本仍正常上报到 Sentry（`SENTRY_DSN` secret 已配）