### PR TITLE
feat(gaming): 玩家卡标签优先级排序与+N溢出收纳,修重叠换行

### DIFF
--- a/docs/superpowers/specs/2026-07-24-tag-overflow-row-design.md
+++ b/docs/superpowers/specs/2026-07-24-tag-overflow-row-design.md
@@ -1,0 +1,31 @@
+# 玩家标签行:优先级排序 + 溢出收纳
+
+**日期**: 2026-07-24
+**状态**: 已批准(方案 A)
+**范围**: `UnifiedTagRow.vue` + `PlayerCard.vue`(对局页玩家卡),战绩页/对局详情随组件自动受益
+
+## 问题
+
+对局页玩家卡右上角标签簇(预组队 / 遇见过×N / 备注 chip / 系统标签)无优先级、无上限、自由换行:
+
+- 标签多的玩家换行到 2-3 行,`justify-content: flex-end` 导致每行起点参差("排序不工整");
+- 标签区和名字/段位行同处一个受限高度的 flex 行,换行撑高后与段位行的 `版本↑` 徽章重叠;
+- 色彩过载:黄/红/绿/粉各说各话。
+
+## 设计决策
+
+| 决策点 | 结论 |
+|---|---|
+| 优先级排序 | 备注 > 预组队 > 遇见过 > 系统 bad > 系统 good(bad 警示价值高于 good) |
+| 可见上限 | `UnifiedTagRow` 新增 `maxVisible` prop;PlayerCard 传 2;其他调用点不传 = 不限(行为不变) |
+| 溢出交互 | 超出部分收进一个 `+N` 中性 chip,click 弹 popover 列出全部溢出 chip,溢出 chip 保留原有 tooltip(tagDesc)与点击固化交互 |
+| 单行强制 | `.profile-tags` 改 `flex-wrap: nowrap`;预组队/遇见过物理在前(DOM 顺序即优先级),`UnifiedTagRow` 内部 note 最前、bad 在 good 前 |
+| 排序位置 | `UnifiedTagRow` 内新增纯函数 `orderTags(tags)`(bad 前 good 后,同组保持后端原序),单测覆盖 |
+| 不做 | 不动 OP.GG chip / 版本徽章(它们在段位行,归属正确);不改 chip 配色体系(留给亮色批 2) |
+
+## 验收
+
+- 对局页 10 张玩家卡标签区全部单行,无重叠、右对齐工整;
+- 标签溢出的玩家出现 `+N`,点开能看到全部并可固化为备注;
+- 战绩页/对局详情的 UnifiedTagRow 行为不变(不传 maxVisible);
+- 真机双主题截图确认;`npm run check` + `npm run test` 全绿,orderTags/切片逻辑有单测。

--- a/docs/superpowers/specs/2026-07-24-tag-overflow-row-design.md
+++ b/docs/superpowers/specs/2026-07-24-tag-overflow-row-design.md
@@ -17,7 +17,7 @@
 | 决策点 | 结论 |
 |---|---|
 | 优先级排序 | 备注 > 预组队 > 遇见过 > 系统 bad > 系统 good(bad 警示价值高于 good) |
-| 可见上限 | `UnifiedTagRow` 新增 `maxVisible` prop;PlayerCard 传 2;其他调用点不传 = 不限(行为不变) |
+| 可见上限 | `UnifiedTagRow` 新增 `maxVisible` prop;PlayerCard 传动态上限(2 起,预组队/遇见过各占一槽递减,下限 0——实现期为满足"全部单行"验收线修订);其他调用点不传 = 不限 |
 | 溢出交互 | 超出部分收进一个 `+N` 中性 chip,click 弹 popover 列出全部溢出 chip,溢出 chip 保留原有 tooltip(tagDesc)与点击固化交互 |
 | 单行强制 | `.profile-tags` 改 `flex-wrap: nowrap`;预组队/遇见过物理在前(DOM 顺序即优先级),`UnifiedTagRow` 内部 note 最前、bad 在 good 前 |
 | 排序位置 | `UnifiedTagRow` 内新增纯函数 `orderTags(tags)`(bad 前 good 后,同组保持后端原序),单测覆盖 |
