### PR TITLE
chore(patch-notes): 抽取模型换成 gpt-4o，修复漏抽英雄

### DIFF
--- a/scripts/patch-notes/extract.mjs
+++ b/scripts/patch-notes/extract.mjs
@@ -5,7 +5,15 @@
  */
 
 export const MODELS_URL = 'https://models.github.ai/inference/chat/completions'
-export const MODEL_ID = 'openai/gpt-4o-mini'
+/**
+ * 2026-07-29 横评（同一篇 7月30日公告，原文 11 个英雄 / 卑尔维斯 49 条改动）：
+ * - gpt-4o-mini：只抽到 8 个英雄、卑尔维斯 36 条，且把加强削弱并存的改动一律判成 nerf
+ * - gpt-4.1：11 个英雄，卑尔维斯 43 条，仍有遗漏
+ * - gpt-4.1-mini：抽出 23 个英雄，把非英雄段落也算了进来
+ * - gpt-4o：11 个英雄、卑尔维斯 49 条与原文精确对齐，direction 判定也最准，且最快
+ * 属 high 档 rate limit，但只在 docid 变化时才真调模型（约每月 2 次），配额充裕。
+ */
+export const MODEL_ID = 'openai/gpt-4o'
 
 /**
  * 公告页实际出现的 HTML 实体。

--- a/scripts/patch-notes/extract.test.mjs
+++ b/scripts/patch-notes/extract.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { htmlToText, parseModelJson, callModel, MODELS_URL } from './extract.mjs'
+import { htmlToText, parseModelJson, callModel, MODELS_URL, MODEL_ID } from './extract.mjs'
 
 // 按真实公告页结构裁剪（与 Rust cn_patch_notes.rs 原 fixture 同源）
 const HTML = `
@@ -46,6 +46,7 @@ test('callModel 发 POST 到 GitHub Models 并解析回包', async () => {
   }
   const out = await callModel('正文', 'tok', fetchFn)
   assert.equal(captured.url, MODELS_URL)
+  assert.equal(JSON.parse(captured.init.body).model, MODEL_ID)
   assert.equal(JSON.parse(captured.init.body).temperature, 0)
   assert.equal(captured.init.headers.Authorization, 'Bearer tok')
   assert.deepEqual(out, { isPatchNotes: true, champions: [] })


### PR DESCRIPTION
## 背景

#127 修好了闸门误杀，但线上数据（`a059f1d`）只有 **8 个英雄** —— 沃利贝尔、茂凯、扎克整个丢了，卑尔维斯 36 条（原文 49 条）。这是 `gpt-4o-mini` 的漏抽，不是闸门问题。

先排除了截断：实测 `finish_reason=stop`、`completion_tokens=1706`，远没到 4096 上限。就是模型自己少抽。

## 横评

同一篇 7月30日公告，原文 **11 个英雄**有改动、卑尔维斯 **49 条**改动行（awk 数过）：

| 模型 | 英雄 | 卑尔维斯 | 耗时 | 备注 |
|---|---|---|---|---|
| gpt-4o-mini（原） | 8 ❌ | 36 条 | 32s | 卑尔维斯/莫德凯撒 direction 误判为 nerf |
| gpt-4.1 | 11 ✓ | 43 条 | 16s | 仍漏 6 条 |
| **gpt-4o（本 PR）** | **11 ✓** | **49 条 ✓** | **13s** | 与原文精确对齐，direction 判定最准 |
| gpt-4.1-mini | 23 ❌ | — | 140s | 把非英雄段落也算了进来 |

`direction` 的差距值得单独说：卑尔维斯、莫德凯撒都是加强削弱并存，gpt-4o 判 `adjusted`（正确），gpt-4o-mini 一律判 `nerf`（错误）。

gpt-4o 属 `high` rate limit 档，比原来的 `low` 紧，但这条管线只在 docid 变化时才真调模型（约每月 2 次），配额充裕。

## Test plan

- [x] `node --test scripts/patch-notes/*.test.mjs` —— 26 passed
- [x] 全链路真跑（拉公告 → gpt-4o → 闸门）：**闸门 PASS，11/11 英雄**，残留实体 0，championId 全对
- [ ] 合并后重置 `cn-latest.json` 的 docId 并 dispatch，用 gpt-4o 重新生成这期数据

改动只有一个常量 + 说明注释，外加给 `callModel` 补上请求体 `model` 字段的断言（原先没测）。