### PR TITLE
fix(patch-notes): 修复校验闸门误杀 AI 合并条目导致的红灯

### DIFF
--- a/scripts/patch-notes/extract.mjs
+++ b/scripts/patch-notes/extract.mjs
@@ -7,18 +7,47 @@
 export const MODELS_URL = 'https://models.github.ai/inference/chat/completions'
 export const MODEL_ID = 'openai/gpt-4o-mini'
 
-/** 公告页实际出现的 HTML 实体子集 */
+/**
+ * 公告页实际出现的 HTML 实体。
+ * 键名大小写敏感：同一批公告里 &rarr; 与 &rArr; 都出现过（编辑手写 HTML，不统一），
+ * 漏一个就会让实体原样漏进正文，最终显示成「330 &rArr; 335」。
+ * 双箭头统一归一到 →，避免同一份数据里两种箭头混排。
+ */
+const ENTITIES = {
+  rarr: '→',
+  rArr: '→',
+  larr: '←',
+  lArr: '←',
+  harr: '↔',
+  emsp: ' ',
+  ensp: ' ',
+  nbsp: ' ',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  ldquo: '“',
+  rdquo: '”',
+  lsquo: '‘',
+  rsquo: '’',
+  hellip: '…',
+  mdash: '—',
+  ndash: '–',
+  middot: '·',
+  times: '×',
+  deg: '°',
+  copy: '©',
+  reg: '®',
+  trade: '™',
+  amp: '&'
+}
+
+/** 具名实体查表，数字实体（&#39; / &#x27;）走码点还原；未收录的实体原样保留，便于发现新漏网 */
 function decodeEntities(s) {
   return s
-    .replaceAll('&rarr;', '→')
-    .replaceAll('&emsp;', ' ')
-    .replaceAll('&nbsp;', ' ')
-    .replaceAll('&amp;', '&')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#39;', "'")
-    .replaceAll('&mdash;', '—')
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&([a-zA-Z]+);/g, (m, name) => ENTITIES[name] ?? m)
 }
 
 /** 去标签取纯文本：块级闭合转换行，行内标签直接剥掉，空行压缩 */

--- a/scripts/patch-notes/extract.test.mjs
+++ b/scripts/patch-notes/extract.test.mjs
@@ -19,6 +19,15 @@ test('htmlToText 去标签、转实体、保留行结构', () => {
   assert.ok(!text.includes('&rarr;'))
 })
 