@@ -27,5 +27,5 @@
 
 - 对局页 10 张玩家卡标签区全部单行,无重叠、右对齐工整;
 - 标签溢出的玩家出现 `+N`,点开能看到全部并可固化为备注;
-- 战绩页/对局详情的 UnifiedTagRow 行为不变(不传 maxVisible);
+- 战绩页/对局详情的 UnifiedTagRow 溢出行为不变(不传 maxVisible);排序(bad 前 good 后)按设计全局生效,各调用点标签顺序统一;
 - 真机双主题截图确认;`npm run check` + `npm run test` 全绿,orderTags/切片逻辑有单测。

--- a/lol-record-analysis-tauri/src/components/common/UnifiedTagChip.vue
+++ b/lol-record-analysis-tauri/src/components/common/UnifiedTagChip.vue
@@ -1,0 +1,60 @@
+<template>
+  <n-popover trigger="click">
+    <template #trigger>
+      <n-tooltip trigger="hover" :disabled="!tag.tagDesc">
+        <template #trigger>
+          <n-tag
+            size="small"
+            round
+            :type="tag.good ? 'success' : 'error'"
+            :bordered="false"
+            class="unified-tag-chip"
+          >
+            {{ tag.tagName }}
+          </n-tag>
+        </template>
+        <span>{{ tag.tagDesc }}</span>
+      </n-tooltip>
+    </template>
+    <div class="solidify-pop">
+      <div class="solidify-pop-text">把「{{ tag.tagName }}」存为对该玩家的备注？</div>
+      <n-button size="tiny" type="primary" @click="emit('solidify', tag)">存为备注</n-button>
+    </div>
+  </n-popover>
+</template>
+
+<script setup lang="ts">
+/**
+ * 单个系统标签 chip：hover 看 tagDesc，点击弹「存为备注」确认
+ *
+ * 从 UnifiedTagRow 抽出，供主行与 +N 溢出列表复用同一套交互。
+ * 固化动作通过 emit 交回父级（store/message 逻辑留在 UnifiedTagRow）。
+ */
+import { NPopover, NTooltip, NTag, NButton } from 'naive-ui'
+import type { RankTag } from '@renderer/types/domain/analysis'
+
+/**
+ * 组件属性
+ * @property tag - 单个系统标签（tagName/tagDesc/good）
+ */
+defineProps<{ tag: RankTag }>()
+const emit = defineEmits<{ solidify: [tag: RankTag] }>()
+</script>
+
+<style scoped>
+.unified-tag-chip {
+  cursor: pointer;
+}
+
+.solidify-pop {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-6, 6px);
+}
+
+.solidify-pop-text {
+  font-size: var(--font-size-xs, 12px);
+  color: var(--text-secondary);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/common/UnifiedTagRow.vue
+++ b/lol-record-analysis-tauri/src/components/common/UnifiedTagRow.vue
@@ -10,27 +10,26 @@
       <span>[{{ noteMeta.text }}] {{ note.note || '（未填写文字）' }}</span>
     </n-popover>
 
-    <!-- 系统标签 chips：hover 看 tagDesc，点击弹「存为备注」确认 -->
-    <n-popover v-for="tag in tags" :key="tag.tagName" trigger="click">
+    <!-- 系统标签 chips：bad 前 good 后，超出 maxVisible 的收进 +N -->
+    <UnifiedTagChip
+      v-for="tag in visibleTags"
+      :key="tag.tagName"
+      :tag="tag"
+      @solidify="solidifyTag"
+    />
+    <n-popover v-if="overflowTags.length > 0" trigger="click">
       <template #trigger>
-        <n-tooltip trigger="hover" :disabled="!tag.tagDesc">
-          <template #trigger>
-            <n-tag
-              size="small"
-              round
-              :type="tag.good ? 'success' : 'error'"
-              :bordered="false"
-              class="unified-tag-chip"
-            >
-              {{ tag.tagName }}
-            </n-tag>
-          </template>
-          <span>{{ tag.tagDesc }}</span>
-        </n-tooltip>
+        <n-tag data-test="overflow-chip" size="small" round :bordered="false" class="overflow-chip">
+          +{{ overflowTags.length }}
+        </n-tag>
       </template>
-      <div class="solidify-pop">
-        <div class="solidify-pop-text">把「{{ tag.tagName }}」存为对该玩家的备注？</div>
-        <n-button size="tiny" type="primary" @click="solidifyTag(tag)">存为备注</n-button>
+      <div class="overflow-list">
+        <UnifiedTagChip
+          v-for="tag in overflowTags"
+          :key="tag.tagName"
+          :tag="tag"
+          @solidify="solidifyTag"
+        />
       </div>
     </n-popover>
   </div>
@@ -51,10 +50,12 @@
  * @see issue #67（手动打备注费劲 → 系统先算标签、用户点一下固化）
  */
 import { computed } from 'vue'
-import { NPopover, NTooltip, NTag, NButton, useMessage } from 'naive-ui'
+import { NPopover, NTag, useMessage } from 'naive-ui'
 import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
 import { getNoteLabelMeta } from '@renderer/types/domain/playerNote'
 import type { RankTag } from '@renderer/types/domain/analysis'
+import { orderTags, splitVisible } from './unifiedTagRow'
+import UnifiedTagChip from './UnifiedTagChip.vue'
 
 /**
  * 组件属性
@@ -62,12 +63,14 @@ import type { RankTag } from '@renderer/types/domain/analysis'
  * @property puuid - 玩家唯一标识（备注存取的 key）
  * @property gameName - 游戏名（固化备注时冗余写入，供设置列表展示）
  * @property tagLine - 标签行
+ * @property maxVisible - 最多可见系统标签数，超出收进 +N；不传 = 不限（战绩页/详情页行为不变）
  */
 interface Props {
   tags: RankTag[]
   puuid: string
   gameName: string
   tagLine: string
+  maxVisible?: number
 }
 const props = defineProps<Props>()
 
@@ -78,6 +81,13 @@ const message = useMessage()
 const note = computed(() => store.getNote(props.puuid))
 /** 备注色档元信息（无备注时回退 normal，仅在 note 存在时被渲染使用） */
 const noteMeta = computed(() => getNoteLabelMeta(note.value?.label ?? 'normal'))
+
+/** 排序后的系统标签（bad 前 good 后，稳定） */
+const orderedTags = computed(() => orderTags(props.tags))
+/** 直接渲染的部分 */
+const visibleTags = computed(() => splitVisible(orderedTags.value, props.maxVisible).visible)
+/** 收进 +N popover 的部分 */
+const overflowTags = computed(() => splitVisible(orderedTags.value, props.maxVisible).overflow)
 
 /** 备注 chip 文本最多展示的字符数（全文放 hover popover） */
 const NOTE_PREVIEW_LEN = 8
@@ -144,19 +154,15 @@ defineExpose({ solidifyTag })
   gap: var(--space-4);
 }
 
