### PR TITLE
fix(test): bp_decision store 测试并行互踩全局单例，CI 偶现失败

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/bp_decision/store.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/bp_decision/store.rs
@@ -83,9 +83,16 @@ pub fn reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// STORE 是进程级单例，而 cargo test 默认多线程并行：
+    /// 两个测试各自 reset() 会互相擦掉对方刚写入的状态（CI 上偶现失败）。
+    /// 用测试内互斥锁把触碰全局状态的测试串行化。
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn last_hovered_round_trips_and_resets() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         reset();
         assert_eq!(last_hovered(), None);
         set_last_hovered(Some(64));
@@ -96,6 +103,7 @@ mod tests {
 
     #[test]
     fn override_is_scoped_to_action_id() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         reset();
         assert!(!is_overridden(10));
         mark_overridden(10);


### PR DESCRIPTION
## Summary
- main 上 #139 合并后 Quality Checks 偶现红：`bp_decision::store::tests::override_is_scoped_to_action_id` 在 `assert!(is_overridden(10))` 处 panic（同一提交在 PR 分支上是绿的）
- 根因：`STORE` 是进程级单例，`cargo test` 默认多线程并行，同文件两个测试各自 `reset()` 会在竞态窗口内擦掉对方刚 `mark_overridden` 的状态
- 修复：测试模块内加 `static TEST_LOCK: Mutex<()>`，两个触碰全局状态的测试先取锁串行化

## Test plan
- [x] `npm run check` passes
- [x] `cargo test --lib` 连跑 5 次全绿（323 passed）
- [x] 仅测试代码改动，无运行时行为变化