### PR TITLE
feat(bp): 智能推荐面板(常用/常输/T0 一键入池)与 OPGG 段位选择

### DIFF
--- a/docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md
+++ b/docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md
@@ -1,0 +1,111 @@
+# BP 智能推荐 + OPGG 段位选择 设计文档
+
+日期：2026-08-02
+分支：feat/bp-decision-preview（或从其切出新分支）
+
+## 背景与目标
+
+自动化页的 ban/pick 目前是「规则列表 + 兜底池」，兜底池（`settings.auto.pickChampionSlice` / `banChampionSlice`）需要用户手动挑英雄。本功能提供一键智能推荐：
+
+1. **常用英雄 → 英雄池**：近期场次最多的英雄推进 pick 兜底池。
+2. **常输给的英雄 → ban 池**：败局中敌方阵容高频出现的英雄推进 ban 兜底池（语义：ban 掉经常打赢我的英雄）。
+3. **版本 T0 → 按熟练度分流**：OPGG T0/T1 英雄，我玩过且胜率≥50% 的建议 pick，不玩的建议 ban（留给对面就是威胁）。
+4. **OPGG 段位可选**：`tier` 参数从硬编码 `emerald_plus` 改为用户可配置，全局生效（推荐、BP 决策 evidence、克制提示、AI prompt 情报同源受益）。
+
+### 已确认的事实依据
+
+- OPGG API `tier` 参数实测有效：`gold_plus / platinum_plus / emerald_plus / diamond_plus / master_plus / all` 均返回 200 且数据（胜率、样本量）随段位真实变化。
+- 「常输给谁」无需额外网络请求：现有 match history 的 `game.game_detail.participants` + `participant_identities` 已含全部 10 人名单（`is_my_team`、`champion_id`、`stats.win`），`user_tag.rs::get_one_game_players` 即是先例。
+- 选人期敌方 `assignedPosition` 恒为空（平台限制），本功能不依赖敌方位置。
+- 国服 lane/role 字段不完全可信（memory: lcu-match-data-gaps），故主玩分路仅作默认值，UI 允许手动切换。
+
+## 非目标
+
+- 不使用 AI（三类候选均为确定性聚合；标签推荐用 AI 是因为要归纳输赢共同点，此处不需要）。
+- 不改动规则列表（pickRules/banRules），只写兜底池。
+- 不做后台自动维护池子；只在用户打开面板并逐项采用时写入。
+- 不推断敌方分路。
+
+## 交互设计（对齐 AISuggestModal 的「采纳」模式）
+
+自动化页加「智能推荐」按钮 → 打开 `BpSuggestModal`：
+
+- 三个分区卡片流：「常用英雄 → 英雄池」「常输给的英雄 → ban 池」「版本 T0（按熟练度分流）」。
+- 每张卡：英雄头像 + 名字 + 依据文案（如「12 场 · 胜率 58%」「8 场败局中出现 5 次」「T0 · 上单 · 胜率 52.3%」）+ 主按钮（「加入英雄池」或「加入 ban 池」）。T0 卡额外提供反向次按钮（手动改去向）。
+- 采用后卡片灰态「已加入」；`already_in_pool=true` 的候选初始即灰态。
+- 右上角「重新生成」强制刷新。
+- 分路下拉：默认统计出的主玩分路，可手动切换；pick 向候选按所选分路过滤，ban 向不限分路。
+- 段位下拉：放「智能推荐」按钮旁（自动化页），改变 `settings.opgg.tier` 并触发 `update_opgg_data`。
+
+### 边态
+
+- 战绩样本 < 10 场：空态「近期对局太少（N 局），打几局再来」。
+- OPGG 拉取失败：仅 T0 分区显示不可用 + 重试；常用/常输分区照常展示。
+- 段位切换后重拉失败：降级用 stale 缓存（沿用现有降级链），UI 提示 stale。
+
+## 后端设计
+
+### 新命令 `get_bp_suggest`（`src-tauri/src/command/bp_suggest.rs`）
+
+输入：`position: Option<String>`（None 时用统计出的主玩分路）。
+数据源：当前登录用户近 30 场 match history（排位 420/440 优先，不足 10 场放宽全模式；遵守冷缓存约束首请求 0-49）+ `ensure_opgg_snapshot("ranked")`。
+
+返回（snake_case，前端同构 `src/types/bpSuggest.ts`）：
+
+```rust
+pub struct BpSuggestResult {
+    pub main_position: String,      // 统计出的主玩分路（top/jungle/middle/bottom/utility，未知为 ""）
+    pub sample_games: i32,          // 参与统计的场次
+    pub opgg_ok: bool,              // false 时 hot_t0 为空，前端展示降级态
+    pub frequent: Vec<BpSuggestItem>,
+    pub nemesis: Vec<BpSuggestItem>,
+    pub hot_t0: Vec<BpSuggestItem>,
+}
+
+pub struct BpSuggestItem {
+    pub champion_id: i32,
+    pub suggested_pool: SuggestedPool,   // Pick | Ban
+    pub already_in_pool: bool,           // 已在对应 slice 中
+    pub evidence: BpSuggestEvidence,     // 全 Option 字段：games/win_rate/losses_against/loss_games/opgg_tier/opgg_rank/position/opgg_win_rate
+}
+```
+
+### 聚合规则（纯函数，输入 games 切片 + snapshot + 现有两个 slice）
+
+- **frequent**：自己（participants[0]）按 champion_id 聚合；`games >= 3` 才入选；按场次降序 top 8；`suggested_pool = Pick`。
+- **nemesis**：仅败局；敌方（`!is_my_team`）champion_id 聚合出现次数；`>= 2` 次才入选；按次数降序 top 8；`suggested_pool = Ban`；排除已在 frequent 的英雄（自己主玩的不建议 ban）。
+- **hot_t0**：snapshot 中 `tier <= 1` 的英雄。「会玩」判据基于**原始按英雄聚合统计**（不受 frequent top8 截断影响）：该英雄我打过 ≥ 3 场且胜率 ≥ 50%。pick 向：`is_main_position` 且 position == 所选分路，且「会玩」→ Pick；其余（「不会玩」的，全分路、按 ban_rate 降序）→ Ban。合计 top 8。与 frequent/nemesis 重复的 champion_id 去重（保留 T0 徽章信息合并进 evidence 亦可，首版直接去重跳过）。
+- **主玩分路统计**：众数 `selectedPosition`（空值跳过）；全部为空则 `main_position = ""`，前端下拉默认「全部」。
+- `already_in_pool`：Pick 向对照 `pickChampionSlice`，Ban 向对照 `banChampionSlice`。
+
+### OPGG 段位配置
+
+- 新配置键 `settings.opgg.tier`，默认 `"emerald_plus"`；合法值白名单 `gold_plus / platinum_plus / emerald_plus / diamond_plus / master_plus / all`，非法值回退默认。
+- `opgg/api.rs::mode_url` 改为接受 tier 参数（仅 ranked 拼接）；`OpggSnapshot` 增加 `tier: String` 字段。
+- 缓存命中校验：内存/磁盘快照的 `tier` 与当前配置不符 → 视为 miss 走 HTTP；磁盘文件名保持 `opgg_cache_ranked.json` 不变（靠内容里的 tier 字段判断，避免文件散落）。旧缓存无 tier 字段 → serde default 空串 → 天然 miss，一次性平滑迁移。
+- aram 模式不受影响（无 tier 参数）。
+
+## 前端设计
+
+- `src/types/bpSuggest.ts`：与 Rust 同构类型。
+- `src/components/automation/BpSuggestModal.vue`：结构/状态机对齐 `AISuggestModal.vue`（loading / insufficient / error / ok；分区卡片；逐卡采用；灰态）。
+- 采用动作：读对应 slice → 去重 append → `putConfigByIpc('settings.auto.pickChampionSlice' | 'banChampionSlice', ...)` → 本地灰态。与 Automation.vue 现有池子状态保持同步（modal 由 Automation.vue 挂载，采用后 emit 让父组件刷新本地 ref）。
+- `Automation.vue`：加「智能推荐」按钮 + 段位下拉（`NSelect`，值写 `settings.opgg.tier`，变更后 invoke `update_opgg_data` 强制刷新）。
+
+## 测试
+
+- Rust（`bp_suggest` 模块内 `#[cfg(test)]`）：
+  - frequent/nemesis 聚合（阈值、排序、排除 frequent、败局过滤）
+  - hot_t0 分流（会玩→pick / 不玩→ban、分路过滤、去重）
+  - 主玩分路众数与全空回退
+  - `already_in_pool` 标记
+  - tier 缓存校验（tier 不匹配视为 miss、旧缓存无 tier 字段视为 miss、非法配置回退默认）
+- 前端（Vitest）：
+  - `BpSuggestModal.spec.ts`：采用写回 slice（去重）、灰态切换、OPGG 降级态、样本不足空态
+  - 段位下拉写配置 + 触发刷新
+
+## 实施拆分建议
+
+1. OPGG 段位配置（后端 tier 贯通 + 缓存校验 + 测试）——独立可交付。
+2. 后端 `get_bp_suggest` 聚合 + 测试。
+3. 前端类型 + `BpSuggestModal` + `Automation.vue` 接线 + 测试。

--- a/docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md
+++ b/docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md
@@ -47,7 +47,7 @@
 
 ### 新命令 `get_bp_suggest`（`src-tauri/src/command/bp_suggest.rs`）
 
-输入：`position: Option<String>`（None 时用统计出的主玩分路）。
+输入：`position: Option<String>`。`None` = 自动模式，用统计出的主玩分路并据此过滤 pick 向；显式传空字符串 `""` = 用户选「全部分路」，不过滤 pick 向（即使统计出的主玩分路非空也不生效）。
 数据源：当前登录用户近 30 场 match history（排位 420/440 优先，不足 10 场放宽全模式；遵守冷缓存约束首请求 0-49）+ `ensure_opgg_snapshot("ranked")`。
 
 返回（snake_case，前端同构 `src/types/bpSuggest.ts`）：
