### PR TITLE
fix(bp): 补 OnePlayer 的 obfuscated_puuid 字段，修复 main 编译失败

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/bp_decision/evaluate.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/bp_decision/evaluate.rs
@@ -394,6 +394,8 @@ mod tests {
         OnePlayer {
             champion_id: champ,
             puuid: puuid.to_string(),
+            // 选人期混淆 puuid（#131 新增字段）；此处构造的是已知 puuid 的测试玩家，留空即可
+            obfuscated_puuid: String::new(),
             assigned_position: position.to_string(),
             cell_id: 0,
             champion_pick_intent: 0,


### PR DESCRIPTION
## Summary

**main 目前编译失败**，这是 #130 与 #131 的语义冲突。

- #131 给 `champion_select::OnePlayer` 新增了 `obfuscated_puuid` 字段，并更新了**当时**所有构造点
- #130 的 `bp_decision` 模块写于 #131 之前，其测试辅助函数 `player()` 不含该字段

两个 PR 各自 CI 都是绿的（各自基于合入前的 main），合并时 git 也没有文本冲突——但合并结果编译不过：

```
error[E0063]: missing field `obfuscated_puuid` in initializer of `champion_select::OnePlayer`
   --> src/bp_decision/evaluate.rs:394:9
```

## 为什么之前没被拦住

错误只出现在 **lib test** 目标下（`player()` 在 `#[cfg(test)]` 里）。`cargo check --lib` 不编译测试代码，必须 `cargo check --all-targets` 才能复现——而 CI 的 clippy 步骤用的正是 `--all-targets`，所以是在合入后的第一次 CI 运行才暴露。

这类语义冲突单 PR 的 CI 天然拦不住，需要 merge queue 或合入后的 main 构建才能提前发现。

## Test plan

- [x] `cargo fmt --all -- --check` 通过
- [x] `cargo clippy --all-targets --all-features -- -Dwarnings` 通过
- [x] `cargo test` 通过（302 passed）

## Note

该字段在此处语义上就该为空——`player()` 构造的是 puuid 已知的测试玩家，不涉及选人期混淆。