### PR TITLE
fix(gaming): 玩家卡标签挤压致胜率 chip 换行、卡片多出空白

### DIFF
--- a/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
+++ b/lol-record-analysis-tauri/src/components/gaming/PlayerCard.vue
@@ -95,7 +95,7 @@
                 />
               </n-flex>
 
-              <n-flex align="center" class="meta-row">
+              <n-flex align="center" :size="[6, 2]" class="meta-row">
                 <span class="tag-line">#{{ sessionSummoner?.summoner.tagLine }}</span>
                 <n-flex align="center" class="tier-row">
                   <span v-if="imgUrl.includes('unranked')" class="tier-icon-placeholder">
@@ -223,7 +223,13 @@ import PlayerNoteBadge from '@renderer/components/common/PlayerNoteBadge.vue'
 import PatchNoteBadge from './PatchNoteBadge.vue'
 import UnifiedTagRow from '@renderer/components/common/UnifiedTagRow.vue'
 import { getChampionMeta, type ChampionMeta, type OpggMode } from '@renderer/services/opgg'
-import { tierBadge, formatWinRate, playerCardPickStateClass, isChampionSwap } from './championIntel'
+import {
+  tierBadge,
+  formatWinRate,
+  playerCardPickStateClass,
+  isChampionSwap,
+  tagVisibleCap
+} from './championIntel'
 
 interface Props {
   sessionSummoner: SessionSummoner
@@ -309,13 +315,13 @@ const isHiddenRecord = computed(
     (!props.sessionSummoner.summoner?.gameName || !props.sessionSummoner.summoner?.puuid)
 )
 
-/** 标签区可见系统标签上限：预组队/遇见过各占一个槽位后动态收缩，保证单行(spec 验收：全部单行) */
-const tagMaxVisible = computed(() => {
-  let cap = 2
-  if (props.sessionSummoner.preGroupMarkers?.name) cap--
-  if (props.sessionSummoner.meetGames?.length > 0) cap--
-  return Math.max(cap, 0)
-})
+/** 标签区可见系统标签上限：预组队/遇见过各按 2 名额折算（宽幅 chip 会把 OP.GG 胜率 chip 挤换行），规则见 tagVisibleCap */
+const tagMaxVisible = computed(() =>
+  tagVisibleCap(
+    !!props.sessionSummoner.preGroupMarkers?.name,
+    props.sessionSummoner.meetGames?.length > 0
+  )
+)
 
 const { isAramMode, balanceTags, overallBalanceStatus } = useAramBalance(
   toRef(() => props.sessionSummoner.championId),
@@ -431,8 +437,9 @@ watch(
   font-weight: 700;
 }
 
+/* 间距走模板里 n-flex 的 :size="[6, 2]"（n-flex 输出内联 gap，scoped 的 gap 声明会被覆盖、
+ * 属于死代码）：横向 6px 同旧视觉；纵向 2px 收紧极窄窗口下胜率 chip 换行后的行距 */
 .meta-row {
-  gap: var(--space-6);
   flex-wrap: wrap;
 }
 

--- a/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/__tests__/championIntel.spec.ts
@@ -4,7 +4,8 @@ import {
   playerCardPickStateClass,
   tierBadge,
   formatWinRate,
-  isChampionSwap
+  isChampionSwap,
+  tagVisibleCap
 } from '../championIntel'
 
 describe('championIntel helpers', () => {
@@ -39,6 +40,14 @@ describe('championIntel helpers', () => {
     expect(formatWinRate(0.5183)).toBe('51.8%')
     expect(formatWinRate(0)).toBe('--')
     expect(formatWinRate(undefined)).toBe('--')
+  })
+  it('tagVisibleCap 无宽幅特殊 chip 时保留 2 个系统标签位', () => {
+    expect(tagVisibleCap(false, false)).toBe(2)
+  })
+  it('tagVisibleCap 预组队/遇见过任一出现即收纳全部系统标签（各占 2 名额，防胜率 chip 被挤换行）', () => {
+    expect(tagVisibleCap(true, false)).toBe(0)
+    expect(tagVisibleCap(false, true)).toBe(0)
+    expect(tagVisibleCap(true, true)).toBe(0)
   })
   it('isChampionSwap 仅在新旧 championId 均为正数且不相等时判定为真换人', () => {
     expect(isChampionSwap(1, 2)).toBe(true)

--- a/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
+++ b/lol-record-analysis-tauri/src/components/gaming/championIntel.ts
@@ -127,6 +127,30 @@ export function isChampionSwap(oldId: number | undefined, newId: number | undefi
 }
 
 /**
+ * PlayerCard 标签区可见系统标签上限
+ *
+ * 标签区（.profile-tags）是 flex-shrink:0 的硬占位，越宽越挤压中间信息列，
+ * 信息列一窄 OP.GG 胜率 chip 就会从段位行被挤换行，卡片凭空高出一行。
+ * 预组队/遇见过属于宽幅特殊 chip，各按 2 个系统标签名额折算：任一出现时
+ * 系统标签（连败/连胜等）全部收进 +N popover，保住"信息列两行"结构。
+ *
+ * @param hasPreGroup - 是否有预组队标记 chip
+ * @param hasMeet - 是否有「遇见过 ×N」chip
+ * @returns 直接可见的系统标签数上限（0 表示全部收进 +N）
+ * @example
+ * ```ts
+ * tagVisibleCap(false, false) // 2
+ * tagVisibleCap(false, true) // 0（遇见过在场，连败等收进 +N）
+ * ```
+ */
+export function tagVisibleCap(hasPreGroup: boolean, hasMeet: boolean): number {
+  let cap = 2
+  if (hasPreGroup) cap -= 2
+  if (hasMeet) cap -= 2
+  return Math.max(cap, 0)
+}
+
+/**
  * 胜率显示：将 0~1 的小数格式化为百分比字符串
  * @param rate - 胜率（0~1），缺省或 <=0 视为无数据
  * @returns 形如 '51.8%' 的字符串；无数据时返回 '--'


### PR DESCRIPTION
## Summary
- 对局页 PlayerCard 右侧标签区（`flex-shrink: 0` 硬占位）出现 3 枚 chip（遇见过×1 + 连败 + +N）时，会把中间信息列挤到放不下 OP.GG 胜率 chip，chip 掉到第三行，卡片凭空高出一截
- 新增纯函数 `tagVisibleCap`：预组队/遇见过等宽幅特殊 chip 从各占 1 个系统标签名额改为各占 2 个——任一在场即把连败等系统标签全部收进 +N popover（点击可看），标签区 3 枚→2 枚，胜率 chip 回到段位行，卡片恢复两行结构与其他卡等高
- 兜底：meta-row 行距显式走 `n-flex :size="[6, 2]"`，并删掉被 n-flex 内联样式覆盖、从未生效的 scoped `gap` 死代码；极窄窗口下仍换行时掉落行紧贴上一行

## Test plan
- [x] `npm run check` passes（119 条 any warning 为存量基线，0 errors）
- [x] `npm run test` passes（705 用例，含新增 `tagVisibleCap` 2 例，TDD 先红后绿）
- [ ] Manual: 下一局排位对局页肉眼复核「遇见过+连败」玩家卡为两行结构
