### PR TITLE
fix(ui): 修复 macOS 主窗口标题栏与对局详情窗口标题栏无法拖动

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/util/token.rs
@@ -731,12 +731,6 @@ mod platform {
                 //
                 // 调试用：打印原始缓冲区（转义成可读形式，避免二进制/控制字符刷屏），
                 // 便于核对 macOS 真实命令行布局是否与解析假设一致。
-                log::info!(
-                    "macOS 原始命令行缓冲区 (pid {}, {} 字节): {:?}",
-                    pid,
-                    bytes.len(),
-                    escape_debug(bytes)
-                );
                 let raw = String::from_utf8_lossy(bytes);
                 let cmd_line = parse_procargs2(raw.as_ref());
                 log::info!("成功获取命令行: {}", cmd_line);
@@ -763,24 +757,6 @@ mod platform {
                 }
             }
             params.join(" ")
-        }
-
-        /// 把原始字节转义成可读字符串（`\0` / `\xNN`），供调试日志打印二进制缓冲区。
-        fn escape_debug(bytes: &[u8]) -> String {
-            use std::fmt::Write;
-            let mut out = String::with_capacity(bytes.len());
-            for &b in bytes {
-                match b {
-                    0 => out.push_str("\\0"),
-                    0x0a => out.push_str("\\n"),
-                    0x0d => out.push_str("\\r"),
-                    0x20..=0x7e => out.push(b as char),
-                    _ => {
-                        let _ = write!(out, "\\x{:02x}", b);
-                    }
-                }
-            }
-            out
         }
 
         /// 按进程名强制结束所有匹配进程（macOS 用 `kill`）。

--- a/lol-record-analysis-tauri/src/components/Header.vue
+++ b/lol-record-analysis-tauri/src/components/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <n-flex justify="space-between" class="header-inner">
-    <div class="header-left">
+    <div class="header-left" data-tauri-drag-region>
       <div class="logo-badge">R</div>
       <span class="header-title">Rank Analysis</span>
     </div>
@@ -35,7 +35,7 @@
         </template>
       </n-input>
     </div>
-    <div class="header-right">
+    <div class="header-right" data-tauri-drag-region>
       <n-popconfirm positive-text="关闭游戏" negative-text="取消" @positive-click="closeLeague">
         <template #trigger>
           <n-tooltip trigger="hover">

--- a/lol-record-analysis-tauri/src/views/MatchDetail.vue
+++ b/lol-record-analysis-tauri/src/views/MatchDetail.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="match-detail-window-page">
-    <div class="match-detail-window-bar">
+    <div class="match-detail-window-bar" data-tauri-drag-region>
       <div class="match-detail-window-title">对局详情</div>
       <button class="match-detail-window-close" type="button" @click="closeWindow">关闭</button>
     </div>


### PR DESCRIPTION
给 Header.vue 的 header-left/header-right 及 MatchDetail.vue 的 match-detail-window-bar 添加 data-tauri-drag-region，修复 macOS 下无原生标题栏窗口无法拖动的问题。
以及删除一个无用的log info