+test('htmlToText 解码大小写混合的箭头实体与中文标点实体', () => {
+  const text = htmlToText(
+    '<p>移动速度：330 &rArr; 335</p><p>&ldquo;引号&rdquo;&hellip;&copy;&#8212;</p>'
+  )
+  assert.match(text, /移动速度：330 → 335/)
+  assert.equal(text.includes('&'), false)
+  assert.match(text, /“引号”…©—/)
+})
+
 test('parseModelJson 容忍代码栅栏包装', () => {
   assert.deepEqual(parseModelJson('```json\n{"a":1}\n```'), { a: 1 })
   assert.deepEqual(parseModelJson('{"a":1}'), { a: 1 })

--- a/scripts/patch-notes/validate.mjs
+++ b/scripts/patch-notes/validate.mjs
@@ -6,12 +6,20 @@
 export const CHAMPION_SUMMARY_URL =
   'https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/zh_cn/v1/champion-summary.json'
 
-/** zh_cn 数据里 name=称号（黑暗之女）、description=中文名（安妮），白名单以后者为键 */
+/**
+ * zh_cn 数据里 name=称号（黑暗之女）、description=中文名（安妮），白名单以后者为键。
+ *
+ * 同名冲突取最小 id：上游从某版起混进了 60000+ 的 Jade_* 模式变体
+ * （60012 Jade_Alistar 与 12 Alistar 同名同称号），后写入会覆盖本体，
+ * 让客户端拿到查不到的 championId。变体 id 恒为「本体 + 60000」，故取小者即本体。
+ */
 export function buildWhitelist(summary) {
   const map = new Map()
   for (const c of summary) {
     if (c.id > 0 && c.description) {
-      map.set(c.description.trim(), { championId: c.id, alias: c.alias })
+      const key = c.description.trim()
+      const prev = map.get(key)
+      if (!prev || c.id < prev.championId) map.set(key, { championId: c.id, alias: c.alias })
     }
   }
   return map
@@ -27,8 +35,37 @@ export async function fetchWhitelist(fetchFn = fetch) {
 }
 
 const DIRECTIONS = new Set(['buff', 'nerf', 'adjusted'])
-/** 原文性比对前压掉所有空白：GBK 页面的 &emsp;/&nbsp; 与 AI 输出的空格习惯不一致 */
-const norm = s => s.replace(/\s+/g, '')
+/** 单个英雄的改动条目上限：实测大改英雄（如卑尔维斯 26.15）单期可达 49 条 */
+const MAX_LINES = 60
+/**
+ * 原文性比对前压掉空白与冒号：
+ * 空白——GBK 页面的 &emsp;/&nbsp; 与 AI 输出的空格习惯不一致；
+ * 冒号——AI 拼接「小节标题 + 改动行」时会自行插入一个「：」。
+ */
+const norm = s => s.replace(/[\s：:]+/g, '')
+/** AI 最多把几条相邻原文行并成一条：实测只见「标题 + 1 条改动」，留一档余量 */
+const MAX_JOIN = 3
+
+/**
+ * 把 AI 的一条 lines 对回原文行。
+ * AI 时而把小节标题与改动行并成一条（"基础属性\n移动速度：330 → 335"、
+ * "R - 放逐之锋：额外攻击力收益：25% → 20%"），故允许匹配「连续若干行的拼接」，
+ * 命中后返回这些原文行——产出因此始终是逐行的原文，与客户端的列表渲染一致。
+ * @returns 命中的原文行数组；未命中返回 null
+ */
+function matchArticleLines(line, articleLines, normedLines) {
+  const n = norm(line)
+  if (!n) return null
+  for (let i = 0; i < normedLines.length; i++) {
+    let acc = ''
+    for (let j = i; j < Math.min(i + MAX_JOIN, normedLines.length); j++) {
+      acc += normedLines[j]
+      if (acc === n) return articleLines.slice(i, j + 1)
+      if (acc.length > n.length) break // 已超长，再往后拼只会更长
+    }
+  }
+  return null
+}
 
 export function validateExtraction(extracted, whitelist, articleText) {
   const errors = []
@@ -38,8 +75,11 @@ export function validateExtraction(extracted, whitelist, articleText) {
     errors.push(`champions 数量越界: ${Array.isArray(champs) ? champs.length : typeof champs}`)
     return { ok: false, errors, champions: [] }
   }
-  const articleLines = articleText.split('\n').map(norm)
+  const articleLines = articleText.split('\n').map(l => l.trim())
+  const normedLines = articleLines.map(norm)
   const out = []
+  /** 同一英雄被 AI 拆成多个条目时合并到首次出现的位置，避免客户端出现重复卡片 */
+  const seen = new Map()
   for (const c of champs) {
     const name = (c?.name ?? '').trim()
     const hit = whitelist.get(name)
@@ -54,29 +94,50 @@ export function validateExtraction(extracted, whitelist, articleText) {
     if (
       !Array.isArray(c.lines) ||
       c.lines.length < 1 ||
-      c.lines.length > 30 ||
       c.lines.some(l => typeof l !== 'string' || !l.trim())
     ) {
       errors.push(`lines 非法: ${name}`)
       continue
     }
-    // 防 AI 改写（包括跨行伪造）：每个英雄至少一条逐字命中原文单行（忽略空白）
-    if (
-      !c.lines.some(l => {
-        const n = norm(l)
-        return n && articleLines.some(al => al.includes(n))
-      })
-    ) {
+    const lines = []
+    // 防 AI 改写（包括跨行伪造）：每个英雄至少一条逐字命中原文
+    let anyHit = false
+    for (const raw of c.lines.flatMap(l => l.split('\n')).map(l => l.trim())) {
+      if (!raw) continue
+      const matched = matchArticleLines(raw, articleLines, normedLines)
+      if (matched) {
+        lines.push(...matched)
+        anyHit = true
+        continue
+      }
+      // 退化路径：AI 只摘了原文单行中的一段。保留原样，仍按老规则算命中，
+      // 但跨行拼接的伪造条目对不上任何单行，命中不了。
+      const n = norm(raw)
+      if (n && normedLines.some(al => al.includes(n))) anyHit = true
+      lines.push(raw)
+    }
+    if (lines.length > MAX_LINES) {
+      errors.push(`lines 数量越界: ${name} → ${lines.length}`)
+      continue
+    }
+    if (!anyHit) {
       errors.push(`条目疑似改写（无一条命中原文）: ${name}`)
       continue
     }
-    out.push({
+    const prev = seen.get(hit.championId)
+    if (prev) {
+      prev.lines.push(...lines)
+      continue
+    }
+    const entry = {
       championId: hit.championId,
       alias: hit.alias,
       name,
       direction: c.direction,
-      lines: c.lines.map(l => l.trim())
-    })
+      lines
+    }
+    seen.set(hit.championId, entry)
+    out.push(entry)
   }
   return { ok: errors.length === 0, errors, champions: errors.length === 0 ? out : [] }
 }

--- a/scripts/patch-notes/validate.test.mjs
+++ b/scripts/patch-notes/validate.test.mjs
@@ -6,7 +6,9 @@ import { buildWhitelist, validateExtraction } from './validate.mjs'
 const SUMMARY = [
   { id: -1, name: '无', description: '', alias: 'None' },
   { id: 1, name: '黑暗之女', description: '安妮', alias: 'Annie' },
-  { id: 267, name: '唤潮鲛姬', description: '娜美', alias: 'Nami' }
+  { id: 267, name: '唤潮鲛姬', description: '娜美', alias: 'Nami' },
+  // 60000+ 的 Jade_* 模式变体与本体同名同称号，排在本体之后
+  { id: 60267, name: '唤潮鲛姬', description: '娜美', alias: 'Jade_Nami' }
 ]
 const wl = () => buildWhitelist(SUMMARY)
 const ARTICLE = 'W 潮涌\n治疗量：60 → 65\n基础护甲：28 → 30'
@@ -22,6 +24,12 @@ test('白名单以 description（中文名）为键并携带 id/alias', () => {
   assert.deepEqual(wl().get('娜美'), { championId: 267, alias: 'Nami' })
   assert.equal(wl().has('唤潮鲛姬'), false) // 称号不是键
   assert.equal(wl().has(''), false) // id=-1 的占位不进白名单
+})
+
+test('白名单遇同名的 Jade_* 模式变体时取本体 id，不被覆盖', () => {
+  // 反序也要稳：不能依赖上游的排列顺序
+  const reversed = buildWhitelist([...SUMMARY].reverse())
+  assert.deepEqual(reversed.get('娜美'), { championId: 267, alias: 'Nami' })
 })
 
 test('happy path：通过并富化 championId/alias', () => {
@@ -70,6 +78,47 @@ test('条目原文比对忽略空白差异', () => {
   assert.equal(r.ok, true)
 })
 
+test('AI 把小节标题与改动行并进同一条时，按换行拆开逐条校验', () => {
+  const r = validateExtraction(
+    extracted(champ({ lines: ['W 潮涌\n治疗量：60 → 65'] })),
+    wl(),
+    ARTICLE
+  )
+  assert.equal(r.ok, true)
+  assert.deepEqual(r.champions[0].lines, ['W 潮涌', '治疗量：60 → 65'])
+})
+
+test('AI 用冒号把小节标题与改动行并成一条时，对回原文并还原成两条', () => {
+  const r = validateExtraction(
+    extracted(champ({ lines: ['W 潮涌：治疗量：60 → 65'] })),
+    wl(),
+    ARTICLE
+  )
+  assert.equal(r.ok, true)
+  assert.deepEqual(r.champions[0].lines, ['W 潮涌', '治疗量：60 → 65'])
+})
+
+test('同一英雄被 AI 拆成多个条目时合并', () => {
+  const r = validateExtraction(
+    extracted(champ({ lines: ['治疗量：60 → 65'] }), champ({ lines: ['基础护甲：28 → 30'] })),
+    wl(),
+    ARTICLE
+  )
+  assert.equal(r.ok, true)
+  assert.equal(r.champions.length, 1)
+  assert.deepEqual(r.champions[0].lines, ['治疗量：60 → 65', '基础护甲：28 → 30'])
+})
+
+test('换行拆分后仍逐条比对原文：拆出的条目全不命中则拒绝', () => {
+  const r = validateExtraction(
+    extracted(champ({ lines: ['治疗量大幅提升\n护甲也加强了'] })),
+    wl(),
+    ARTICLE
+  )
+  assert.equal(r.ok, false)
+  assert.match(r.errors.join(), /改写/)
+})
+
 test('拒绝：跨行拼接的伪造条目', () => {
   const r = validateExtraction(
     extracted(champ({ lines: ['潮涌治疗量'] })), // 跨行拼接：'W 潮涌' + '治疗量：...'
@@ -78,6 +127,14 @@ test('拒绝：跨行拼接的伪造条目', () => {
   )
   assert.equal(r.ok, false)
   assert.match(r.errors.join(), /改写/)
+})
+
+test('lines 上限容纳大改英雄的长改动列表', () => {
+  const many = Array.from({ length: 40 }, (_, i) => `属性${i}：1 → 2`)
+  assert.equal(validateExtraction(extracted(champ({ lines: many })), wl(), many.join('\n')).ok, true)
+  const tooMany = Array.from({ length: 61 }, (_, i) => `属性${i}：1 → 2`)
+  const r = validateExtraction(extracted(champ({ lines: tooMany })), wl(), tooMany.join('\n'))
+  assert.equal(r.ok, false)
 })
 
 test('失败时 champions 为空数组', () => {


### PR DESCRIPTION
## 背景

`Patch Notes Data` 从 7月30日公告起每 6h 红一次（[run 30458206447](https://github.com/wnzzer/rank-analysis/actions/runs/30458206447)），9 个英雄里 7 个被判「条目疑似改写（无一条命中原文）」。失败时 docid 不落盘，所以会一直红到下期公告。

## 根因

AI 把「小节标题 + 改动行」并进了同一条 `lines`，分隔符时而是 `\n`、时而是 `：`：

```
"基础属性\n移动速度：330 → 335"
"R - 放逐之锋：额外攻击力收益：25% → 20%"
```

而闸门（`validate.mjs`）先用 `norm()` 压掉所有空白（`\n` 一并压掉），再要求结果是**某一条原文单行**的子串 —— 横跨两行原文的串永远匹配不上。不是公告结构变了，是模型输出格式漂移：7-16 那期 37 条 lines，含换行 0 条。

## 改动

**闸门（`validate.mjs`）**
- 条目可匹配「连续至多 3 行原文的拼接」，命中后回填**原文行**，产出恢复成逐行原文（和客户端列表渲染、和 7-16 已上线数据同形）
- 归一化增加压掉 `：`：AI 拼接标题时会自行插入冒号
- 同一英雄被 AI 拆成多个条目时合并，避免重复卡片（本期 `莫德凯撒` 实测出现两次）
- `lines` 上限 30 → 60：实测大改英雄（卑尔维斯 26.15）单期 49 条改动
- 跨行伪造仍被拒：对不上任何单行，也拼不出完整行

**顺带修掉两个会污染线上数据的隐患**
- `extract.mjs` 实体表漏了 `&rArr;`（本期出现 168 次，表里只有小写 `&rarr;`），会让客户端直接显示「移动速度：330 &rArr; 335」。改为查表 + 数字实体（`&#39;` / `&#x27;`）还原，补齐中文标点实体
- `validate.mjs` 白名单被上游 60000+ 的 `Jade_*` 模式变体覆盖 —— `60012 Jade_Alistar` 顶掉 `12 Alistar`，**58 个英雄**会拿到客户端查不到的 championId。同名取最小 id

## Test plan

- [x] `node --test scripts/patch-notes/*.test.mjs` —— 26 passed（新增 6 例：换行合并、冒号合并、跨行伪造仍拒、同名英雄合并、lines 上限、Jade_* 覆盖且顺序无关）
- [x] 每个新测试都先看到 RED 再实现
- [x] 全链路真跑（拉公告 → GitHub Models → 闸门），对 7月30日这篇实际公告：闸门 **PASS**，10 个英雄，残留实体 0，championId 全部正确（阿利斯塔 12 而非 60012）
- [ ] 合并后 dispatch 一次 workflow 落数据

`npm run check` 不覆盖 `scripts/`（`prettier --write .` / `eslint .` 都在 `lol-record-analysis-tauri/` 下跑），本 PR 未改该目录下任何文件。