-.unified-tag-chip {
+.overflow-chip {
   cursor: pointer;
-}
-
-.solidify-pop {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-6, 6px);
-}
-
-.solidify-pop-text {
-  font-size: var(--font-size-xs, 12px);
   color: var(--text-secondary);
+}
+
+.overflow-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  max-width: 240px;
 }
 </style>

--- a/lol-record-analysis-tauri/src/components/common/__tests__/UnifiedTagRow.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/UnifiedTagRow.spec.ts
@@ -60,6 +60,9 @@ const tags: RankTag[] = [
   { tagName: '专精', tagDesc: '', good: true }
 ]
 
+/** 便捷构造：排序/溢出用例的最小标签 */
+const t2 = (tagName: string, good: boolean): RankTag => ({ tagName, tagDesc: '', good })
+
 /** 便捷挂载：默认无备注玩家 */
 function mountRow(props: Partial<InstanceType<typeof UnifiedTagRow>['$props']> = {}) {
   return mount(UnifiedTagRow, {
@@ -173,5 +176,37 @@ describe('UnifiedTagRow', () => {
     expect(saved?.label).toBe('friendly')
     expect(messageMock.warning).toHaveBeenCalledWith('备注已达长度上限，请先在备注面板整理')
     expect(messageMock.success).not.toHaveBeenCalled()
+  })
+
+  it('默认（未传 maxVisible）渲染全部标签且无 overflow chip', () => {
+    const w = mountRow()
+
+    expect(w.findAll('.unified-tag-chip')).toHaveLength(2)
+    expect(w.find('[data-test="overflow-chip"]').exists()).toBe(false)
+  })
+
+  it('bad 标签排在 good 前（与传入顺序无关）', () => {
+    // tags 定义里 good 的「专精」在后？否——固定用明确顺序的入参验证
+    const w = mountRow({ tags: [t2('专精', true), t2('炸鱼嫌疑', false)] })
+
+    const chips = w.findAll('.unified-tag-chip')
+    expect(chips[0].text()).toContain('炸鱼嫌疑')
+    expect(chips[1].text()).toContain('专精')
+  })
+
+  it('maxVisible=2 时超出标签收进 +N，溢出 chip 保留在 popover 内', () => {
+    const many: RankTag[] = [
+      t2('bad1', false),
+      t2('bad2', false),
+      t2('good1', true),
+      t2('good2', true)
+    ]
+    const w = mountRow({ tags: many, maxVisible: 2 })
+
+    // 可见 2 个 + 溢出列表 2 个（stub 使 popover 内容内联渲染，共 4 个 chip 节点）
+    const overflow = w.find('[data-test="overflow-chip"]')
+    expect(overflow.exists()).toBe(true)
+    expect(overflow.text()).toContain('+2')
+    expect(w.findAll('.unified-tag-chip')).toHaveLength(4)
   })
 })

--- a/lol-record-analysis-tauri/src/components/common/__tests__/unifiedTagRowHelpers.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/unifiedTagRowHelpers.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * unifiedTagRow 纯函数单元测试:排序稳定性与溢出切片边界
+ * @module components/common/__tests__/unifiedTagRowHelpers
+ */
+import { describe, it, expect } from 'vitest'
+import { orderTags, splitVisible } from '../unifiedTagRow'
+import type { RankTag } from '@renderer/types/domain/analysis'
+
+const t = (tagName: string, good: boolean): RankTag => ({ tagName, tagDesc: '', good })
+
+describe('orderTags', () => {
+  it('bad 排在 good 前', () => {
+    const result = orderTags([t('专精', true), t('炸鱼嫌疑', false)])
+    expect(result.map(x => x.tagName)).toEqual(['炸鱼嫌疑', '专精'])
+  })
+
+  it('同组保持原序(稳定排序)', () => {
+    const result = orderTags([t('good1', true), t('bad1', false), t('good2', true), t('bad2', false)])
+    expect(result.map(x => x.tagName)).toEqual(['bad1', 'bad2', 'good1', 'good2'])
+  })
+
+  it('不修改原数组', () => {
+    const input = [t('专精', true), t('炸鱼嫌疑', false)]
+    orderTags(input)
+    expect(input.map(x => x.tagName)).toEqual(['专精', '炸鱼嫌疑'])
+  })
+})
+
+describe('splitVisible', () => {
+  const four = [t('a', false), t('b', false), t('c', true), t('d', true)]
+
+  it('未传 maxVisible 时全部可见', () => {
+    expect(splitVisible(four)).toEqual({ visible: four, overflow: [] })
+  })
+
+  it('长度不超过 maxVisible 时无溢出', () => {
+    expect(splitVisible(four, 4).overflow).toEqual([])
+    expect(splitVisible(four, 9).overflow).toEqual([])
+  })
+
+  it('超出时按序切片', () => {
+    const { visible, overflow } = splitVisible(four, 2)
+    expect(visible.map(x => x.tagName)).toEqual(['a', 'b'])
+    expect(overflow.map(x => x.tagName)).toEqual(['c', 'd'])
+  })
+
+  it('maxVisible 为 0 时全部进溢出', () => {
+    const { visible, overflow } = splitVisible(four, 0)
+    expect(visible).toEqual([])
+    expect(overflow).toHaveLength(4)
+  })
+})

--- a/lol-record-analysis-tauri/src/components/common/__tests__/unifiedTagRowHelpers.spec.ts
+++ b/lol-record-analysis-tauri/src/components/common/__tests__/unifiedTagRowHelpers.spec.ts
@@ -15,7 +15,12 @@ describe('orderTags', () => {
   })
 
   it('同组保持原序(稳定排序)', () => {
-    const result = orderTags([t('good1', true), t('bad1', false), t('good2', true), t('bad2', false)])
+    const result = orderTags([
+      t('good1', true),
+      t('bad1', false),
+      t('good2', true),
+      t('bad2', false)
+    ])
     expect(result.map(x => x.tagName)).toEqual(['bad1', 'bad2', 'good1', 'good2'])
   })
 

--- a/lol-record-analysis-tauri/src/components/common/unifiedTagRow.ts
+++ b/lol-record-analysis-tauri/src/components/common/unifiedTagRow.ts
@@ -1,0 +1,32 @@
+/**
+ * UnifiedTagRow 的纯函数逻辑:标签排序与溢出切片
+ *
+ * 抽离为独立模块以便单测(同 championIntel.ts 旁置模式)。
+ * @module components/common/unifiedTagRow
+ */
+import type { RankTag } from '@renderer/types/domain/analysis'
+
+/**
+ * 系统标签排序:bad(警示)在前,good 在后;同组保持后端原序
+ * @param tags - 后端计算的标签列表
+ * @returns 新数组,不修改入参
+ */
+export function orderTags(tags: RankTag[]): RankTag[] {
+  return [...tags].sort((a, b) => Number(a.good) - Number(b.good))
+}
+
+/**
+ * 按可见上限切片
+ * @param tags - 已排序标签
+ * @param maxVisible - 最多可见数;undefined 表示不限
+ * @returns visible 直接渲染,overflow 收进 +N popover
+ */
+export function splitVisible(
+  tags: RankTag[],
+  maxVisible?: number
+): { visible: RankTag[]; overflow: RankTag[] } {
+  if (maxVisible === undefined || tags.length <= maxVisible) {
+    return { visible: tags, overflow: [] }
+  }
+  return { visible: tags.slice(0, maxVisible), overflow: tags.slice(maxVisible) }
+}

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -174,7 +174,7 @@
                 :puuid="sessionSummoner.summoner.puuid"
                 :game-name="sessionSummoner.summoner.gameName"
                 :tag-line="sessionSummoner.summoner.tagLine"
-                :max-visible="2"
+                :max-visible="tagMaxVisible"
               />
             </div>
           </n-flex>
@@ -308,6 +308,14 @@ const isHiddenRecord = computed(
     !!props.sessionSummoner.championId &&
     (!props.sessionSummoner.summoner?.gameName || !props.sessionSummoner.summoner?.puuid)
 )
+
+/** 标签区可见系统标签上限：预组队/遇见过各占一个槽位后动态收缩，保证单行(spec 验收：全部单行) */
+const tagMaxVisible = computed(() => {
+  let cap = 2
+  if (props.sessionSummoner.preGroupMarkers?.name) cap--
+  if (props.sessionSummoner.meetGames?.length > 0) cap--
+  return Math.max(cap, 0)
+})
 
 const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   toRef(() => props.sessionSummoner.championId),

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -417,6 +417,12 @@ watch(
 
 .name-row {
   gap: var(--space-4);
+  /* n-flex（NFlex）默认按 wrap 属性写内联 style="flex-wrap: wrap"，
+   * 优先级高于外部样式表的类选择器，必须 !important 才压得下去——
+   * info-wrapper 让位收缩后，若不锁 nowrap，复制按钮/备注徽标会被挤到第二行
+   * （比 meta-row 换行更抢眼的"名字行跳动"）。名字文本本身已有
+   * name-ellipsis 的 max-width 兜底截断，这里只需保证整行不换。 */
+  flex-wrap: nowrap !important;
 }
 
 /* :deep 因为 .name-ellipsis 在 n-ellipsis 子组件根，scoped 属性不自动透传 */
@@ -559,13 +565,17 @@ watch(
   line-height: 14px;
 }
 
+/* flex:1（非 0 1 auto）+ min-width:0：长名字/长版本号等不可控内容让位收缩，
+ * 由 name-ellipsis 的 max-width 截断兜底，而不是把 .profile-tags 榨干 */
 .info-wrapper {
-  flex: 0 1 auto;
+  flex: 1;
   min-width: 0;
 }
 
 .profile-tags {
-  flex: 1;
+  /* 不再参与增长（原 flex:1 会抢占 .info-wrapper 让出的空间，导致标签区被压到几十像素内换行）；
+   * chip 数量已经过 tagMaxVisible 收纳上限，天然宽度可控，按内容大小占位即可 */
+  flex-shrink: 0;
   min-width: 0;
   display: flex;
   /* 单行强制：标签经 maxVisible 收纳后不再换行，杜绝撑高与段位行重叠 */

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -60,7 +60,7 @@
             </div>
 
             <div class="info-wrapper">
-              <n-flex align="center" class="name-row">
+              <n-flex align="center" :wrap="false" class="name-row">
                 <n-button
                   text
                   @click="
@@ -417,12 +417,9 @@ watch(
 
 .name-row {
   gap: var(--space-4);
-  /* n-flex（NFlex）默认按 wrap 属性写内联 style="flex-wrap: wrap"，
-   * 优先级高于外部样式表的类选择器，必须 !important 才压得下去——
-   * info-wrapper 让位收缩后，若不锁 nowrap，复制按钮/备注徽标会被挤到第二行
-   * （比 meta-row 换行更抢眼的"名字行跳动"）。名字文本本身已有
-   * name-ellipsis 的 max-width 兜底截断，这里只需保证整行不换。 */
-  flex-wrap: nowrap !important;
+  min-width: 0;
+  /* nowrap 后兜底:空间不足时裁切而非涂过标签区(compact 密度) */
+  overflow: hidden;
 }
 
 /* :deep 因为 .name-ellipsis 在 n-ellipsis 子组件根，scoped 属性不自动透传 */

--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -174,6 +174,7 @@
                 :puuid="sessionSummoner.summoner.puuid"
                 :game-name="sessionSummoner.summoner.gameName"
                 :tag-line="sessionSummoner.summoner.tagLine"
+                :max-visible="2"
               />
             </div>
           </n-flex>
@@ -559,7 +560,8 @@ watch(
   flex: 1;
   min-width: 0;
   display: flex;
-  flex-wrap: wrap;
+  /* 单行强制：标签经 maxVisible 收纳后不再换行，杜绝撑高与段位行重叠 */
+  flex-wrap: nowrap;
   gap: var(--space-4);
   justify-content: flex-end;
   align-items: center;


### PR DESCRIPTION
## Summary
- spec: docs/superpowers/specs/2026-07-24-tag-overflow-row-design.md
- 系统标签 bad 前 good 后稳定排序(orderTags 纯函数,全调用点统一);UnifiedTagRow 新增 maxVisible,溢出收进 +N popover(保留 tooltip/一键固化交互),chip 抽取为 UnifiedTagChip 复用
- PlayerCard 标签区单行强制:动态上限(2 起,预组队/遇见过各占一槽递减,下限 0),长名字省略号截断让位标签区(:wrap=\"false\" 惯例 + 裁切兜底,无 !important)
- 战绩页/对局详情不传 maxVisible,溢出行为不变

## Test plan
- [x] npm run check 全绿;npm run test 648/648(新增 helpers 7 用例 + 组件 3 用例)
- [x] 真机对局页 10 张卡三档窗口宽度(1800/1165/950)验证全部单行,用户验收通过