### PR TITLE
fix(record): 详情页头部被压扁导致「AI 整局复盘」按钮被裁

### DIFF
--- a/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
+++ b/lol-record-analysis-tauri/src/components/record/MatchDetailModal.vue
@@ -797,6 +797,12 @@ watch(
   --hdr-color: var(--semantic-win);
   position: relative;
   overflow: hidden;
+  /* 头部是固定内容区，绝不参与压缩：它是 .match-detail-shell（flex column, height:100%）
+     的子项，默认 flex-shrink:1 会在窗口高度不足时被挤扁。一旦挤扁，比左栏更高的右侧
+     按钮列（统计条 + 观看回放 + AI 整局复盘）就会超出头部，被上面的 overflow:hidden
+     裁掉底部——表现为「AI 整局复盘」按钮缺一截。窗口越矮越明显。
+     该滚动的是下面的正文区，不是头部。 */
+  flex-shrink: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;


### PR DESCRIPTION
## Summary

对局详情窗口里「AI 整局复盘」按钮显示不全，底部被切掉一截。

**根因**：`.match-detail-header` 是 `.match-detail-shell`（`flex-direction: column; height: 100%`）的子项，默认 `flex-shrink: 1`，窗口高度不足时会被挤扁。而头部右侧按钮列（统计条 + 观看回放 + AI 整局复盘）比左栏更高——头部一被压缩，按钮列就超出头部边界，被头部上的 `overflow: hidden`（用于裁剪背景的模糊英雄图）切掉。

实测数据（macOS 1440×900，详情窗口 1300×743）：

```
.match-detail-header        bottom = 137   overflow: hidden   ← 裁剪者
.match-detail-summary-side  bottom = 141   ← 按钮列超出 4px
AI 整局复盘 按钮             bottom = 141   ← 底部被切
```

加 `flex-shrink: 0` 后 header bottom = 152，按钮完整显示。

**窗口越矮越明显**——头部是固定内容区，本就不该参与压缩，该滚动的是下面的正文区。

## Test plan

- [x] `vue-tsc --noEmit` 通过
- [x] `prettier --check` 通过
- [x] 实机验证：修复前后分别截图对比，`AI 整局复盘` 按钮从被切变为完整圆角矩形
- [x] DOM 测量确认 `按钮 bottom (141) <= header bottom (152)`