@@ -74,7 +74,7 @@ pub struct BpSuggestItem {
 
 - **frequent**：自己（participants[0]）按 champion_id 聚合；`games >= 3` 才入选；按场次降序 top 8；`suggested_pool = Pick`。
 - **nemesis**：仅败局；敌方（`!is_my_team`）champion_id 聚合出现次数；`>= 2` 次才入选；按次数降序 top 8；`suggested_pool = Ban`；排除已在 frequent 的英雄（自己主玩的不建议 ban）。
-- **hot_t0**：snapshot 中 `tier <= 1` 的英雄。「会玩」判据基于**原始按英雄聚合统计**（不受 frequent top8 截断影响）：该英雄我打过 ≥ 3 场且胜率 ≥ 50%。pick 向：`is_main_position` 且 position == 所选分路，且「会玩」→ Pick；其余（「不会玩」的，全分路、按 ban_rate 降序）→ Ban。合计 top 8。与 frequent/nemesis 重复的 champion_id 去重（保留 T0 徽章信息合并进 evidence 亦可，首版直接去重跳过）。
+- **hot_t0**：snapshot 中 `tier == 1` 的英雄（OP.GG tier 1 即最强档；tier 0 表示该英雄无该分路数据，不能用 `<=` 把它误判为强势）。「会玩」判据基于**原始按英雄聚合统计**（不受 frequent top8 截断影响）：该英雄我打过 ≥ 3 场且胜率 ≥ 50%。pick 向：`is_main_position` 且（所选分路为空字符串「全部分路」，或 position == 所选分路），且「会玩」→ Pick；其余（「不会玩」的，全分路、按 ban_rate 降序）→ Ban。合计 top 8。与 frequent/nemesis 重复的 champion_id 去重（保留 T0 徽章信息合并进 evidence 亦可，首版直接去重跳过）。
 - **主玩分路统计**：Rust 侧战绩结构（`model.rs::Participant/Stats`）没有声明任何 lane/position 字段，且国服 lane 数据本就不可信——改用 **常用英雄的 OPGG 主分路加权众数**：对我打过 ≥2 场的每个英雄，取其 OPGG `is_main_position` 分路，按我的场次加权投票，得票最高的分路即 `main_position`。OPGG 不可用或无票时 `main_position = ""`，前端下拉默认「全部」（不过滤）。
 - `already_in_pool`：Pick 向对照 `pickChampionSlice`，Ban 向对照 `banChampionSlice`。
 

--- a/docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md
+++ b/docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md
@@ -75,7 +75,7 @@ pub struct BpSuggestItem {
 - **frequent**：自己（participants[0]）按 champion_id 聚合；`games >= 3` 才入选；按场次降序 top 8；`suggested_pool = Pick`。
 - **nemesis**：仅败局；敌方（`!is_my_team`）champion_id 聚合出现次数；`>= 2` 次才入选；按次数降序 top 8；`suggested_pool = Ban`；排除已在 frequent 的英雄（自己主玩的不建议 ban）。
 - **hot_t0**：snapshot 中 `tier <= 1` 的英雄。「会玩」判据基于**原始按英雄聚合统计**（不受 frequent top8 截断影响）：该英雄我打过 ≥ 3 场且胜率 ≥ 50%。pick 向：`is_main_position` 且 position == 所选分路，且「会玩」→ Pick；其余（「不会玩」的，全分路、按 ban_rate 降序）→ Ban。合计 top 8。与 frequent/nemesis 重复的 champion_id 去重（保留 T0 徽章信息合并进 evidence 亦可，首版直接去重跳过）。
-- **主玩分路统计**：众数 `selectedPosition`（空值跳过）；全部为空则 `main_position = ""`，前端下拉默认「全部」。
+- **主玩分路统计**：Rust 侧战绩结构（`model.rs::Participant/Stats`）没有声明任何 lane/position 字段，且国服 lane 数据本就不可信——改用 **常用英雄的 OPGG 主分路加权众数**：对我打过 ≥2 场的每个英雄，取其 OPGG `is_main_position` 分路，按我的场次加权投票，得票最高的分路即 `main_position`。OPGG 不可用或无票时 `main_position = ""`，前端下拉默认「全部」（不过滤）。
 - `already_in_pool`：Pick 向对照 `pickChampionSlice`，Ban 向对照 `banChampionSlice`。
 
 ### OPGG 段位配置

--- a/lol-record-analysis-tauri/src-tauri/src/bp_decision/evaluate.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/bp_decision/evaluate.rs
@@ -425,6 +425,7 @@ mod tests {
         );
         OpggSnapshot {
             mode: "ranked".into(),
+            tier: "emerald_plus".into(),
             patch: "16.13".into(),
             fetched_at: 0,
             champions: HashMap::new(),

--- a/lol-record-analysis-tauri/src-tauri/src/command.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command.rs
@@ -40,6 +40,7 @@
 pub mod ai;
 pub mod asset;
 pub mod bp;
+pub mod bp_suggest;
 pub mod cloud_sync;
 pub mod config;
 pub mod fandom;

--- a/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
@@ -279,7 +279,8 @@ fn build_suggestions(
                 continue;
             };
             let agg = my_champs.get(champ_id);
-            if main.position == effective_pos && is_proficient(agg) {
+            // effective_pos 为空串 = 显式「全部分路」或主分路无法推断，均不过滤 pick 向。
+            if (effective_pos.is_empty() || main.position == effective_pos) && is_proficient(agg) {
                 pick_candidates.push((*champ_id, main));
             } else if !is_proficient(agg)
                 && !nemesis_set.contains(champ_id)
@@ -588,6 +589,33 @@ mod tests {
         assert_eq!(picks, vec![1]);
         // ban 向按 ban_rate 降序：5(0.3) 在 6(0.1) 前
         assert_eq!(bans, vec![5, 6]);
+    }
+
+    #[test]
+    fn hot_t0_pick_should_not_filter_by_position_when_explicitly_empty() {
+        // 主分路投票会是 TOP（英雄 1 打了 4 场 TOP，多于英雄 5 的 3 场 MIDDLE），
+        // 但显式传 Some("")（=「全部分路」，不过滤）时，MIDDLE 的会玩英雄（5）
+        // 也应出现在 pick 向，不应被按 TOP 过滤掉。
+        let mut games = vec![];
+        for _ in 0..4 {
+            games.push(game(1, true, &[50], 420));
+        }
+        for _ in 0..3 {
+            games.push(game(5, true, &[50], 420));
+        }
+        let snap = snapshot(vec![meta(1, "TOP", 1, 0.2), meta(5, "MIDDLE", 1, 0.3)]);
+        let result = build_suggestions(&games, "me", Some(&snap), Some(""), &[], &[]);
+        let picks: Vec<i32> = result
+            .hot_t0
+            .iter()
+            .filter(|i| i.suggested_pool == "pick")
+            .map(|i| i.champion_id)
+            .collect();
+        assert!(picks.contains(&1), "TOP 会玩英雄应出现在 pick 向");
+        assert!(
+            picks.contains(&5),
+            "显式空字符串=不过滤分路，MIDDLE 会玩英雄也应出现在 pick 向"
+        );
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
@@ -193,12 +193,16 @@ fn build_suggestions(
     let main_position = derive_main_position(&my_champs, snapshot);
     let effective_pos = position.unwrap_or(&main_position);
 
-    // frequent：常用英雄，按 (games, wins) 降序 → pick 池候选
-    let mut frequent_ids: Vec<i32> = my_champs
+    // 常用英雄资格集合（games >= FREQUENT_MIN_GAMES）：frequent 排序基底、
+    // nemesis 排除、hot_t0 ban 排除三处共用同一判据，算一次到处复用。
+    let my_frequent_ids: std::collections::HashSet<i32> = my_champs
         .iter()
         .filter(|(_, (games, _))| *games >= FREQUENT_MIN_GAMES)
         .map(|(id, _)| *id)
         .collect();
+
+    // frequent：常用英雄，按 (games, wins) 降序 → pick 池候选
+    let mut frequent_ids: Vec<i32> = my_frequent_ids.iter().copied().collect();
     frequent_ids.sort_by(|a, b| {
         let (ga, wa) = my_champs[a];
         let (gb, wb) = my_champs[b];
@@ -226,12 +230,7 @@ fn build_suggestions(
     let (nemesis_map, loss_games) = aggregate_nemesis(games);
     let mut nemesis_ids: Vec<i32> = nemesis_map
         .iter()
-        .filter(|(id, count)| {
-            **count >= NEMESIS_MIN_ENCOUNTERS
-                && !my_champs
-                    .get(id)
-                    .is_some_and(|(g, _)| *g >= FREQUENT_MIN_GAMES)
-        })
+        .filter(|(id, count)| **count >= NEMESIS_MIN_ENCOUNTERS && !my_frequent_ids.contains(id))
         .map(|(id, _)| *id)
         .collect();
     nemesis_ids.sort_by(|a, b| nemesis_map[b].cmp(&nemesis_map[a]));
@@ -268,8 +267,11 @@ fn build_suggestions(
         // 这也是 Step 1 测试 `hot_t0_should_split_by_proficiency_and_filter_pick_by_position`
         // 显式要求的行为（英雄 1 打了 4 场、同时满足 frequent 与 proficient，仍应出现在 pick）。
         let mut pick_candidates: Vec<(i32, &crate::opgg::data::ChampionMeta)> = vec![];
-        // ban 向：T0 + 主分路 + 我不会玩，且不与 nemesis 重复（两个判据相互独立，
-        // 不存在 pick 侧那种子集必空的矛盾，可以正常按 ID 排除）。
+        // ban 向：T0 + 主分路 + 我不会玩，且不与 nemesis 重复，且不与 frequent 重复。
+        // 与 pick 向相反，这里必须排除 frequent：is_proficient 只是 frequent 的子集
+        // 判据（多了胜率 ≥50% 一道门槛），打过 ≥3 场但胜率 <50% 的英雄会同时落入
+        // "常用"(frequent, pick 池候选) 与 "不会玩"(!is_proficient, ban 池候选)——
+        // 不排除就会对同一英雄同时给出「建议加入英雄池」和「建议 ban」的矛盾推荐。
         let mut ban_candidates: Vec<(i32, &crate::opgg::data::ChampionMeta)> = vec![];
 
         for (champ_id, metas) in &snap.champions {
@@ -279,7 +281,10 @@ fn build_suggestions(
             let agg = my_champs.get(champ_id);
             if main.position == effective_pos && is_proficient(agg) {
                 pick_candidates.push((*champ_id, main));
-            } else if !is_proficient(agg) && !nemesis_set.contains(champ_id) {
+            } else if !is_proficient(agg)
+                && !nemesis_set.contains(champ_id)
+                && !my_frequent_ids.contains(champ_id)
+            {
                 ban_candidates.push((*champ_id, main));
             }
         }
@@ -583,6 +588,26 @@ mod tests {
         assert_eq!(picks, vec![1]);
         // ban 向按 ban_rate 降序：5(0.3) 在 6(0.1) 前
         assert_eq!(bans, vec![5, 6]);
+    }
+
+    #[test]
+    fn hot_t0_ban_should_exclude_my_frequent_champions() {
+        // 英雄 9：T0 主分路 TOP,我打过 3 场但全败(胜率 0% → 不「会玩」)
+        // 它已在 frequent(3 场达标)——不该再被建议 ban,矛盾推荐
+        let mut games = vec![];
+        for _ in 0..3 {
+            games.push(game(9, false, &[50], 420));
+        }
+        let snap = snapshot(vec![meta(9, "TOP", 1, 0.2)]);
+        let result = build_suggestions(&games, "me", Some(&snap), Some("TOP"), &[], &[]);
+        assert!(
+            result.frequent.iter().any(|i| i.champion_id == 9),
+            "9 是常用英雄"
+        );
+        assert!(
+            !result.hot_t0.iter().any(|i| i.champion_id == 9),
+            "常用英雄不该出现在 hot_t0 ban 向"
+        );
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
@@ -155,9 +155,12 @@ fn derive_main_position(
             }
         }
     }
+    // 平票时 HashMap 遍历序不确定；次级 tie-break 用 position 字典序（取较小者），
+    // 保证同输入恒定输出。Reverse(*p) 让字典序更小的 p 在 (votes, Reverse(p))
+    // 元组比较中显得"更大"，从而被 max_by_key 选中。
     votes
         .into_iter()
-        .max_by_key(|(_, v)| *v)
+        .max_by_key(|(p, v)| (*v, std::cmp::Reverse(*p)))
         .map(|(p, _)| p.to_string())
         .unwrap_or_default()
 }
@@ -659,6 +662,26 @@ mod tests {
         let result = build_suggestions(&games, "me", Some(&snap), None, &[], &[]);
         assert_eq!(result.main_position, "TOP");
         // 未显式传分路时,hot_t0 pick 向应按推断出的 TOP 过滤
+    }
+
+    #[test]
+    fn main_position_tie_should_be_deterministic_by_position_lexical_order() {
+        // 英雄 A(JUNGLE) 与英雄 B(TOP) 各打 3 场 → 得票数相等（平票）。
+        // HashMap 遍历序不确定，必须靠次级 tie-break（字典序最小）保证结果稳定：
+        // JUNGLE < TOP，故恒返回 JUNGLE。
+        let mut games = vec![];
+        for _ in 0..3 {
+            games.push(game(10, true, &[50], 420)); // 英雄 10 → JUNGLE
+        }
+        for _ in 0..3 {
+            games.push(game(20, true, &[50], 420)); // 英雄 20 → TOP
+        }
+        let snap = snapshot(vec![meta(10, "JUNGLE", 2, 0.1), meta(20, "TOP", 2, 0.1)]);
+        let my_champs = aggregate_my_champions(&games);
+        for _ in 0..20 {
+            // 反复跑几次，覆盖 HashMap 遍历序的随机性
+            assert_eq!(derive_main_position(&my_champs, Some(&snap)), "JUNGLE");
+        }
     }
 
     #[test]

--- a/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
@@ -44,6 +44,8 @@ pub struct BpSuggestResult {
     pub sample_games: i32,
     /// OP.GG 快照是否可用；false 时 `hot_t0` 恒空。
     pub opgg_ok: bool,
+    /// OP.GG 快照是否为过期缓存（刷新失败降级使用旧数据）；快照缺失时恒为 false。
+    pub opgg_stale: bool,
     /// 常用英雄 → pick 池候选。
     pub frequent: Vec<BpSuggestItem>,
     /// 常输给的敌方英雄 → ban 池候选。
@@ -345,6 +347,9 @@ fn build_suggestions(
         main_position,
         sample_games: games.len() as i32,
         opgg_ok,
+        // 纯函数不知道快照是否 stale（命令层拿到 `(snap, stale)` 后才知道）；
+        // 命令层用 struct update 覆盖此字段，这里先给非 stale 的默认值。
+        opgg_stale: false,
         frequent,
         nemesis,
         hot_t0,
@@ -407,29 +412,33 @@ pub async fn get_bp_suggest(
             main_position: String::new(),
             sample_games: games.len() as i32,
             opgg_ok: false,
+            opgg_stale: false,
             frequent: vec![],
             nemesis: vec![],
             hot_t0: vec![],
         });
     }
 
-    // OP.GG 数据缺失不阻塞：hot_t0 降级为空
-    let snapshot = crate::command::opgg::ensure_opgg_snapshot(&state, "ranked")
-        .await
-        .ok()
-        .map(|(snap, _stale)| snap);
+    // OP.GG 数据缺失不阻塞：hot_t0 降级为空；stale 透传给前端提示，快照缺失时恒 false
+    let (snapshot, opgg_stale) =
+        match crate::command::opgg::ensure_opgg_snapshot(&state, "ranked").await {
+            Ok((snap, stale)) => (Some(snap), stale),
+            Err(_) => (None, false),
+        };
 
     let pick_pool = load_pool("settings.auto.pickChampionSlice").await;
     let ban_pool = load_pool("settings.auto.banChampionSlice").await;
 
-    Ok(build_suggestions(
+    let mut result = build_suggestions(
         games,
         &me.puuid,
         snapshot.as_deref(),
         position.as_deref(),
         &pick_pool,
         &ban_pool,
-    ))
+    );
+    result.opgg_stale = opgg_stale;
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/bp_suggest.rs
@@ -1,0 +1,621 @@
+//! # BP 智能推荐命令模块
+//!
+//! 从近期战绩 + OP.GG 快照算出三类兜底池候选：
+//! - frequent：常用英雄 → pick 池
+//! - nemesis：败局中敌方高频英雄（常输给谁）→ ban 池
+//! - hot_t0：版本 T0/T1，按熟练度分流 pick/ban
+//!
+//! 纯统计无 AI；聚合全部是纯函数，方便单测。
+//! 主玩分路不用国服不可信的 lane 字段，改用常用英雄的 OP.GG 主分路加权众数。
+
+use crate::config::{get_config, Value};
+use crate::lcu::api::match_history::{Game, MatchHistory};
+use crate::lcu::api::summoner::Summoner;
+use crate::opgg::data::OpggSnapshot;
+use crate::state::AppState;
+use serde::Serialize;
+use std::collections::HashMap;
+use tauri::State;
+
+/// 参与统计的最大场次（LCU 可靠窗口 50 场内取近 30）。
+const SAMPLE_GAMES: i32 = 30;
+/// 样本下限：不足时返回空结果让前端显示「打几局再来」。
+const MIN_SAMPLE_GAMES: usize = 10;
+/// 常用英雄入选门槛（场次）。
+const FREQUENT_MIN_GAMES: i32 = 3;
+/// 常输英雄入选门槛（败局出现次数）。
+const NEMESIS_MIN_ENCOUNTERS: i32 = 2;
+/// 各分区候选上限。
+const SECTION_CAP: usize = 8;
+/// 「会玩」判据：≥3 场且胜率 ≥50%。
+const PROFICIENT_MIN_GAMES: i32 = 3;
+const PROFICIENT_MIN_WIN_RATE: f64 = 0.5;
+/// 主玩分路投票的最低场次（≥2 场才算「玩过」）。
+const POSITION_VOTE_MIN_GAMES: i32 = 2;
+/// 排位队列（单双/灵活）。
+const RANKED_QUEUES: [i32; 2] = [420, 440];
+
+/// `get_bp_suggest` 的聚合结果：主玩分路 + 三类候选分区。
+#[derive(Serialize, Debug, Clone)]
+pub struct BpSuggestResult {
+    /// 推断（或显式指定）的主玩分路："TOP"|"JUNGLE"|"MIDDLE"|"BOTTOM"|"UTILITY"|""（""=无法判定）
+    pub main_position: String,
+    /// 参与统计的样本场次。
+    pub sample_games: i32,
+    /// OP.GG 快照是否可用；false 时 `hot_t0` 恒空。
+    pub opgg_ok: bool,
+    /// 常用英雄 → pick 池候选。
+    pub frequent: Vec<BpSuggestItem>,
+    /// 常输给的敌方英雄 → ban 池候选。
+    pub nemesis: Vec<BpSuggestItem>,
+    /// 版本 T0/T1 英雄，按熟练度分流 pick/ban。
+    pub hot_t0: Vec<BpSuggestItem>,
+}
+
+/// 单个候选英雄条目。
+#[derive(Serialize, Debug, Clone)]
+pub struct BpSuggestItem {
+    /// 英雄 ID。
+    pub champion_id: i32,
+    /// 建议去向池："pick" | "ban"。
+    pub suggested_pool: String,
+    /// 是否已在对应的兜底池中。
+    pub already_in_pool: bool,
+    /// 支撑本条建议的统计证据。
+    pub evidence: BpSuggestEvidence,
+}
+
+/// 候选条目的统计证据；全 Option，缺失字段序列化时省略。
+#[derive(Serialize, Debug, Clone, Default)]
+pub struct BpSuggestEvidence {
+    /// 我玩该英雄的场次。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub games: Option<i32>,
+    /// 我玩该英雄的胜率（0~1）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub win_rate: Option<f64>,
+    /// 败局中出现次数（nemesis 专用）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub losses_against: Option<i32>,
+    /// 败局总数（nemesis 专用，作为 `losses_against` 的分母参考）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loss_games: Option<i32>,
+    /// OP.GG T 级（hot_t0 专用）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opgg_tier: Option<i32>,
+    /// OP.GG 胜率（hot_t0 专用，0~1）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opgg_win_rate: Option<f64>,
+    /// OP.GG 分路（hot_t0 专用）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
+}
+
+/// 我的按英雄聚合：champion_id → (场次, 胜场)。
+fn aggregate_my_champions(games: &[Game]) -> HashMap<i32, (i32, i32)> {
+    let mut map: HashMap<i32, (i32, i32)> = HashMap::new();
+    for g in games {
+        let Some(me) = g.participants.first() else {
+            continue;
+        };
+        let e = map.entry(me.champion_id).or_insert((0, 0));
+        e.0 += 1;
+        if me.stats.win {
+            e.1 += 1;
+        }
+    }
+    map
+}
+
+/// 败局敌方英雄出现次数：champion_id → 次数；同时返回败局总数。
+///
+/// 敌我判定对齐 user_tag::get_one_game_players：以 participants[0]（本人）的
+/// team_id 为基准，game_detail 里 team_id 不同者为敌方。
+fn aggregate_nemesis(games: &[Game]) -> (HashMap<i32, i32>, i32) {
+    let mut map: HashMap<i32, i32> = HashMap::new();
+    let mut loss_games = 0;
+    for g in games {
+        let Some(me) = g.participants.first() else {
+            continue;
+        };
+        if me.stats.win {
+            continue;
+        }
+        loss_games += 1;
+        for p in &g.game_detail.participants {
+            if p.team_id != me.team_id && p.champion_id > 0 {
+                *map.entry(p.champion_id).or_insert(0) += 1;
+            }
+        }
+    }
+    (map, loss_games)
+}
+
+/// 主玩分路：常用英雄（≥POSITION_VOTE_MIN_GAMES 场）的 OP.GG 主分路按场次加权投票。
+///
+/// 不用国服战绩里不可信的 lane 字段；OP.GG 缺数据或无票时返回 ""。
+fn derive_main_position(
+    my_champs: &HashMap<i32, (i32, i32)>,
+    snapshot: Option<&OpggSnapshot>,
+) -> String {
+    let Some(snap) = snapshot else {
+        return String::new();
+    };
+    let mut votes: HashMap<&str, i32> = HashMap::new();
+    for (champ_id, (games, _wins)) in my_champs {
+        if *games < POSITION_VOTE_MIN_GAMES {
+            continue;
+        }
+        let Some(metas) = snap.champions.get(champ_id) else {
+            continue;
+        };
+        if let Some(main) = metas.iter().find(|m| m.is_main_position) {
+            if !main.position.is_empty() {
+                *votes.entry(main.position.as_str()).or_insert(0) += games;
+            }
+        }
+    }
+    votes
+        .into_iter()
+        .max_by_key(|(_, v)| *v)
+        .map(|(p, _)| p.to_string())
+        .unwrap_or_default()
+}
+
+/// 「会玩」判据：打过 ≥3 场且胜率 ≥50%。
+fn is_proficient(agg: Option<&(i32, i32)>) -> bool {
+    match agg {
+        Some((games, wins)) => {
+            *games >= PROFICIENT_MIN_GAMES
+                && (*wins as f64 / *games as f64) >= PROFICIENT_MIN_WIN_RATE
+        }
+        None => false,
+    }
+}
+
+/// 三类候选总装（纯函数，网络/配置读取都在命令层）。
+///
+/// # 参数
+/// - `games`: 参与统计的样本（已按排位优先筛过）
+/// - `my_puuid`: 本人 puuid（当前聚合按 participants[0] 即本人，保留参数备用敌我校验）
+/// - `snapshot`: OP.GG 快照，None 时 hot_t0 为空、主分路为 ""
+/// - `position`: 显式指定分路（None 用推断的主分路）
+/// - `pick_pool` / `ban_pool`: 现有兜底池，用于标记 already_in_pool
+fn build_suggestions(
+    games: &[Game],
+    _my_puuid: &str,
+    snapshot: Option<&OpggSnapshot>,
+    position: Option<&str>,
+    pick_pool: &[i32],
+    ban_pool: &[i32],
+) -> BpSuggestResult {
+    let my_champs = aggregate_my_champions(games);
+    let main_position = derive_main_position(&my_champs, snapshot);
+    let effective_pos = position.unwrap_or(&main_position);
+
+    // frequent：常用英雄，按 (games, wins) 降序 → pick 池候选
+    let mut frequent_ids: Vec<i32> = my_champs
+        .iter()
+        .filter(|(_, (games, _))| *games >= FREQUENT_MIN_GAMES)
+        .map(|(id, _)| *id)
+        .collect();
+    frequent_ids.sort_by(|a, b| {
+        let (ga, wa) = my_champs[a];
+        let (gb, wb) = my_champs[b];
+        (gb, wb).cmp(&(ga, wa))
+    });
+    frequent_ids.truncate(SECTION_CAP);
+    let frequent: Vec<BpSuggestItem> = frequent_ids
+        .iter()
+        .map(|id| {
+            let (games, wins) = my_champs[id];
+            BpSuggestItem {
+                champion_id: *id,
+                suggested_pool: "pick".to_string(),
+                already_in_pool: pick_pool.contains(id),
+                evidence: BpSuggestEvidence {
+                    games: Some(games),
+                    win_rate: Some(wins as f64 / games as f64),
+                    ..Default::default()
+                },
+            }
+        })
+        .collect();
+
+    // nemesis：败局中敌方高频英雄，排除我自己的常用英雄 → ban 池候选
+    let (nemesis_map, loss_games) = aggregate_nemesis(games);
+    let mut nemesis_ids: Vec<i32> = nemesis_map
+        .iter()
+        .filter(|(id, count)| {
+            **count >= NEMESIS_MIN_ENCOUNTERS
+                && !my_champs
+                    .get(id)
+                    .is_some_and(|(g, _)| *g >= FREQUENT_MIN_GAMES)
+        })
+        .map(|(id, _)| *id)
+        .collect();
+    nemesis_ids.sort_by(|a, b| nemesis_map[b].cmp(&nemesis_map[a]));
+    nemesis_ids.truncate(SECTION_CAP);
+    let nemesis: Vec<BpSuggestItem> = nemesis_ids
+        .iter()
+        .map(|id| {
+            let count = nemesis_map[id];
+            BpSuggestItem {
+                champion_id: *id,
+                suggested_pool: "ban".to_string(),
+                already_in_pool: ban_pool.contains(id),
+                evidence: BpSuggestEvidence {
+                    losses_against: Some(count),
+                    loss_games: Some(loss_games),
+                    ..Default::default()
+                },
+            }
+        })
+        .collect();
+
+    // hot_t0：版本 T0/T1（OP.GG tier==1），按我的熟练度分流 pick/ban
+    let opgg_ok = snapshot.is_some();
+    let mut hot_t0: Vec<BpSuggestItem> = vec![];
+    if let Some(snap) = snapshot {
+        let nemesis_set: std::collections::HashSet<i32> = nemesis_ids.iter().copied().collect();
+
+        // pick 向：T0 + 主分路匹配 effective_pos + 我会玩。
+        //
+        // ⚠️ 不对 frequent 做 ID 级排除：PROFICIENT_MIN_GAMES 与 FREQUENT_MIN_GAMES
+        // 都是 3 场，"会玩"(is_proficient) 在场次门槛上是 frequent 判据的严格子集
+        // （proficient 还多一道胜率 ≥50% 的要求）。若排除与 frequent 重叠的英雄，
+        // hot_t0.pick 将对任何输入恒为空——版本强势且我常玩的英雄理应双重命中，
+        // 这也是 Step 1 测试 `hot_t0_should_split_by_proficiency_and_filter_pick_by_position`
+        // 显式要求的行为（英雄 1 打了 4 场、同时满足 frequent 与 proficient，仍应出现在 pick）。
+        let mut pick_candidates: Vec<(i32, &crate::opgg::data::ChampionMeta)> = vec![];
+        // ban 向：T0 + 主分路 + 我不会玩，且不与 nemesis 重复（两个判据相互独立，
+        // 不存在 pick 侧那种子集必空的矛盾，可以正常按 ID 排除）。
+        let mut ban_candidates: Vec<(i32, &crate::opgg::data::ChampionMeta)> = vec![];
+
+        for (champ_id, metas) in &snap.champions {
+            let Some(main) = metas.iter().find(|m| m.is_main_position && m.tier == 1) else {
+                continue;
+            };
+            let agg = my_champs.get(champ_id);
+            if main.position == effective_pos && is_proficient(agg) {
+                pick_candidates.push((*champ_id, main));
+            } else if !is_proficient(agg) && !nemesis_set.contains(champ_id) {
+                ban_candidates.push((*champ_id, main));
+            }
+        }
+
+        // pick 向：按场次/胜率降序（贴近 frequent 排序习惯）
+        pick_candidates.sort_by(|(a_id, _), (b_id, _)| {
+            let (ga, wa) = my_champs.get(a_id).copied().unwrap_or((0, 0));
+            let (gb, wb) = my_champs.get(b_id).copied().unwrap_or((0, 0));
+            (gb, wb).cmp(&(ga, wa))
+        });
+        // ban 向：按 ban_rate 降序
+        ban_candidates.sort_by(|(_, a), (_, b)| {
+            b.ban_rate
+                .partial_cmp(&a.ban_rate)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        for (champ_id, meta) in pick_candidates.into_iter().take(SECTION_CAP) {
+            let agg = my_champs.get(&champ_id);
+            hot_t0.push(BpSuggestItem {
+                champion_id: champ_id,
+                suggested_pool: "pick".to_string(),
+                already_in_pool: pick_pool.contains(&champ_id),
+                evidence: BpSuggestEvidence {
+                    games: agg.map(|(g, _)| *g),
+                    win_rate: agg.map(|(g, w)| *w as f64 / *g as f64),
+                    opgg_tier: Some(meta.tier),
+                    opgg_win_rate: Some(meta.win_rate),
+                    position: Some(meta.position.clone()),
+                    ..Default::default()
+                },
+            });
+        }
+        let remaining = SECTION_CAP.saturating_sub(hot_t0.len());
+        for (champ_id, meta) in ban_candidates.into_iter().take(remaining) {
+            let agg = my_champs.get(&champ_id);
+            hot_t0.push(BpSuggestItem {
+                champion_id: champ_id,
+                suggested_pool: "ban".to_string(),
+                already_in_pool: ban_pool.contains(&champ_id),
+                evidence: BpSuggestEvidence {
+                    games: agg.map(|(g, _)| *g),
+                    win_rate: agg.map(|(g, w)| *w as f64 / *g as f64),
+                    opgg_tier: Some(meta.tier),
+                    opgg_win_rate: Some(meta.win_rate),
+                    position: Some(meta.position.clone()),
+                    ..Default::default()
+                },
+            });
+        }
+    }
+
+    BpSuggestResult {
+        main_position,
+        sample_games: games.len() as i32,
+        opgg_ok,
+        frequent,
+        nemesis,
+        hot_t0,
+    }
+}
+
+/// 读取兜底池配置（照抄 automation.rs::load_champion_pool 的容错读法）。
+async fn load_pool(key: &str) -> Vec<i32> {
+    let to_ids = |list: &Vec<Value>| -> Vec<i32> {
+        list.iter()
+            .filter_map(|v| match v {
+                Value::Integer(i) => Some(*i as i32),
+                _ => None,
+            })
+            .collect()
+    };
+    match get_config(key).await {
+        Ok(Value::Map(m)) => match m.get("value") {
+            Some(Value::List(list)) => to_ids(list),
+            _ => vec![],
+        },
+        Ok(Value::List(list)) => to_ids(&list),
+        _ => vec![],
+    }
+}
+
+/// BP 智能推荐：算出三类兜底池候选。
+///
+/// # 参数
+/// - `position`: 显式指定分路（大写 TOP/...）；None 用常用英雄推断的主分路
+///
+/// # 行为
+/// - 近 30 场里筛排位（420/440）；排位不足 10 场则放宽用全部模式
+/// - 全部样本仍不足 10 场时返回空分区（sample_games 告知前端显示空态）
+/// - OP.GG 快照拿不到时 opgg_ok=false，hot_t0 为空，其余分区照常
+#[tauri::command]
+pub async fn get_bp_suggest(
+    position: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<BpSuggestResult, String> {
+    let me = Summoner::get_my_summoner().await?;
+    let mut history =
+        MatchHistory::get_match_history_by_puuid(&me.puuid, 0, SAMPLE_GAMES - 1).await?;
+    history.enrich_game_detail().await?;
+
+    let all_games = history.games.games;
+    let ranked: Vec<Game> = all_games
+        .iter()
+        .filter(|g| RANKED_QUEUES.contains(&g.queue_id))
+        .cloned()
+        .collect();
+    let games: &[Game] = if ranked.len() >= MIN_SAMPLE_GAMES {
+        &ranked
+    } else {
+        &all_games
+    };
+
+    if games.len() < MIN_SAMPLE_GAMES {
+        return Ok(BpSuggestResult {
+            main_position: String::new(),
+            sample_games: games.len() as i32,
+            opgg_ok: false,
+            frequent: vec![],
+            nemesis: vec![],
+            hot_t0: vec![],
+        });
+    }
+
+    // OP.GG 数据缺失不阻塞：hot_t0 降级为空
+    let snapshot = crate::command::opgg::ensure_opgg_snapshot(&state, "ranked")
+        .await
+        .ok()
+        .map(|(snap, _stale)| snap);
+
+    let pick_pool = load_pool("settings.auto.pickChampionSlice").await;
+    let ban_pool = load_pool("settings.auto.banChampionSlice").await;
+
+    Ok(build_suggestions(
+        games,
+        &me.puuid,
+        snapshot.as_deref(),
+        position.as_deref(),
+        &pick_pool,
+        &ban_pool,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lcu::api::game_detail::GameDetail;
+    use crate::lcu::api::model::{Participant, ParticipantIdentity, Player, Stats};
+    use crate::opgg::data::ChampionMeta;
+
+    /// 构造一场对局：我用 my_champ，胜负 win，敌方阵容 enemy_champs。
+    fn game(my_champ: i32, win: bool, enemy_champs: &[i32], queue_id: i32) -> Game {
+        let me = Participant {
+            team_id: 100,
+            champion_id: my_champ,
+            stats: Stats {
+                win,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // game_detail：我 + 敌方（识别靠 puuid，敌方 team_id=200）
+        let mut participants = vec![me.clone()];
+        let mut identities = vec![ParticipantIdentity {
+            player: Player {
+                puuid: "me".into(),
+                ..Default::default()
+            },
+        }];
+        for (i, champ) in enemy_champs.iter().enumerate() {
+            participants.push(Participant {
+                team_id: 200,
+                champion_id: *champ,
+                stats: Stats {
+                    win: !win,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+            identities.push(ParticipantIdentity {
+                player: Player {
+                    puuid: format!("enemy{}", i),
+                    ..Default::default()
+                },
+            });
+        }
+        Game {
+            queue_id,
+            participants: vec![me],
+            game_detail: GameDetail {
+                participants,
+                participant_identities: identities,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn meta(champion_id: i32, position: &str, tier: i32, ban_rate: f64) -> ChampionMeta {
+        ChampionMeta {
+            champion_id,
+            position: position.into(),
+            tier,
+            rank: 1,
+            rank_prev_patch: 0,
+            win_rate: 0.52,
+            pick_rate: 0.1,
+            ban_rate,
+            role_rate: 0.8,
+            is_main_position: true,
+        }
+    }
+
+    fn snapshot(metas: Vec<ChampionMeta>) -> OpggSnapshot {
+        let mut champions: HashMap<i32, Vec<ChampionMeta>> = HashMap::new();
+        for m in metas {
+            champions.entry(m.champion_id).or_default().push(m);
+        }
+        OpggSnapshot {
+            mode: "ranked".into(),
+            tier: "emerald_plus".into(),
+            patch: "16.13".into(),
+            fetched_at: 0,
+            champions,
+            counters: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn frequent_should_require_min_games_and_sort_by_count() {
+        // 英雄 1 打 4 场、英雄 2 打 3 场、英雄 3 打 2 场（低于门槛淘汰）
+        let mut games = vec![];
+        for _ in 0..4 {
+            games.push(game(1, true, &[50], 420));
+        }
+        for _ in 0..3 {
+            games.push(game(2, false, &[50], 420));
+        }
+        for _ in 0..2 {
+            games.push(game(3, true, &[50], 420));
+        }
+        let result = build_suggestions(&games, "me", None, None, &[], &[]);
+        let ids: Vec<i32> = result.frequent.iter().map(|i| i.champion_id).collect();
+        assert_eq!(ids, vec![1, 2]);
+        assert_eq!(result.frequent[0].suggested_pool, "pick");
+        assert_eq!(result.frequent[0].evidence.games, Some(4));
+        assert_eq!(result.frequent[0].evidence.win_rate, Some(1.0));
+    }
+
+    #[test]
+    fn nemesis_should_count_enemies_in_losses_only_and_skip_my_frequents() {
+        let mut games = vec![];
+        // 3 场败局都有敌方英雄 77；1 场胜局的敌方 88 不该被计入
+        for _ in 0..3 {
+            games.push(game(1, false, &[77, 78], 420));
+        }
+        games.push(game(1, true, &[88], 420));
+        // 我自己也常玩 78（4 场）→ nemesis 应排除 78
+        for _ in 0..4 {
+            games.push(game(78, true, &[50], 420));
+        }
+        let result = build_suggestions(&games, "me", None, None, &[], &[]);
+        let ids: Vec<i32> = result.nemesis.iter().map(|i| i.champion_id).collect();
+        assert_eq!(
+            ids,
+            vec![77],
+            "只统计败局敌方,排除自己常玩的 78,88 不达门槛"
+        );
+        assert_eq!(result.nemesis[0].suggested_pool, "ban");
+        assert_eq!(result.nemesis[0].evidence.losses_against, Some(3));
+        assert_eq!(result.nemesis[0].evidence.loss_games, Some(3));
+    }
+
+    #[test]
+    fn hot_t0_should_split_by_proficiency_and_filter_pick_by_position() {
+        // 英雄 1：T0 上单,我 4 场全胜 → pick；英雄 5：T0 中单,我没玩过 → ban
+        // 英雄 6：T0 上单但我没玩过 → ban（ban 不限分路）
+        let mut games = vec![];
+        for _ in 0..4 {
+            games.push(game(1, true, &[50], 420));
+        }
+        let snap = snapshot(vec![
+            meta(1, "TOP", 1, 0.2),
+            meta(5, "MIDDLE", 1, 0.3),
+            meta(6, "TOP", 1, 0.1),
+        ]);
+        let result = build_suggestions(&games, "me", Some(&snap), Some("TOP"), &[], &[]);
+        assert!(result.opgg_ok);
+        let picks: Vec<i32> = result
+            .hot_t0
+            .iter()
+            .filter(|i| i.suggested_pool == "pick")
+            .map(|i| i.champion_id)
+            .collect();
+        let bans: Vec<i32> = result
+            .hot_t0
+            .iter()
+            .filter(|i| i.suggested_pool == "ban")
+            .map(|i| i.champion_id)
+            .collect();
+        assert_eq!(picks, vec![1]);
+        // ban 向按 ban_rate 降序：5(0.3) 在 6(0.1) 前
+        assert_eq!(bans, vec![5, 6]);
+    }
+
+    #[test]
+    fn main_position_should_be_weighted_mode_of_opgg_main_positions() {
+        // 英雄 1(TOP) 4 场 + 英雄 2(TOP) 2 场 vs 英雄 3(MIDDLE) 3 场 → TOP
+        let mut games = vec![];
+        for _ in 0..4 {
+            games.push(game(1, true, &[50], 420));
+        }
+        for _ in 0..2 {
+            games.push(game(2, true, &[50], 420));
+        }
+        for _ in 0..3 {
+            games.push(game(3, true, &[50], 420));
+        }
+        let snap = snapshot(vec![
+            meta(1, "TOP", 2, 0.1),
+            meta(2, "TOP", 3, 0.1),
+            meta(3, "MIDDLE", 2, 0.1),
+        ]);
+        let result = build_suggestions(&games, "me", Some(&snap), None, &[], &[]);
+        assert_eq!(result.main_position, "TOP");
+        // 未显式传分路时,hot_t0 pick 向应按推断出的 TOP 过滤
+    }
+
+    #[test]
+    fn already_in_pool_should_be_flagged_per_target_pool() {
+        let mut games = vec![];
+        for _ in 0..3 {
+            games.push(game(1, false, &[77], 420));
+        }
+        let result = build_suggestions(&games, "me", None, None, &[1], &[77]);
+        assert!(result.frequent[0].already_in_pool, "1 已在 pick 池");
+        assert!(result.nemesis[0].already_in_pool, "77 已在 ban 池");
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
@@ -107,12 +107,15 @@ fn collect_counters(snap: &OpggSnapshot, champion_ids: &[i32]) -> HashMap<i32, V
 ///
 /// # 参数
 /// - `mem_cache`: 内存缓存（无 TTL，保留最后已知快照供降级）
+/// - `mode`: 数据模式（"ranked"/"aram"）
+/// - `tier`: 当前配置的段位（仅 ranked 参与新鲜度判定，见 `tier_ok`）
 /// - `now`: 当前 unix 秒（新鲜度判定基准）
 /// - `fetch`: HTTP 拉取（生产为 `api::fetch_mode`）
 /// - `disk_load` / `disk_save`: 磁盘缓存读写（生产为 `cache::load` / `cache::save`）
 async fn ensure_snapshot_impl<F, Fut>(
     mem_cache: &moka::future::Cache<String, Arc<OpggSnapshot>>,
     mode: &str,
+    tier: &str,
     now: i64,
     fetch: F,
     disk_load: impl Fn(&str) -> Option<OpggSnapshot>,
@@ -124,16 +127,19 @@ where
 {
     validate_mode(mode)?;
 
+    // ranked 快照还需 tier 与当前配置一致才算命中；aram 无段位概念跳过。
+    let tier_ok = |snap: &OpggSnapshot| mode != "ranked" || snap.tier == tier;
+
     // 1. 内存 fresh
     if let Some(snap) = mem_cache.get(mode).await {
-        if cache::is_fresh(&snap, now) {
+        if cache::is_fresh(&snap, now) && tier_ok(&snap) {
             return Ok((snap, false));
         }
     }
 
     // 2. 磁盘 fresh（跨重启复用）
     if let Some(disk) = disk_load(mode) {
-        if cache::is_fresh(&disk, now) {
+        if cache::is_fresh(&disk, now) && tier_ok(&disk) {
             let arc = Arc::new(disk);
             mem_cache.insert(mode.to_string(), arc.clone()).await;
             return Ok((arc, false));
@@ -178,12 +184,20 @@ pub async fn ensure_opgg_snapshot(
     state: &AppState,
     mode: &str,
 ) -> Result<(Arc<OpggSnapshot>, bool), String> {
+    // 段位配置：前端写入 Map{value:String}，extract_string 两种格式都容忍；
+    // 非法/缺省回退默认段位，读失败不阻塞主流程。
+    let tier_cfg = crate::config::get_config("settings.opgg.tier")
+        .await
+        .ok()
+        .and_then(|v| crate::config::extract_string(&v));
+    let tier = api::sanitize_tier(tier_cfg.as_deref());
+
     ensure_snapshot_impl(
         &state.opgg_cache,
         mode,
+        tier,
         now_secs(),
-        // TODO(task-2): tier 应读用户配置，此处暂用默认段位以保证编译通过
-        |m| async move { api::fetch_mode(&m, api::DEFAULT_TIER).await },
+        |m| async move { api::fetch_mode(&m, tier).await },
         cache::load,
         cache::save,
     )
@@ -356,6 +370,14 @@ mod tests {
         }
     }
 
+    /// 指定 tier 的快照。
+    fn snapshot_at_tier(fetched_at: i64, tier: &str) -> OpggSnapshot {
+        OpggSnapshot {
+            tier: tier.into(),
+            ..snapshot_at(fetched_at)
+        }
+    }
+
     /// 空内存缓存（与 `AppState::opgg_cache` 同构：无 TTL）。
     fn mem_cache() -> moka::future::Cache<String, Arc<OpggSnapshot>> {
         moka::future::Cache::builder().build()
@@ -382,6 +404,7 @@ mod tests {
         let (snap, stale) = ensure_snapshot_impl(
             &cache_map,
             "ranked",
+            "emerald_plus",
             NOW,
             |_m| {
                 fetch_called.store(true, Ordering::SeqCst);
@@ -409,6 +432,7 @@ mod tests {
         let (snap, stale) = ensure_snapshot_impl(
             &cache_map,
             "ranked",
+            "emerald_plus",
             NOW,
             |_m| {
                 fetch_called.store(true, Ordering::SeqCst);
@@ -442,6 +466,7 @@ mod tests {
         let (snap, stale) = ensure_snapshot_impl(
             &cache_map,
             "ranked",
+            "emerald_plus",
             NOW,
             |_m| async { Ok(snapshot_at(NOW)) },
             disk_none,
@@ -471,6 +496,7 @@ mod tests {
         let (snap, stale) = ensure_snapshot_impl(
             &cache_map,
             "ranked",
+            "emerald_plus",
             NOW,
             |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
             disk_none,
@@ -490,6 +516,7 @@ mod tests {
         let (snap, stale) = ensure_snapshot_impl(
             &cache_map,
             "ranked",
+            "emerald_plus",
             NOW,
             |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
             |_mode| Some(snapshot_at(NOW - TTL_SECS - 100)),
@@ -511,6 +538,7 @@ mod tests {
         let err = ensure_snapshot_impl(
             &cache_map,
             "ranked",
+            "emerald_plus",
             NOW,
             |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
             disk_none,
@@ -530,6 +558,7 @@ mod tests {
         let err = ensure_snapshot_impl(
             &cache_map,
             "urf",
+            "emerald_plus",
             NOW,
             |_m| {
                 fetch_called.store(true, Ordering::SeqCst);
@@ -543,5 +572,112 @@ mod tests {
 
         assert!(err.contains("invalid opgg mode"));
         assert!(!fetch_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn ensure_should_refetch_when_memory_tier_mismatches() {
+        let cache_map = mem_cache();
+        // 内存里是 fresh 的 emerald_plus 快照，但当前配置要 gold_plus
+        cache_map
+            .insert(
+                "ranked".into(),
+                Arc::new(snapshot_at_tier(NOW - 100, "emerald_plus")),
+            )
+            .await;
+
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            "gold_plus",
+            NOW,
+            |_m| async { Ok(snapshot_at_tier(NOW, "gold_plus")) },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(!stale);
+        assert_eq!(snap.tier, "gold_plus", "tier 不匹配应重拉");
+    }
+
+    #[tokio::test]
+    async fn ensure_should_skip_disk_with_mismatched_or_legacy_tier() {
+        let cache_map = mem_cache();
+        // 磁盘是旧缓存（无 tier 字段 → serde default 空串），应视为 miss 走拉取
+        let (snap, _stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            "emerald_plus",
+            NOW,
+            |_m| async { Ok(snapshot_at_tier(NOW, "emerald_plus")) },
+            |_mode| Some(snapshot_at_tier(NOW - 100, "")),
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+        assert_eq!(snap.tier, "emerald_plus", "旧缓存空 tier 应重拉");
+    }
+
+    #[tokio::test]
+    async fn ensure_should_still_fall_back_to_stale_mismatched_tier_on_fetch_failure() {
+        let cache_map = mem_cache();
+        // 拉取失败时，宁可给错段位的旧数据也不给空——降级链兜底不校验 tier
+        cache_map
+            .insert(
+                "ranked".into(),
+                Arc::new(snapshot_at_tier(NOW - 100, "emerald_plus")),
+            )
+            .await;
+
+        let (snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "ranked",
+            "gold_plus",
+            NOW,
+            |_m| async { Err::<OpggSnapshot, String>("network down".into()) },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(stale, "错段位数据按 stale 降级返回");
+        assert_eq!(snap.tier, "emerald_plus");
+    }
+
+    #[tokio::test]
+    async fn ensure_should_ignore_tier_for_aram() {
+        let cache_map = mem_cache();
+        // aram 快照 tier 恒空串，不应因配置了段位而 miss
+        cache_map
+            .insert(
+                "aram".into(),
+                Arc::new(OpggSnapshot {
+                    mode: "aram".into(),
+                    tier: String::new(),
+                    ..snapshot_at(NOW - 100)
+                }),
+            )
+            .await;
+
+        let fetch_called = AtomicBool::new(false);
+        let (_snap, stale) = ensure_snapshot_impl(
+            &cache_map,
+            "aram",
+            "gold_plus",
+            NOW,
+            |_m| {
+                fetch_called.store(true, Ordering::SeqCst);
+                async { Err::<OpggSnapshot, String>("should not fetch".into()) }
+            },
+            disk_none,
+            disk_save_ok,
+        )
+        .await
+        .unwrap();
+
+        assert!(!fetch_called.load(Ordering::SeqCst), "aram 不校验 tier");
+        assert!(!stale);
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/command/opgg.rs
@@ -182,7 +182,8 @@ pub async fn ensure_opgg_snapshot(
         &state.opgg_cache,
         mode,
         now_secs(),
-        |m| async move { api::fetch_mode(&m).await },
+        // TODO(task-2): tier 应读用户配置，此处暂用默认段位以保证编译通过
+        |m| async move { api::fetch_mode(&m, api::DEFAULT_TIER).await },
         cache::load,
         cache::save,
     )
@@ -288,6 +289,7 @@ mod tests {
         );
         OpggSnapshot {
             mode: "ranked".into(),
+            tier: "emerald_plus".into(),
             patch: "16.13".into(),
             fetched_at: 1_752_000_000,
             champions,

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -125,6 +125,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::ai::stream_ai_analysis,
             command::asset::get_asset_details,
             command::bp::get_bp_decision,
+            command::bp_suggest::get_bp_suggest,
             command::config::put_config,
             command::config::get_config,
             // command::config::get_http_server_port,

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/api.rs
@@ -7,10 +7,33 @@ use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASE_URL: &str = "https://lol-api-champion.op.gg/api/global/champions";
-/// ranked 数据取 emerald+ 分段（样本大且贴近排位主流生态）。
-const RANKED_TIER_PARAM: &str = "tier=emerald_plus";
 /// 同 fandom::api 风格的浏览器 UA——OP.GG 对无 UA 请求可能拒绝。
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+/// 段位白名单：OP.GG 支持的 tier 参数取值（实测均返回有效数据）。
+pub const VALID_TIERS: [&str; 6] = [
+    "gold_plus",
+    "platinum_plus",
+    "emerald_plus",
+    "diamond_plus",
+    "master_plus",
+    "all",
+];
+
+/// 默认段位分段（样本大且贴近排位主流生态）。
+pub const DEFAULT_TIER: &str = "emerald_plus";
+
+/// 校验段位取值：在白名单内原样返回，非法/缺省回退 [`DEFAULT_TIER`]。
+pub fn sanitize_tier(raw: Option<&str>) -> &'static str {
+    match raw {
+        Some(t) => VALID_TIERS
+            .iter()
+            .find(|v| **v == t)
+            .copied()
+            .unwrap_or(DEFAULT_TIER),
+        None => DEFAULT_TIER,
+    }
+}
 
 /// OP.GG 原始响应（只解出需要的字段，其余忽略；可空字段全部 Option 容错）。
 #[derive(Deserialize)]
@@ -65,9 +88,9 @@ struct RawCounter {
 }
 
 /// 拼接某模式的请求 URL（仅 ranked 需要 tier 参数）。
-pub fn mode_url(mode: &str) -> String {
+pub fn mode_url(mode: &str, tier: &str) -> String {
     if mode == "ranked" {
-        format!("{}/{}?{}", BASE_URL, mode, RANKED_TIER_PARAM)
+        format!("{}/{}?tier={}", BASE_URL, mode, tier)
     } else {
         format!("{}/{}", BASE_URL, mode)
     }
@@ -77,11 +100,12 @@ pub fn mode_url(mode: &str) -> String {
 ///
 /// # 参数
 /// - `mode`: "ranked" | "aram"
+/// - `tier`: ranked 段位分段（如 "emerald_plus"）；aram 忽略此参数
 ///
 /// # 错误
 /// 网络失败、非 2xx、响应解析失败时返回 Err；调用方负责降级到缓存。
-pub async fn fetch_mode(mode: &str) -> Result<OpggSnapshot, String> {
-    let url = mode_url(mode);
+pub async fn fetch_mode(mode: &str, tier: &str) -> Result<OpggSnapshot, String> {
+    let url = mode_url(mode, tier);
     log::info!("Fetching OP.GG data: {}", url);
 
     let client = Client::builder()
@@ -101,7 +125,7 @@ pub async fn fetch_mode(mode: &str) -> Result<OpggSnapshot, String> {
         .map_err(|e| e.to_string())?
         .as_secs() as i64;
 
-    let snap = parse_snapshot(mode, &body, now)?;
+    let snap = parse_snapshot(mode, tier, &body, now)?;
     log::info!(
         "OP.GG {} snapshot: patch {}, {} champions",
         mode,
@@ -115,6 +139,7 @@ pub async fn fetch_mode(mode: &str) -> Result<OpggSnapshot, String> {
 ///
 /// # 参数
 /// - `mode`: "ranked" | "aram"（写入快照，不参与解析分支——分路有无由数据自身决定）
+/// - `tier`: 请求时使用的段位分段，写入快照的 `tier` 字段（非 ranked 恒记 ""）
 /// - `body`: 响应体 JSON 字符串
 /// - `fetched_at`: 拉取时间（unix 秒），由调用方注入以便测试
 ///
@@ -122,7 +147,12 @@ pub async fn fetch_mode(mode: &str) -> Result<OpggSnapshot, String> {
 /// - `positions` 为 null（aram）→ 用 `average_stats` 生成单条 position="" 的记录
 /// - `ban_rate`/`tier` 等为 null → 取 0
 /// - 单个英雄缺 `average_stats` 且无 positions → 跳过该英雄
-pub fn parse_snapshot(mode: &str, body: &str, fetched_at: i64) -> Result<OpggSnapshot, String> {
+pub fn parse_snapshot(
+    mode: &str,
+    tier: &str,
+    body: &str,
+    fetched_at: i64,
+) -> Result<OpggSnapshot, String> {
     let raw: RawResponse =
         serde_json::from_str(body).map_err(|e| format!("OP.GG response parse error: {}", e))?;
 
@@ -209,6 +239,11 @@ pub fn parse_snapshot(mode: &str, body: &str, fetched_at: i64) -> Result<OpggSna
 
     Ok(OpggSnapshot {
         mode: mode.to_string(),
+        tier: if mode == "ranked" {
+            tier.to_string()
+        } else {
+            String::new()
+        },
         patch: raw.meta.version,
         fetched_at,
         champions,
@@ -225,8 +260,9 @@ mod tests {
 
     #[test]
     fn should_parse_ranked_snapshot_with_positions_and_counters() {
-        let snap = parse_snapshot("ranked", RANKED_FIXTURE, 1_752_000_000).unwrap();
+        let snap = parse_snapshot("ranked", "emerald_plus", RANKED_FIXTURE, 1_752_000_000).unwrap();
         assert_eq!(snap.mode, "ranked");
+        assert_eq!(snap.tier, "emerald_plus");
         assert_eq!(snap.patch, "16.13");
         assert_eq!(snap.fetched_at, 1_752_000_000);
 
@@ -250,7 +286,7 @@ mod tests {
 
     #[test]
     fn should_normalize_positions_and_mark_main_by_role_rate() {
-        let snap = parse_snapshot("ranked", RANKED_FIXTURE, 0).unwrap();
+        let snap = parse_snapshot("ranked", "emerald_plus", RANKED_FIXTURE, 0).unwrap();
         let c = &snap.champions[&999];
         assert_eq!(c.len(), 2);
         // OP.GG 命名 → LCU 命名
@@ -264,7 +300,7 @@ mod tests {
 
     #[test]
     fn should_parse_aram_with_null_positions_and_null_ban_rate() {
-        let snap = parse_snapshot("aram", ARAM_FIXTURE, 0).unwrap();
+        let snap = parse_snapshot("aram", "emerald_plus", ARAM_FIXTURE, 0).unwrap();
         let c = &snap.champions[&1];
         assert_eq!(c.len(), 1);
         assert_eq!(c[0].position, ""); // 无分路模式
@@ -272,12 +308,13 @@ mod tests {
         assert_eq!(c[0].ban_rate, 0.0); // null → 0.0
         assert!(c[0].is_main_position);
         assert!(snap.counters.is_empty()); // aram 无 counter
+        assert_eq!(snap.tier, ""); // aram 无段位概念
     }
 
     #[test]
     fn should_reject_malformed_body() {
-        assert!(parse_snapshot("ranked", "not json", 0).is_err());
-        assert!(parse_snapshot("ranked", r#"{"foo": 1}"#, 0).is_err());
+        assert!(parse_snapshot("ranked", "emerald_plus", "not json", 0).is_err());
+        assert!(parse_snapshot("ranked", "emerald_plus", r#"{"foo": 1}"#, 0).is_err());
     }
 
     #[test]
@@ -290,22 +327,36 @@ mod tests {
     }
 
     #[test]
-    fn mode_url_should_add_tier_param_only_for_ranked() {
+    fn mode_url_should_append_tier_only_for_ranked() {
         assert_eq!(
-            mode_url("ranked"),
-            "https://lol-api-champion.op.gg/api/global/champions/ranked?tier=emerald_plus"
+            mode_url("ranked", "gold_plus"),
+            "https://lol-api-champion.op.gg/api/global/champions/ranked?tier=gold_plus"
         );
+        // aram 无 tier 参数
         assert_eq!(
-            mode_url("aram"),
+            mode_url("aram", "gold_plus"),
             "https://lol-api-champion.op.gg/api/global/champions/aram"
         );
+    }
+
+    #[test]
+    fn sanitize_tier_should_whitelist_and_fall_back() {
+        assert_eq!(sanitize_tier(Some("gold_plus")), "gold_plus");
+        assert_eq!(sanitize_tier(Some("master_plus")), "master_plus");
+        assert_eq!(sanitize_tier(Some("all")), "all");
+        // 非法值与缺省回退默认段位
+        assert_eq!(sanitize_tier(Some("bogus")), "emerald_plus");
+        assert_eq!(sanitize_tier(None), "emerald_plus");
+        assert_eq!(sanitize_tier(Some("")), "emerald_plus");
     }
 
     /// 真实网络冒烟测试：默认忽略，本机联调时 `cargo test opgg -- --ignored` 手动跑。
     #[tokio::test]
     #[ignore]
     async fn live_fetch_ranked_should_return_snapshot() {
-        let snap = fetch_mode("ranked").await.expect("live fetch");
+        let snap = fetch_mode("ranked", DEFAULT_TIER)
+            .await
+            .expect("live fetch");
         assert!(!snap.patch.is_empty());
         assert!(snap.champions.len() > 100);
         assert!(!snap.counters.is_empty());

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
@@ -57,6 +57,7 @@ mod tests {
     fn snap(fetched_at: i64) -> OpggSnapshot {
         OpggSnapshot {
             mode: "ranked".into(),
+            tier: "emerald_plus".into(),
             patch: "16.13".into(),
             fetched_at,
             champions: HashMap::new(),

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/data.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/data.rs
@@ -55,6 +55,10 @@ pub struct LaneCounter {
 pub struct OpggSnapshot {
     /// 模式："ranked" | "aram"
     pub mode: String,
+    /// ranked 数据的段位分段（如 "emerald_plus"）；aram 无段位概念恒为 ""。
+    /// `serde(default)`：旧磁盘缓存无此字段 → 空串 → 与当前配置不匹配自然视为 miss。
+    #[serde(default)]
+    pub tier: String,
     /// patch 版本号（OP.GG meta.version，如 "16.13"）
     pub patch: String,
     /// 拉取时间（unix 秒）

--- a/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
+++ b/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
@@ -36,8 +36,14 @@ const emit = defineEmits<{
 const loading = ref(false)
 const error = ref<string | null>(null)
 const result = ref<BpSuggestResult | null>(null)
-/** 分路下拉当前值（'' = 全部/后端推断） */
+/** 分路下拉当前值（'' = 全部分路，即不过滤；自动模式首载后会回填为推断的主分路） */
 const selectedPosition = ref<string>('')
+/**
+ * 用户是否手动动过分路下拉（含显式选中「全部分路」）。
+ * false（自动模式）时「重新生成」仍传 null 让后端重新推断并回填下拉；
+ * true（用户已显式选择，哪怕选的是空串）后不再让响应覆写下拉。
+ */
+const positionTouched = ref(false)
 /** 本次会话内已采用的 (pool:championId) 集合，驱动灰态 */
 const adopted = ref<Set<string>>(new Set())
 /** 正在提交中的 (pool:championId) 集合，防连点 + 驱动按钮 loading */
@@ -54,16 +60,17 @@ const POSITION_OPTIONS = [
 
 /**
  * 拉取一次推荐结果
- * @param position - 大写分路名，不传/空串时由后端推断主打分路
+ * @param position - 大写分路名；null=自动模式，由后端推断主打分路并回填下拉；
+ *   显式空串 `''` = 用户选了「全部分路」，原样传给后端表示不过滤，不再被响应回填覆写
  */
-async function load(position?: string) {
+async function load(position: string | null) {
   loading.value = true
   error.value = null
   try {
-    result.value = await invoke<BpSuggestResult>('get_bp_suggest', {
-      position: position || null
-    })
-    if (!position) selectedPosition.value = result.value.main_position
+    result.value = await invoke<BpSuggestResult>('get_bp_suggest', { position })
+    // 只有自动模式（未显式指定分路）才用响应回填下拉；用户显式选择后
+    // （含选「全部分路」的空串）不再被覆写，否则用户的选择会被弹回。
+    if (position === null) selectedPosition.value = result.value.main_position
   } catch (e) {
     error.value = (e as Error).message ?? String(e)
   } finally {
@@ -71,10 +78,15 @@ async function load(position?: string) {
   }
 }
 
+/** 「重新生成」：用户没动过下拉则维持自动语义，动过则用当前显式值（含空串） */
+function regenerate() {
+  void load(positionTouched.value ? selectedPosition.value : null)
+}
+
 watch(
   () => props.show,
   isShown => {
-    if (isShown && result.value === null) void load()
+    if (isShown && result.value === null) void load(null)
   },
   { immediate: true }
 )
@@ -172,7 +184,8 @@ async function adopt(item: BpSuggestItem, pool: SuggestedPool) {
 
 async function onPositionChange(pos: string) {
   selectedPosition.value = pos
-  await load(pos || undefined)
+  positionTouched.value = true
+  await load(pos)
 }
 
 /** 头像加载失败时回退到占位英雄图（id -1） */
@@ -200,9 +213,7 @@ function close() {
             style="width: 120px"
             @update:value="onPositionChange"
           />
-          <n-button size="small" :loading="loading" @click="load(selectedPosition || undefined)">
-            🔄 重新生成
-          </n-button>
+          <n-button size="small" :loading="loading" @click="regenerate">🔄 重新生成</n-button>
         </n-space>
       </template>
 
@@ -216,7 +227,7 @@ function close() {
       <div v-else-if="error">
         <n-empty description="推荐生成失败">
           <template #extra>
-            <n-button @click="load(selectedPosition || undefined)">重试</n-button>
+            <n-button @click="regenerate">重试</n-button>
             <n-text
               depth="3"
               style="display: block; margin-top: var(--space-8); font-size: var(--font-size-sm)"

--- a/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
+++ b/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
@@ -40,6 +40,8 @@ const result = ref<BpSuggestResult | null>(null)
 const selectedPosition = ref<string>('')
 /** 本次会话内已采用的 (pool:championId) 集合，驱动灰态 */
 const adopted = ref<Set<string>>(new Set())
+/** 正在提交中的 (pool:championId) 集合，防连点 + 驱动按钮 loading */
+const adoptingKeys = ref<Set<string>>(new Set())
 
 const POSITION_OPTIONS = [
   { label: '全部分路', value: '' },
@@ -136,15 +138,36 @@ function isAdopted(item: BpSuggestItem, pool: SuggestedPool): boolean {
   )
 }
 
-/** 采用：读现有池 → 去重 append → 写回 → 灰态 + 通知父组件 */
+/** 是否正在提交该 (pool, championId)——驱动按钮 loading/disabled，防连点 */
+function isAdopting(item: BpSuggestItem, pool: SuggestedPool): boolean {
+  return adoptingKeys.value.has(adoptKey(pool, item.champion_id))
+}
+
+/**
+ * 采用：读现有池 → 去重 append → 写回 → 灰态 + 通知父组件
+ *
+ * 用 `adoptingKeys` 在 (pool, championId) 粒度防重入：同一张卡片的按钮在
+ * 请求完成前再次点击会被直接忽略；IPC 失败时吞掉异常仅打日志，不置灰、不
+ * emit，避免用户零反馈或双击竞态下两次都读到旧池子。
+ */
 async function adopt(item: BpSuggestItem, pool: SuggestedPool) {
-  const key = pool === 'pick' ? 'settings.auto.pickChampionSlice' : 'settings.auto.banChampionSlice'
-  const existing = (await getConfigByIpc<number[]>(key)) ?? []
-  if (!existing.includes(item.champion_id)) {
-    await putConfigByIpc(key, [...existing, item.champion_id])
+  const aKey = adoptKey(pool, item.champion_id)
+  if (adoptingKeys.value.has(aKey)) return
+  adoptingKeys.value.add(aKey)
+  try {
+    const key =
+      pool === 'pick' ? 'settings.auto.pickChampionSlice' : 'settings.auto.banChampionSlice'
+    const existing = (await getConfigByIpc<number[]>(key)) ?? []
+    if (!existing.includes(item.champion_id)) {
+      await putConfigByIpc(key, [...existing, item.champion_id])
+    }
+    adopted.value = new Set(adopted.value).add(aKey)
+    emit('adopted', pool)
+  } catch (e) {
+    console.error('采用推荐失败', e)
+  } finally {
+    adoptingKeys.value.delete(aKey)
   }
-  adopted.value = new Set(adopted.value).add(adoptKey(pool, item.champion_id))
-  emit('adopted', pool)
 }
 
 async function onPositionChange(pos: string) {
@@ -248,7 +271,10 @@ function close() {
                 size="small"
                 type="primary"
                 style="margin-top: var(--space-8); width: 100%"
-                :disabled="isAdopted(item, item.suggested_pool)"
+                :disabled="
+                  isAdopted(item, item.suggested_pool) || isAdopting(item, item.suggested_pool)
+                "
+                :loading="isAdopting(item, item.suggested_pool)"
                 @click="adopt(item, item.suggested_pool)"
               >
                 {{
@@ -264,7 +290,11 @@ function close() {
                 quaternary
                 size="small"
                 style="margin-top: var(--space-4); width: 100%"
-                :disabled="isAdopted(item, item.suggested_pool === 'pick' ? 'ban' : 'pick')"
+                :disabled="
+                  isAdopted(item, item.suggested_pool === 'pick' ? 'ban' : 'pick') ||
+                  isAdopting(item, item.suggested_pool === 'pick' ? 'ban' : 'pick')
+                "
+                :loading="isAdopting(item, item.suggested_pool === 'pick' ? 'ban' : 'pick')"
                 @click="adopt(item, item.suggested_pool === 'pick' ? 'ban' : 'pick')"
               >
                 {{ item.suggested_pool === 'pick' ? '转入 Ban 池' : '转入英雄池' }}

--- a/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
+++ b/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
@@ -1,0 +1,288 @@
+<script setup lang="ts">
+/**
+ * BP 智能推荐面板
+ *
+ * 基于近期战绩（常用英雄 / 常输给的英雄）与 OP.GG 版本强势英雄（按主打分路 + 熟练度分流）
+ * 三分区展示候选，逐张卡片可一键采纳进「英雄池」或「Ban 池」兜底配置。
+ * 后端 `get_bp_suggest` 可能让同一个英雄同时出现在 frequent 与 hot_t0 两张卡里——
+ * 采用任一张后，另一张靠共享的 `adopted` Set（key `pool:championId`）一起变灰，
+ * 不需要额外去重逻辑。
+ */
+import { ref, watch, computed } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import {
+  NModal,
+  NCard,
+  NButton,
+  NSpace,
+  NText,
+  NTag,
+  NEmpty,
+  NSpin,
+  NSelect,
+  NAvatar
+} from 'naive-ui'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import { assetPrefix } from '@renderer/services/http'
+import type { championOption } from '@renderer/types/domain/champion'
+import type { BpSuggestResult, BpSuggestItem, SuggestedPool } from '@renderer/types/bpSuggest'
+
+const props = defineProps<{ show: boolean; championOptions: championOption[] }>()
+const emit = defineEmits<{
+  (e: 'update:show', v: boolean): void
+  (e: 'adopted', pool: SuggestedPool): void
+}>()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const result = ref<BpSuggestResult | null>(null)
+/** 分路下拉当前值（'' = 全部/后端推断） */
+const selectedPosition = ref<string>('')
+/** 本次会话内已采用的 (pool:championId) 集合，驱动灰态 */
+const adopted = ref<Set<string>>(new Set())
+
+const POSITION_OPTIONS = [
+  { label: '全部分路', value: '' },
+  { label: '上单', value: 'TOP' },
+  { label: '打野', value: 'JUNGLE' },
+  { label: '中单', value: 'MIDDLE' },
+  { label: '下路', value: 'BOTTOM' },
+  { label: '辅助', value: 'UTILITY' }
+]
+
+/**
+ * 拉取一次推荐结果
+ * @param position - 大写分路名，不传/空串时由后端推断主打分路
+ */
+async function load(position?: string) {
+  loading.value = true
+  error.value = null
+  try {
+    result.value = await invoke<BpSuggestResult>('get_bp_suggest', {
+      position: position || null
+    })
+    if (!position) selectedPosition.value = result.value.main_position
+  } catch (e) {
+    error.value = (e as Error).message ?? String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.show,
+  isShown => {
+    if (isShown && result.value === null) void load()
+  },
+  { immediate: true }
+)
+
+const insufficient = computed(() => result.value !== null && result.value.sample_games < 10)
+
+/** 三分区（标题 + 候选 + 空文案） */
+const sections = computed(() => {
+  if (!result.value) return []
+  return [
+    {
+      key: 'frequent',
+      title: '常用英雄 → 英雄池',
+      items: result.value.frequent,
+      emptyText: '近期没有 3 场以上的英雄'
+    },
+    {
+      key: 'nemesis',
+      title: '常输给的英雄 → Ban 池',
+      items: result.value.nemesis,
+      emptyText: '败局里没有高频出现的敌方英雄'
+    },
+    {
+      key: 'hot_t0',
+      title: '版本 T0（按熟练度分流）',
+      items: result.value.hot_t0,
+      emptyText: result.value.opgg_ok ? '所选分路没有 T0 候选' : 'OP.GG 数据暂不可用'
+    }
+  ]
+})
+
+function championName(id: number): string {
+  return props.championOptions.find(o => o.value === id)?.label ?? `英雄 ${id}`
+}
+
+/** 依据文案：按 evidence 里有什么拼什么 */
+function evidenceText(item: BpSuggestItem): string {
+  const e = item.evidence
+  const parts: string[] = []
+  if (e.games !== undefined) parts.push(`${e.games} 场`)
+  if (e.win_rate !== undefined) parts.push(`胜率 ${(e.win_rate * 100).toFixed(0)}%`)
+  if (e.losses_against !== undefined && e.loss_games !== undefined)
+    parts.push(`${e.loss_games} 场败局中出现 ${e.losses_against} 次`)
+  if (e.opgg_tier !== undefined) parts.push(`T${e.opgg_tier}`)
+  if (e.position) {
+    const label = POSITION_OPTIONS.find(p => p.value === e.position)?.label
+    if (label) parts.push(label)
+  }
+  if (e.opgg_win_rate !== undefined) parts.push(`OP.GG 胜率 ${(e.opgg_win_rate * 100).toFixed(1)}%`)
+  return parts.join(' · ')
+}
+
+function adoptKey(pool: SuggestedPool, id: number): string {
+  return `${pool}:${id}`
+}
+
+function isAdopted(item: BpSuggestItem, pool: SuggestedPool): boolean {
+  return (
+    (pool === item.suggested_pool && item.already_in_pool) ||
+    adopted.value.has(adoptKey(pool, item.champion_id))
+  )
+}
+
+/** 采用：读现有池 → 去重 append → 写回 → 灰态 + 通知父组件 */
+async function adopt(item: BpSuggestItem, pool: SuggestedPool) {
+  const key = pool === 'pick' ? 'settings.auto.pickChampionSlice' : 'settings.auto.banChampionSlice'
+  const existing = (await getConfigByIpc<number[]>(key)) ?? []
+  if (!existing.includes(item.champion_id)) {
+    await putConfigByIpc(key, [...existing, item.champion_id])
+  }
+  adopted.value = new Set(adopted.value).add(adoptKey(pool, item.champion_id))
+  emit('adopted', pool)
+}
+
+async function onPositionChange(pos: string) {
+  selectedPosition.value = pos
+  await load(pos || undefined)
+}
+
+/** 头像加载失败时回退到占位英雄图（id -1） */
+function onAvatarError(e: Event) {
+  const img = e.target as HTMLImageElement
+  img.src = `${assetPrefix}/champion/-1`
+}
+
+function close() {
+  emit('update:show', false)
+}
+</script>
+
+<template>
+  <n-modal :show="show" @update:show="close">
+    <n-card
+      style="width: 760px; max-height: 80vh; overflow: auto"
+      title="智能推荐（基于近期战绩与 OP.GG）"
+    >
+      <template #header-extra>
+        <n-space>
+          <n-select
+            :options="POSITION_OPTIONS"
+            :value="selectedPosition"
+            style="width: 120px"
+            @update:value="onPositionChange"
+          />
+          <n-button size="small" :loading="loading" @click="load(selectedPosition || undefined)">
+            🔄 重新生成
+          </n-button>
+        </n-space>
+      </template>
+
+      <div v-if="loading" style="padding: 40px; text-align: center">
+        <n-spin />
+        <div style="margin-top: var(--space-12); color: var(--n-text-color-disabled)">
+          正在计算推荐（约数秒）
+        </div>
+      </div>
+
+      <div v-else-if="error">
+        <n-empty description="推荐生成失败">
+          <template #extra>
+            <n-button @click="load(selectedPosition || undefined)">重试</n-button>
+            <n-text
+              depth="3"
+              style="display: block; margin-top: var(--space-8); font-size: var(--font-size-sm)"
+            >
+              {{ error }}
+            </n-text>
+          </template>
+        </n-empty>
+      </div>
+
+      <div v-else-if="insufficient">
+        <n-empty :description="`近期对局太少（${result!.sample_games} 局），打几局再来`" />
+      </div>
+
+      <template v-else-if="result">
+        <template v-for="section in sections" :key="section.key">
+          <div class="section-title" :style="{ marginTop: 'var(--space-16)' }">
+            {{ section.title }}
+          </div>
+          <n-space v-if="section.items.length > 0">
+            <n-card
+              v-for="item in section.items"
+              :key="`${section.key}-${item.champion_id}`"
+              size="small"
+              style="width: 220px"
+              :style="isAdopted(item, item.suggested_pool) ? 'opacity: 0.5' : ''"
+            >
+              <n-space align="center">
+                <n-avatar
+                  :src="`${assetPrefix}/champion/${item.champion_id}`"
+                  size="small"
+                  @error="onAvatarError"
+                />
+                <n-tag
+                  :type="item.suggested_pool === 'pick' ? 'success' : 'error'"
+                  size="small"
+                  round
+                >
+                  {{ championName(item.champion_id) }}
+                </n-tag>
+              </n-space>
+              <div
+                style="
+                  margin-top: var(--space-8);
+                  font-size: var(--font-size-sm);
+                  color: var(--n-text-color-2);
+                "
+              >
+                {{ evidenceText(item) }}
+              </div>
+              <n-button
+                size="small"
+                type="primary"
+                style="margin-top: var(--space-8); width: 100%"
+                :disabled="isAdopted(item, item.suggested_pool)"
+                @click="adopt(item, item.suggested_pool)"
+              >
+                {{
+                  isAdopted(item, item.suggested_pool)
+                    ? '已加入'
+                    : item.suggested_pool === 'pick'
+                      ? '加入英雄池'
+                      : '加入 Ban 池'
+                }}
+              </n-button>
+              <n-button
+                v-if="section.key === 'hot_t0'"
+                quaternary
+                size="small"
+                style="margin-top: var(--space-4); width: 100%"
+                :disabled="isAdopted(item, item.suggested_pool === 'pick' ? 'ban' : 'pick')"
+                @click="adopt(item, item.suggested_pool === 'pick' ? 'ban' : 'pick')"
+              >
+                {{ item.suggested_pool === 'pick' ? '转入 Ban 池' : '转入英雄池' }}
+              </n-button>
+            </n-card>
+          </n-space>
+          <div v-else style="color: var(--n-text-color-disabled); font-size: var(--font-size-sm)">
+            {{ section.emptyText }}
+          </div>
+        </template>
+      </template>
+    </n-card>
+  </n-modal>
+</template>
+
+<style scoped>
+.section-title {
+  font-weight: 600;
+  margin-bottom: var(--space-8);
+}
+</style>

--- a/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
+++ b/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
@@ -48,6 +48,11 @@ const positionTouched = ref(false)
 const adopted = ref<Set<string>>(new Set())
 /** 正在提交中的 (pool:championId) 集合，防连点 + 驱动按钮 loading */
 const adoptingKeys = ref<Set<string>>(new Set())
+/**
+ * 采用写操作串行化队列：连点两张不同英雄卡对同一兜底池的
+ * 读-改-写会互相用旧读值覆盖对方的写入，故排成一条链依次执行。
+ */
+let adoptChain: Promise<void> = Promise.resolve()
 
 const POSITION_OPTIONS = [
   { label: '全部分路', value: '' },
@@ -156,16 +161,10 @@ function isAdopting(item: BpSuggestItem, pool: SuggestedPool): boolean {
 }
 
 /**
- * 采用：读现有池 → 去重 append → 写回 → 灰态 + 通知父组件
- *
- * 用 `adoptingKeys` 在 (pool, championId) 粒度防重入：同一张卡片的按钮在
- * 请求完成前再次点击会被直接忽略；IPC 失败时吞掉异常仅打日志，不置灰、不
- * emit，避免用户零反馈或双击竞态下两次都读到旧池子。
+ * 采用的实际读写体：读现有池 → 去重 append → 写回 → 灰态 + 通知父组件。
+ * IPC 失败时吞掉异常仅打日志，不置灰、不 emit。
  */
-async function adopt(item: BpSuggestItem, pool: SuggestedPool) {
-  const aKey = adoptKey(pool, item.champion_id)
-  if (adoptingKeys.value.has(aKey)) return
-  adoptingKeys.value.add(aKey)
+async function doAdopt(item: BpSuggestItem, pool: SuggestedPool, aKey: string) {
   try {
     const key =
       pool === 'pick' ? 'settings.auto.pickChampionSlice' : 'settings.auto.banChampionSlice'
@@ -180,6 +179,24 @@ async function adopt(item: BpSuggestItem, pool: SuggestedPool) {
   } finally {
     adoptingKeys.value.delete(aKey)
   }
+}
+
+/**
+ * 采用：把读写体挂到 `adoptChain` 尾部串行执行，避免跨卡竞态。
+ *
+ * 用 `adoptingKeys` 在 (pool, championId) 粒度防重入：同一张卡片的按钮在
+ * 请求完成前再次点击会被直接忽略。但不同 (pool, championId) 的两张卡若
+ * 几乎同时点击，各自的读-改-写会并发发生，后写入者用旧读值覆盖先写入者
+ * 的结果——串行化到一条 promise 链上，保证同一池子的读写按点击顺序依次
+ * 落地，两次采用都能生效。
+ */
+async function adopt(item: BpSuggestItem, pool: SuggestedPool) {
+  const aKey = adoptKey(pool, item.champion_id)
+  if (adoptingKeys.value.has(aKey)) return
+  adoptingKeys.value.add(aKey)
+  const myTurn = adoptChain.then(() => doAdopt(item, pool, aKey))
+  adoptChain = myTurn
+  await myTurn
 }
 
 async function onPositionChange(pos: string) {

--- a/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
+++ b/lol-record-analysis-tauri/src/components/automation/BpSuggestModal.vue
@@ -263,6 +263,13 @@ function close() {
         <template v-for="section in sections" :key="section.key">
           <div class="section-title" :style="{ marginTop: 'var(--space-16)' }">
             {{ section.title }}
+            <n-tag
+              v-if="section.key === 'hot_t0' && result!.opgg_stale"
+              size="small"
+              type="warning"
+            >
+              OP.GG 数据为过期缓存
+            </n-tag>
           </div>
           <n-space v-if="section.items.length > 0">
             <n-card

--- a/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
+++ b/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
@@ -216,4 +216,36 @@ describe('BpSuggestModal', () => {
     await new Promise(r => setTimeout(r, 0))
     expect(vi.mocked(invoke).mock.calls.at(-1)?.[1]).toEqual({ position: 'MIDDLE' })
   })
+
+  it('serializes concurrent adopts to the same pool so both writes land', async () => {
+    // frequent 卡（86，pick）与 hot_t0 卡（157，suggested_pool=ban，反向按钮转入英雄池）
+    // 都写 pickChampionSlice：不串行化会互相用旧读值覆盖对方的写入。
+    vi.mocked(invoke).mockResolvedValue(okResult())
+    let poolState: number[] = []
+    vi.mocked(getConfigByIpc).mockImplementation(async () => [...poolState] as never)
+    vi.mocked(putConfigByIpc).mockImplementation(async (_key, value) => {
+      await new Promise(r => setTimeout(r, 5))
+      poolState = value as number[]
+    })
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    const addBtn = w.findAll('button').find(b => b.text().includes('加入英雄池'))!
+    const convertBtn = w.findAll('button').find(b => b.text().includes('转入英雄池'))!
+
+    // 不等待第一次点击完成就触发第二次，制造跨卡竞态
+    const p1 = addBtn.trigger('click')
+    const p2 = convertBtn.trigger('click')
+    await Promise.all([p1, p2])
+    await new Promise(r => setTimeout(r, 30))
+
+    expect(poolState).toHaveLength(2)
+    expect(poolState).toEqual(expect.arrayContaining([86, 157]))
+    const lastCall = vi.mocked(putConfigByIpc).mock.calls.at(-1)
+    expect(lastCall?.[1]).toEqual(expect.arrayContaining([86, 157]))
+  })
 })

--- a/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
+++ b/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
@@ -34,7 +34,16 @@ const stubs = {
   Spin: { template: '<div>spinning</div>' },
   Empty: { template: '<div>{{ $attrs.description }}<slot /><slot name="extra" /></div>' },
   Text: { template: '<span><slot /></span>' },
-  Select: { template: '<select />' },
+  // 真实 <select>：value 受控回显 + change 时 emit update:value，
+  // 以便测试用 DOM 层面的 setValue 驱动 onPositionChange，不依赖组件内部暴露。
+  Select: {
+    props: ['value', 'options'],
+    emits: ['update:value'],
+    template:
+      '<select :value="value" @change="$emit(\'update:value\', $event.target.value)">' +
+      '<option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option>' +
+      '</select>'
+  },
   Avatar: { template: '<img />' }
 }
 
@@ -158,5 +167,53 @@ describe('BpSuggestModal', () => {
     expect(w.emitted('adopted')).toBeFalsy()
     // 失败后按钮不该停留在「已加入」灰态
     expect(btn.text()).not.toContain('已加入')
+  })
+
+  it('position select re-invokes with explicit value (including empty) and is not overwritten by main_position', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult())
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    // 首载自动模式：position 传 null，让后端推断
+    expect(vi.mocked(invoke).mock.calls[0][1]).toEqual({ position: null })
+    // 自动模式下，下拉回填成后端推断出的 main_position
+    expect((w.find('select').element as HTMLSelectElement).value).toBe('TOP')
+
+    // 用户显式切到「全部分路」（空串）
+    await w.find('select').setValue('')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    expect(vi.mocked(invoke).mock.calls.at(-1)?.[1]).toEqual({ position: '' })
+    // main_position 仍是 'TOP'，但用户已显式选择「全部分路」，下拉不该被响应覆写回去
+    expect((w.find('select').element as HTMLSelectElement).value).toBe('')
+  })
+
+  it('重新生成 keeps auto semantics until user touches the position select', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult())
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    const regenBtn = w.findAll('button').find(b => b.text().includes('重新生成'))!
+
+    // 用户没动过下拉：重新生成应维持自动语义（position: null）
+    await regenBtn.trigger('click')
+    await new Promise(r => setTimeout(r, 0))
+    expect(vi.mocked(invoke).mock.calls.at(-1)?.[1]).toEqual({ position: null })
+
+    // 用户显式选了分路后，重新生成应传该显式值
+    await w.find('select').setValue('MIDDLE')
+    await new Promise(r => setTimeout(r, 0))
+    await regenBtn.trigger('click')
+    await new Promise(r => setTimeout(r, 0))
+    expect(vi.mocked(invoke).mock.calls.at(-1)?.[1]).toEqual({ position: 'MIDDLE' })
   })
 })

--- a/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
+++ b/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
@@ -58,6 +58,7 @@ function okResult(overrides: Partial<BpSuggestResult> = {}): BpSuggestResult {
     main_position: 'TOP',
     sample_games: 25,
     opgg_ok: true,
+    opgg_stale: false,
     frequent: [
       {
         champion_id: 86,
@@ -247,5 +248,16 @@ describe('BpSuggestModal', () => {
     expect(poolState).toEqual(expect.arrayContaining([86, 157]))
     const lastCall = vi.mocked(putConfigByIpc).mock.calls.at(-1)
     expect(lastCall?.[1]).toEqual(expect.arrayContaining([86, 157]))
+  })
+
+  it('shows a warning tag next to hot_t0 title when opgg_stale is true', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult({ opgg_stale: true }))
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('OP.GG 数据为过期缓存')
   })
 })

--- a/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
+++ b/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
@@ -141,4 +141,22 @@ describe('BpSuggestModal', () => {
     await w.vm.$nextTick()
     expect(w.text()).toContain('OP.GG 数据暂不可用')
   })
+
+  it('adopt failure does not grey the card or emit adopted', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult())
+    vi.mocked(getConfigByIpc).mockResolvedValue([])
+    vi.mocked(putConfigByIpc).mockRejectedValue(new Error('ipc down'))
+    const w = mount(BpSuggestModal, { props: { show: true, championOptions }, global: { stubs } })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    const btn = w.findAll('button').find(b => b.text().includes('加入英雄池'))!
+    await btn.trigger('click')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    expect(w.emitted('adopted')).toBeFalsy()
+    // 失败后按钮不该停留在「已加入」灰态
+    expect(btn.text()).not.toContain('已加入')
+  })
 })

--- a/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
+++ b/lol-record-analysis-tauri/src/components/automation/__tests__/BpSuggestModal.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * BpSuggestModal 组件单元测试
+ *
+ * 验证：
+ * - 样本不足时显示空态
+ * - ok 状态下渲染三分区候选与依据文案
+ * - 「加入」按钮把英雄追加进对应兜底池（去重）并置灰
+ * - opgg_ok=false 时 T0 分区显示降级提示
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@renderer/services/ipc', () => ({
+  getConfigByIpc: vi.fn(),
+  putConfigByIpc: vi.fn()
+}))
+vi.mock('@renderer/services/http', () => ({ assetPrefix: '' }))
+
+import { invoke } from '@tauri-apps/api/core'
+import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
+import BpSuggestModal from '../BpSuggestModal.vue'
+import type { BpSuggestResult } from '@renderer/types/bpSuggest'
+
+const stubs = {
+  Modal: { template: '<div><slot /></div>' },
+  Card: { template: '<div><slot /><slot name="header-extra" /></div>' },
+  Button: {
+    template: '<button :disabled="$attrs.disabled" @click="$emit(\'click\')"><slot /></button>'
+  },
+  Tag: { template: '<span><slot /></span>' },
+  Space: { template: '<div><slot /></div>' },
+  Spin: { template: '<div>spinning</div>' },
+  Empty: { template: '<div>{{ $attrs.description }}<slot /><slot name="extra" /></div>' },
+  Text: { template: '<span><slot /></span>' },
+  Select: { template: '<select />' },
+  Avatar: { template: '<img />' }
+}
+
+const championOptions = [
+  { label: '盖伦', value: 86, realName: 'Garen', nickname: 'garen' },
+  { label: '亚索', value: 157, realName: 'Yasuo', nickname: 'yasuo' },
+  { label: '劫', value: 238, realName: 'Zed', nickname: 'zed' }
+]
+
+function okResult(overrides: Partial<BpSuggestResult> = {}): BpSuggestResult {
+  return {
+    main_position: 'TOP',
+    sample_games: 25,
+    opgg_ok: true,
+    frequent: [
+      {
+        champion_id: 86,
+        suggested_pool: 'pick',
+        already_in_pool: false,
+        evidence: { games: 12, win_rate: 0.58 }
+      }
+    ],
+    nemesis: [
+      {
+        champion_id: 238,
+        suggested_pool: 'ban',
+        already_in_pool: false,
+        evidence: { losses_against: 5, loss_games: 8 }
+      }
+    ],
+    hot_t0: [
+      {
+        champion_id: 157,
+        suggested_pool: 'ban',
+        already_in_pool: false,
+        evidence: { opgg_tier: 1, position: 'MIDDLE', opgg_win_rate: 0.523 }
+      }
+    ],
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getConfigByIpc).mockResolvedValue([])
+})
+
+describe('BpSuggestModal', () => {
+  it('shows insufficient state when sample_games < 10', async () => {
+    vi.mocked(invoke).mockResolvedValue(
+      okResult({ sample_games: 4, frequent: [], nemesis: [], hot_t0: [] })
+    )
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('近期对局太少')
+  })
+
+  it('renders three sections with evidence text', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult())
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('盖伦')
+    expect(w.text()).toContain('12 场')
+    expect(w.text()).toContain('劫')
+    expect(w.text()).toContain('亚索')
+  })
+
+  it('adopt appends champion to pick pool without duplicates and greys out', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult())
+    vi.mocked(getConfigByIpc).mockResolvedValue([157]) // 池里已有 157
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+
+    const btn = w.findAll('button').find(b => b.text().includes('加入英雄池'))!
+    await btn.trigger('click')
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(vi.mocked(putConfigByIpc)).toHaveBeenCalledWith(
+      'settings.auto.pickChampionSlice',
+      [157, 86]
+    )
+    expect(w.emitted('adopted')).toBeTruthy()
+  })
+
+  it('shows opgg degraded note when opgg_ok=false', async () => {
+    vi.mocked(invoke).mockResolvedValue(okResult({ opgg_ok: false, hot_t0: [] }))
+    const w = mount(BpSuggestModal, {
+      props: { show: true, championOptions },
+      global: { stubs }
+    })
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('OP.GG 数据暂不可用')
+  })
+})

--- a/lol-record-analysis-tauri/src/types/bpSuggest.ts
+++ b/lol-record-analysis-tauri/src/types/bpSuggest.ts
@@ -1,0 +1,36 @@
+/**
+ * BP 智能推荐相关类型，与 Rust schema (src-tauri/src/command/bp_suggest.rs)
+ * 严格同构（snake_case，与 bpDecision.ts 同约定）。
+ */
+
+/** 候选去向池 */
+export type SuggestedPool = 'pick' | 'ban'
+
+/** 单条候选的依据（后端 None 字段被省略） */
+export interface BpSuggestEvidence {
+  games?: number
+  win_rate?: number // 0~1
+  losses_against?: number
+  loss_games?: number
+  opgg_tier?: number
+  opgg_win_rate?: number // 0~1
+  position?: string // 大写 TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY
+}
+
+/** 单条推荐候选 */
+export interface BpSuggestItem {
+  champion_id: number
+  suggested_pool: SuggestedPool
+  already_in_pool: boolean
+  evidence: BpSuggestEvidence
+}
+
+/** 推荐结果（三分区） */
+export interface BpSuggestResult {
+  main_position: string
+  sample_games: number
+  opgg_ok: boolean
+  frequent: BpSuggestItem[]
+  nemesis: BpSuggestItem[]
+  hot_t0: BpSuggestItem[]
+}

--- a/lol-record-analysis-tauri/src/types/bpSuggest.ts
+++ b/lol-record-analysis-tauri/src/types/bpSuggest.ts
@@ -30,6 +30,8 @@ export interface BpSuggestResult {
   main_position: string
   sample_games: number
   opgg_ok: boolean
+  /** OP.GG 快照是否为过期缓存（刷新失败降级使用旧数据）；快照缺失时恒为 false */
+  opgg_stale: boolean
   frequent: BpSuggestItem[]
   nemesis: BpSuggestItem[]
   hot_t0: BpSuggestItem[]

--- a/lol-record-analysis-tauri/src/views/settings/Automation.vue
+++ b/lol-record-analysis-tauri/src/views/settings/Automation.vue
@@ -23,6 +23,27 @@
           </span>
           <n-switch v-model:value="autoStart" @update:value="updateStartSwitch" />
         </div>
+
+        <div class="setting-item">
+          <span class="setting-label">
+            <n-icon size="20" class="setting-item-icon setting-item-icon-start">
+              <BulbOutline />
+            </n-icon>
+            智能推荐（英雄池 / Ban 池）
+          </span>
+          <n-space align="center">
+            <n-select
+              v-model:value="opggTier"
+              :options="TIER_OPTIONS"
+              size="small"
+              style="width: 130px"
+              @update:value="updateOpggTier"
+            />
+            <n-button size="small" type="primary" ghost @click="suggestModalShow = true">
+              智能推荐
+            </n-button>
+          </n-space>
+        </div>
       </n-space>
     </n-card>
 
@@ -214,19 +235,32 @@
         @save="onBanSave"
       />
     </n-card>
+
+    <BpSuggestModal
+      v-model:show="suggestModalShow"
+      :champion-options="options"
+      @adopted="onSuggestAdopted"
+    />
   </n-space>
 </template>
 <script setup lang="ts">
 import { VueDraggable } from 'vue-draggable-plus'
 import { onMounted, ref } from 'vue'
 import { renderSingleSelectTag, renderLabel, filterChampionFunc } from '@renderer/utils/champion'
-import { CheckmarkCircleOutline, FlashOutline, Close, PlayCircleOutline } from '@vicons/ionicons5'
+import {
+  CheckmarkCircleOutline,
+  FlashOutline,
+  Close,
+  PlayCircleOutline,
+  BulbOutline
+} from '@vicons/ionicons5'
 import { getConfigByIpc, putConfigByIpc } from '@renderer/services/ipc'
 import { assetPrefix } from '@renderer/services/http'
 import type { championOption } from '@renderer/types/domain/champion'
 import { invoke } from '@tauri-apps/api/core'
 import { usePickRules, useBanRules } from '@renderer/composables/useRules'
 import RuleEditModal from '@renderer/components/automation/RuleEditModal.vue'
+import BpSuggestModal from '@renderer/components/automation/BpSuggestModal.vue'
 import type { PickRule, BanRule, PickAction } from '@renderer/types/rules'
 
 const { rules: pickRules, reload: reloadPickRules, save: savePickRules } = usePickRules()
@@ -237,6 +271,33 @@ const pickEditing = ref<PickRule | undefined>(undefined)
 const banModalShow = ref(false)
 const banEditing = ref<BanRule | undefined>(undefined)
 
+const suggestModalShow = ref(false)
+/** OP.GG 段位分段（与 Rust opgg::api::VALID_TIERS 同白名单） */
+const opggTier = ref('emerald_plus')
+const TIER_OPTIONS = [
+  { label: '黄金以上', value: 'gold_plus' },
+  { label: '铂金以上', value: 'platinum_plus' },
+  { label: '翡翠以上', value: 'emerald_plus' },
+  { label: '钻石以上', value: 'diamond_plus' },
+  { label: '大师以上', value: 'master_plus' },
+  { label: '全部段位', value: 'all' }
+]
+
+/** 段位变更：写配置并强制刷新 ranked 快照（失败静默，降级链自会兜底） */
+const updateOpggTier = async () => {
+  await putConfigByIpc('settings.opgg.tier', opggTier.value)
+  invoke('update_opgg_data', { mode: 'ranked' }).catch(() => {})
+}
+
+/** 采纳后重读对应池，保持页面上的兜底池列表同步 */
+const onSuggestAdopted = async (pool: 'pick' | 'ban') => {
+  if (pool === 'pick') {
+    myPickData.value = (await getConfigByIpc<number[]>('settings.auto.pickChampionSlice')) ?? []
+  } else {
+    myBanData.value = (await getConfigByIpc<number[]>('settings.auto.banChampionSlice')) ?? []
+  }
+}
+
 onMounted(async () => {
   const opts = await invoke<championOption[]>('get_champion_options')
   options.value = opts.filter(opt => opt.value > 0)
@@ -246,6 +307,7 @@ onMounted(async () => {
   myPickData.value = (await getConfigByIpc<number[]>('settings.auto.pickChampionSlice')) ?? []
   myBanData.value = (await getConfigByIpc<number[]>('settings.auto.banChampionSlice')) ?? []
   autoStart.value = (await getConfigByIpc<boolean>('settings.auto.startMatchSwitch')) ?? false
+  opggTier.value = (await getConfigByIpc<string>('settings.opgg.tier')) ?? 'emerald_plus'
   await reloadPickRules()
   await reloadBanRules()
 })


### PR DESCRIPTION
## Summary
- **智能推荐面板**：自动化页新增「智能推荐」入口，`BpSuggestModal` 三分区逐卡采纳（对齐 AI 标签推荐的交互模式，纯统计不走 AI）：
  - 常用英雄 → pick 兜底池（近 30 场 ≥3 场，带场次/胜率依据）
  - 常输给的英雄 → ban 兜底池（败局敌方高频，自动排除自己常玩的）
  - 版本 T0 按熟练度分流（会玩→pick / 不玩→ban，卡片可反向改去向）
- **分路过滤**：主玩分路用常用英雄的 OPGG 主分路加权众数推断（国服 lane 不可信，Rust 战绩结构也无 lane 字段）；下拉可切「全部分路」（显式空串 = 不过滤）
- **OPGG 段位可选**：`settings.opgg.tier` 贯通（gold_plus~master_plus/all，默认 emerald_plus），快照记录 tier、缓存按 tier 校验（降级兜底宁 stale 勿空），BP 决策 evidence/克制提示/AI 情报全局同源受益；段位切换失败有 stale 提示
- 后端新命令 `get_bp_suggest`：聚合全部纯函数可测；采纳写现有 `pickChampionSlice`/`banChampionSlice`，不动规则列表
- 设计文档：`docs/superpowers/specs/2026-08-02-bp-smart-suggest-design.md`

## 审查记录
5 任务各经 spec+质量双审，整分支终审 Ready to merge。过程中修复 5 个 Important：同英雄 pick/ban 矛盾推荐、采纳静默失败/连点竞态、跨卡丢更新竞态、「全部分路」名不副实、stale 无提示。

## Test plan
- [x] `npm run check` passes（exit 0，无新增 warning）
- [x] `npm run test` passes（714/714）
- [x] `cargo test` passes（316 passed / 0 failed）
- [ ] Manual: dev 模式打开自动化页 → 智能推荐面板三分区数据合理 → 采纳同步兜底池 → 段位切换重拉（LCU 在线验收中）