### PR TITLE
fix(config): 配置与缓存改用绝对路径，修 macOS 上配置存不下来

### DIFF
--- a/lol-record-analysis-tauri/src-tauri/src/cn_patch_notes.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/cn_patch_notes.rs
@@ -102,9 +102,9 @@ pub fn parse_data(json: &str) -> Option<CnPatchData> {
     Some(data)
 }
 
-/// 磁盘缓存路径（工作目录相对，与 opgg/wiki 缓存同约定）
+/// 磁盘缓存路径（系统临时目录，与 opgg/wiki 缓存同约定）
 pub fn default_path() -> PathBuf {
-    PathBuf::from("cn_patch_notes_cache.json")
+    crate::paths::cache_file("cn_patch_notes_cache.json")
 }
 
 fn load_from_path(path: &Path) -> Option<CnPatchSnapshot> {

--- a/lol-record-analysis-tauri/src-tauri/src/config.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/config.rs
@@ -87,8 +87,13 @@ type ConfigCallback = Box<dyn Fn(&str, &Value) + Send + Sync>;
 /// 回调函数列表类型，使用 Mutex 保证线程安全。
 type CallbackList = Mutex<Vec<ConfigCallback>>;
 
-/// 配置文件路径常量。
-static CONFIG_PATH: &str = "config.yaml";
+/// 配置文件的绝对路径（由 [`crate::paths`] 按平台解析）。
+///
+/// 这里刻意**不是**常量字符串：曾经是 `"config.yaml"` 这种 CWD 相对路径，落点随启动
+/// 方式漂移——macOS 上由 Finder 拉起时 CWD 为只读的 `/`，配置读不到也写不进。
+fn config_path() -> std::path::PathBuf {
+    crate::paths::config_file()
+}
 
 /// 全局配置变更回调列表。
 ///
@@ -126,12 +131,13 @@ pub async fn get_cache() -> &'static Cache<String, Value> {
             log::info!("Initializing config cache...");
             let cache = Cache::builder().build();
 
-            match read_config(CONFIG_PATH) {
+            let path = config_path();
+            match read_config(&path) {
                 Ok(config) => {
                     log::info!(
                         "Loaded {} config entries from {}",
                         config.len(),
-                        CONFIG_PATH
+                        path.display()
                     );
                     for (k, v) in config {
                         // 在 async 块中可以自由 .await
@@ -139,8 +145,13 @@ pub async fn get_cache() -> &'static Cache<String, Value> {
                         log::debug!("Config loaded: {} = {:?}", k, v);
                     }
                 }
+                // 文件不存在是首次运行的正常情况（全新安装 / 换了新机器），不该报 error：
+                // error 级日志会被转发成 Sentry 事件，每个新用户都刷一条纯噪音。
+                Err(e) if is_not_found(e.as_ref()) => {
+                    log::info!("配置文件尚不存在，按默认值启动: {}", path.display());
+                }
                 Err(e) => {
-                    log::error!("Failed to load config from {}: {}", CONFIG_PATH, e);
+                    log::error!("Failed to load config from {}: {}", path.display(), e);
                 }
             }
             log::info!("Config cache initialized");
@@ -187,7 +198,7 @@ where
 ///
 /// 此方法通常在应用程序启动时调用一次。后续配置访问应使用 `get_cache()` 或 `get_config()`。
 pub async fn init_config() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    match read_config(CONFIG_PATH) {
+    match read_config(&config_path()) {
         Ok(config) => {
             for (key, value) in config {
                 get_cache().await.insert(key, value).await;
@@ -211,12 +222,21 @@ pub async fn init_config() -> Result<(), Box<dyn std::error::Error + Send + Sync
 /// - `Ok(HashMap)`: 成功解析的配置映射
 /// - `Err(...)`: 文件读取或解析错误
 fn read_config(
-    path: &str,
+    path: &std::path::Path,
 ) -> Result<HashMap<String, Value>, Box<dyn std::error::Error + Send + Sync>> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let config: HashMap<String, Value> = serde_yaml::from_reader(reader)?;
     Ok(config)
+}
+
+/// 判断读配置的错误是否为「文件不存在」。
+///
+/// 首次运行没有配置文件是正常的，需要与「文件损坏 / 无权限」区分开，避免把正常情况
+/// 记成 error（进而变成 Sentry 噪音）。
+fn is_not_found(err: &(dyn std::error::Error + Send + Sync + 'static)) -> bool {
+    err.downcast_ref::<std::io::Error>()
+        .is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound)
 }
 
 /// 将配置写入文件。
@@ -233,9 +253,24 @@ async fn write_config() -> Result<(), Box<dyn std::error::Error + Send + Sync>> 
         .iter()
         .map(|(k, v)| (k.as_ref().clone(), v.clone()))
         .collect();
-    let file = File::create(CONFIG_PATH)?;
+    write_config_to(&config_path(), &config)
+}
+
+/// 把一份配置写到指定路径，父目录不存在则先创建。
+///
+/// 与 [`write_config`] 拆开是为了可测：写入才是 macOS 上真正失败的那条路径
+/// （目录不存在 + CWD 只读），必须有回归测试盯着，而 [`write_config`] 依赖全局缓存
+/// 单例、不适合在并行测试里碰。
+fn write_config_to(
+    path: &std::path::Path,
+    config: &HashMap<String, Value>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // macOS 首次写入时 `~/Library/Application Support/<bundle id>` 还不存在，
+    // 不先建目录 File::create 会直接失败。
+    crate::paths::ensure_parent_dir(path)?;
+    let file = File::create(path)?;
     let writer = BufWriter::new(file);
-    serde_yaml::to_writer(writer, &config)?;
+    serde_yaml::to_writer(writer, config)?;
     Ok(())
 }
 
@@ -353,7 +388,7 @@ pub fn extract_string(value: &Value) -> Option<String> {
 ///
 /// 配置中该键解析出的布尔值；文件不存在、键缺失或类型不符时返回 `false`。
 pub fn read_bool_sync(key: &str) -> bool {
-    read_config(CONFIG_PATH)
+    read_config(&config_path())
         .ok()
         .and_then(|m| m.get(key).and_then(extract_bool))
         .unwrap_or(false)
@@ -754,5 +789,27 @@ mod tests {
         // 备份文件允许恢复 API key(黑名单只挡设备级键)
         assert!(keys.contains(&"dashscopeApiKey"));
         assert!(!keys.contains(&"cloudSyncSession"));
+    }
+
+    /// 回归测试：macOS 上「配置存不下来」的直接成因就是写入时父目录不存在
+    /// （`~/Library/Application Support/<bundle id>/` 首次运行时尚未创建），
+    /// 叠加 CWD 为只读的 `/`。这里锁住「目录不存在也能写成功并读回」。
+    #[test]
+    fn write_config_to_should_create_missing_parent_dirs_and_round_trip() {
+        let root = std::env::temp_dir().join(format!("ra-cfg-test-{}", std::process::id()));
+        let path = root.join("nested").join("config.yaml");
+        let _ = std::fs::remove_dir_all(&root);
+        let mut config = HashMap::new();
+        config.insert("theme".to_string(), Value::String("dark".to_string()));
+
+        write_config_to(&path, &config).expect("父目录不存在时也应写入成功");
+
+        assert!(path.is_file(), "配置文件应已落盘: {:?}", path);
+        let read_back = read_config(&path).expect("应能读回刚写入的配置");
+        assert_eq!(
+            read_back.get("theme"),
+            Some(&Value::String("dark".to_string()))
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/fandom/patch_notes.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/fandom/patch_notes.rs
@@ -231,9 +231,9 @@ pub fn parse_patch_champions(wikitext: &str) -> HashMap<String, ChampionPatchNot
     result
 }
 
-/// 磁盘缓存路径（工作目录相对，与 opgg 缓存同约定；单文件存最近一个 patch）。
+/// 磁盘缓存路径（系统临时目录，与 opgg 缓存同约定；单文件存最近一个 patch）。
 pub fn default_path() -> PathBuf {
-    PathBuf::from("patch_notes_cache.json")
+    crate::paths::cache_file("patch_notes_cache.json")
 }
 
 /// 快照是否命中给定 patch 且未过期。

--- a/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lcu/api/asset.rs
@@ -472,8 +472,10 @@ async fn init_lcu_assets() {
 }
 
 /// cdragon 描述表磁盘缓存路径（temp 目录：可写、跨重启保留、无需额外依赖）。
+///
+/// 走 [`crate::paths::cache_file`] 与其余缓存统一；解析结果与改造前逐字节一致。
 fn cdragon_cache_path() -> std::path::PathBuf {
-    std::env::temp_dir().join("lol-record-analysis-cdragon-augments.json")
+    crate::paths::cache_file("cdragon-augments.json")
 }
 
 /// 描述表磁盘缓存有效期：7 天。过期则后台重拉刷新（augment 偶尔随版本新增）。

--- a/lol-record-analysis-tauri/src-tauri/src/lib.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/lib.rs
@@ -9,5 +9,6 @@ pub mod game_state_monitor;
 pub mod lcu;
 pub mod observability;
 pub mod opgg;
+pub mod paths;
 pub mod rule_engine;
 pub mod state;

--- a/lol-record-analysis-tauri/src-tauri/src/main.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/main.rs
@@ -55,8 +55,13 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     info!("========================================");
     info!("Starting Tauri application with Asset Protocol");
+    // CWD 仅作参考：数据落点已不依赖它（见 `paths` 模块），但排障时知道进程被谁以什么
+    // 姿势拉起仍然有用。
     info!("Current working directory: {:?}", std::env::current_dir());
-    info!("Config file path: config.yaml");
+    info!(
+        "Config file path: {}",
+        lol_record_analysis_app_lib::paths::config_file().display()
+    );
     info!("========================================");
 
     // 初始化错误上报（创建 Sentry client + guard）。

--- a/lol-record-analysis-tauri/src-tauri/src/observability.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/observability.rs
@@ -39,8 +39,16 @@ use std::sync::{Arc, LazyLock};
 /// 配置中控制是否开启错误上报的键名（以 `Enabled` 结尾 → 默认 `false`）。
 pub const REPORTING_KEY: &str = "errorReportingEnabled";
 
-/// 持久化匿名设备 ID 的文件名（与 `config.yaml` 同目录，相对 CWD）。
+/// 持久化匿名设备 ID 的文件名（与 `config.yaml` 同目录，路径由 [`crate::paths`] 解析）。
 pub const DEVICE_ID_FILE: &str = "device_id";
+
+/// 匿名设备 ID 文件的绝对路径。
+///
+/// 曾经这里是相对 CWD 的裸文件名，macOS 上 CWD 为只读的 `/` → 每次启动都写盘失败、
+/// 重新生成 UUID，导致上报侧把同一台机器算成无数台新设备（DAU / 设备数虚高）。
+fn device_id_path() -> std::path::PathBuf {
+    crate::paths::data_file(DEVICE_ID_FILE)
+}
 
 /// 解析最终使用的 Sentry DSN：运行时环境变量（开发/测试）→ `option_env!` 编译期注入（线上 CI）。
 ///
@@ -89,7 +97,7 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
         return None;
     };
 
-    let device_id = device_id(Path::new(DEVICE_ID_FILE));
+    let device_id = device_id(&device_id_path());
     let guard = sentry::init((
         dsn,
         sentry::ClientOptions {
@@ -137,7 +145,7 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
 ///
 /// 文件不存在时会生成并落盘——即使上报未开启也返回稳定 ID，便于将来开启后对上。
 pub fn current_device_id() -> String {
-    device_id(Path::new(DEVICE_ID_FILE))
+    device_id(&device_id_path())
 }
 
 /// 把当前登录大区（如 `HN1` / `TJ100`）设为全局 tag，供 Sentry 侧按大区切片。
@@ -161,7 +169,7 @@ pub fn track_feature(feature: &'static str) {
 /// 读取或首次生成匿名设备 ID。
 ///
 /// 失败时返回随机 UUID 但**不写盘**——意味着这次会话被当作新设备，
-/// 不会让无法持久化的环境（例如只读 CWD）让上报整体崩。
+/// 不会让无法持久化的环境让上报整体崩。
 fn device_id(path: &Path) -> String {
     if let Ok(existing) = std::fs::read_to_string(path) {
         let trimmed = existing.trim();
@@ -170,6 +178,11 @@ fn device_id(path: &Path) -> String {
         }
     }
     let new_id = uuid::Uuid::new_v4().to_string();
+    // 首次运行时配置目录可能还不存在（macOS 的 Application Support 子目录），
+    // 不先建目录 write 必失败 —— 那正是设备 ID 反复重生成的直接原因。
+    if let Err(e) = crate::paths::ensure_parent_dir(path) {
+        log::warn!("failed to create device_id directory: {}", e);
+    }
     if let Err(e) = std::fs::write(path, &new_id) {
         log::warn!(
             "failed to persist device_id to {}: {} (will regenerate next launch)",

--- a/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/opgg/cache.rs
@@ -1,7 +1,7 @@
 //! OP.GG 快照磁盘缓存。
 //!
-//! 按模式一个 JSON 文件（`opgg_cache_ranked.json` / `opgg_cache_aram.json`），
-//! 工作目录相对路径——与 `config.yaml` 相同的存储约定。
+//! 按模式一个 JSON 文件，落在系统临时目录（见 [`crate::paths`]）。
+//! 纯缓存，丢了自动重建，不必占用配置目录，也不必操心写权限。
 //! 一个 patch 内数据基本不变，TTL 取 12 小时。
 
 use crate::opgg::data::OpggSnapshot;
@@ -15,9 +15,9 @@ pub fn is_fresh(snapshot: &OpggSnapshot, now: i64) -> bool {
     now - snapshot.fetched_at < TTL_SECS
 }
 
-/// 某模式的默认缓存文件路径（工作目录相对）。
+/// 某模式的默认缓存文件路径（系统临时目录下的绝对路径）。
 pub fn default_path(mode: &str) -> PathBuf {
-    PathBuf::from(format!("opgg_cache_{}.json", mode))
+    crate::paths::cache_file(&format!("opgg_cache_{}.json", mode))
 }
 
 /// 序列化快照写入指定路径。
@@ -97,14 +97,16 @@ mod tests {
     }
 
     #[test]
-    fn default_path_should_be_mode_scoped_relative_file() {
-        assert_eq!(
-            default_path("ranked").to_str().unwrap(),
-            "opgg_cache_ranked.json"
-        );
-        assert_eq!(
-            default_path("aram").to_str().unwrap(),
-            "opgg_cache_aram.json"
-        );
+    fn default_path_should_be_mode_scoped_and_absolute() {
+        let ranked = default_path("ranked");
+        let aram = default_path("aram");
+
+        // 绝对路径：缓存落点不能随启动方式（CWD）漂移，详见 crate::paths。
+        assert!(ranked.is_absolute(), "{:?}", ranked);
+        assert!(aram.is_absolute(), "{:?}", aram);
+        // 两个模式必须各自独立，不能互相覆盖。
+        assert_ne!(ranked, aram);
+        assert!(ranked.to_str().unwrap().contains("ranked"));
+        assert!(aram.to_str().unwrap().contains("aram"));
     }
 }

--- a/lol-record-analysis-tauri/src-tauri/src/paths.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/paths.rs
@@ -1,0 +1,264 @@
+//! # 应用数据路径解析
+//!
+//! 统一决定「配置文件」和「缓存文件」落在哪里。**唯一的硬性要求：不依赖进程的当前
+//! 工作目录（CWD）。**
+//!
+//! ## 为什么不能用 CWD 相对路径
+//!
+//! 曾经这些文件都写成 `PathBuf::from("config.yaml")` 这样的相对路径，实际落点等于
+//! `CWD + 文件名`。而 CWD 是**由启动方决定的，不是应用能保证的**：
+//!
+//! - Windows 上走开始菜单/桌面快捷方式时，CWD = 快捷方式的「起始位置」= 安装目录，
+//!   于是恰好落在 exe 旁边，看起来一切正常；
+//! - 但从命令行、Win+R、或被其他进程拉起时，CWD 可能是 `C:\`、`%USERPROFILE%`、
+//!   甚至 `System32`，配置就写去了别处，表现为「设置莫名其妙回到默认」；
+//! - macOS 上由 LaunchServices 拉起的 `.app`，CWD 恒为 `/`（实测 Chrome / iTerm2
+//!   亦然），而 `/` 在 SIP 下只读 —— 配置**读不到也写不进**，每次启动全部重置。
+//!
+//! ## 现在的规则
+//!
+//! | 平台 | 配置目录 | 理由 |
+//! |------|---------|------|
+//! | Windows | **exe 所在目录** | 保持便携版（绿色软件）约定，且与老版本落点一致，升级无需迁移数据 |
+//! | macOS | `~/Library/Application Support/<bundle id>` | 不能写进 `.app` bundle：会破坏代码签名，且每次更新整个 bundle 被替换 |
+//! | 其他 Unix | `~/.config/<bundle id>` | 未发布平台，仅为编译完整性 |
+//!
+//! 缓存一律放系统临时目录（带应用前缀避免撞名）—— 它们都能自动重建，丢了只是多拉
+//! 一次，不值得占用配置目录，也不必考虑写权限。
+//!
+//! ## ⚠️ 前提：Windows 安装在用户可写目录
+//!
+//! Windows 侧把配置放 exe 旁边成立的前提是 `tauri.conf.json` 里
+//! `bundle.windows.nsis.installMode = "currentUser"`（装进 `%LOCALAPPDATA%`，可写）。
+//! **若哪天改成 `perMachine`（装进 `Program Files`），exe 目录将不可写，届时必须改用
+//! `%APPDATA%\<bundle id>` 并为老用户写一次数据迁移。**
+
+use std::path::{Path, PathBuf};
+
+/// 应用 bundle 标识，与 `tauri.conf.json` 的 `identifier` 保持一致。
+///
+/// 用作 macOS / Linux 配置目录名。改动 `identifier` 时必须同步改这里，否则老用户的
+/// 配置会「消失」（其实是去了新目录）。
+const BUNDLE_ID: &str = "com.lol-record-analysis-tauri.app";
+
+/// 配置文件名。
+const CONFIG_FILE_NAME: &str = "config.yaml";
+
+/// 缓存文件名前缀，避免在多应用共用的临时目录里与别人撞名。
+const CACHE_PREFIX: &str = "lol-record-analysis-";
+
+// 三个 `config_dir_*` 按目标平台分别编译：不 cfg 门控的话，未被本平台选中的那些在
+// 普通 lib 构建里就是 dead code，而 CI 的 clippy 是 `-Dwarnings`。CI 跑
+// windows-latest + macos-latest 双矩阵，两个真实发布平台的分支都会被编译和测试。
+
+/// Windows 配置目录：exe 所在目录（便携版约定）。
+///
+/// 传入 `current_exe()` 的结果。返回 `None` 表示无法确定（父目录缺失或为空——空父目录
+/// 意味着又要退回 CWD，正是本模块要杜绝的），调用方应回退到别处。
+#[cfg(target_os = "windows")]
+fn config_dir_windows(exe: &Path) -> Option<PathBuf> {
+    exe.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(PathBuf::from)
+}
+
+/// macOS 配置目录：`<home>/Library/Application Support/<bundle id>`。
+#[cfg(target_os = "macos")]
+fn config_dir_macos(home: &Path) -> PathBuf {
+    home.join("Library")
+        .join("Application Support")
+        .join(BUNDLE_ID)
+}
+
+/// 其他 Unix 配置目录：`<home>/.config/<bundle id>`。
+///
+/// 本项目只发布 Windows / macOS，此分支不在 CI 矩阵内，仅为在 Linux 上也能编译。
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+fn config_dir_unix(home: &Path) -> PathBuf {
+    home.join(".config").join(BUNDLE_ID)
+}
+
+/// 缓存文件路径：临时目录 + 应用前缀 + 文件名。
+fn cache_file_in(temp_dir: &Path, name: &str) -> PathBuf {
+    temp_dir.join(format!("{}{}", CACHE_PREFIX, name))
+}
+
+/// 配置文件的绝对路径。
+///
+/// 落点见模块文档。**保证返回绝对路径**——这是本模块存在的意义，相对路径会退回
+/// 依赖 CWD 的老行为。
+pub fn config_file() -> PathBuf {
+    data_file(CONFIG_FILE_NAME)
+}
+
+/// 按平台解析配置目录，解析不出来时回退到临时目录。
+///
+/// 回退分支现实中几乎不可能走到（`current_exe()` / `$HOME` 皆失效）。选临时目录而不是
+/// CWD，是因为它至少保证「绝对且可写」；配置存在那里会随系统清理丢失，所以额外打一条
+/// 告警，便于线上发现。
+fn config_dir() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    let resolved = std::env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(config_dir_windows);
+
+    #[cfg(target_os = "macos")]
+    let resolved = home_dir().map(|h| config_dir_macos(&h));
+
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    let resolved = home_dir().map(|h| config_dir_unix(&h));
+
+    resolved.unwrap_or_else(|| {
+        let fallback = std::env::temp_dir();
+        log::warn!(
+            "无法解析配置目录（exe 路径 / $HOME 均不可用），回退到临时目录 {:?}；配置可能随系统清理丢失",
+            fallback
+        );
+        fallback
+    })
+}
+
+/// 用户主目录（`$HOME`），空值视为不可用。
+#[cfg(not(target_os = "windows"))]
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+}
+
+/// 配置目录下某个数据文件的绝对路径。
+///
+/// 用于配置以外、但同样需要**跨重启保留**的小文件（如 Sentry 的匿名设备 ID）。与
+/// [`cache_file`] 的区别：缓存丢了自动重建，数据文件丢了会造成语义损失（设备 ID 重生成
+/// 会让上报侧把同一台机器算成多台）。
+pub fn data_file(name: &str) -> PathBuf {
+    config_dir().join(name)
+}
+
+/// 某个缓存文件的绝对路径（系统临时目录下，带应用前缀）。
+///
+/// # 参数
+/// - `name`: 不含前缀的文件名，如 `"opgg_ranked.json"`
+pub fn cache_file(name: &str) -> PathBuf {
+    cache_file_in(&std::env::temp_dir(), name)
+}
+
+/// 确保某个文件路径的父目录存在（不存在则递归创建）。
+///
+/// macOS 首次运行时 `~/Library/Application Support/<bundle id>` 尚不存在，写配置前
+/// 必须先建目录，否则 `File::create` 会直接失败。
+pub fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
+    match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => std::fs::create_dir_all(dir),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 路径字面量统一用 `/` 分隔：Windows 的 Path 同样接受 `/`，这样断言在 CI 的
+    // windows-latest 与 macos-latest 上语义一致（`\` 在 Unix 上不是分隔符，会被当成
+    // 普通字符，令 parent() 结果随平台漂移）。
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_config_dir_should_be_the_exe_directory() {
+        let dir = config_dir_windows(Path::new("/AppData/Local/app/app.exe"));
+
+        assert_eq!(dir, Some(PathBuf::from("/AppData/Local/app")));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_config_dir_should_be_none_when_exe_has_no_real_parent() {
+        // 父目录为空字符串等价于「相对 CWD」，正是本模块要杜绝的，必须当作失败。
+        assert_eq!(config_dir_windows(Path::new("app.exe")), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_config_dir_should_live_under_application_support() {
+        let dir = config_dir_macos(Path::new("/Users/me"));
+
+        assert_eq!(
+            dir,
+            PathBuf::from(
+                "/Users/me/Library/Application Support/com.lol-record-analysis-tauri.app"
+            )
+        );
+    }
+
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    #[test]
+    fn unix_config_dir_should_live_under_dot_config() {
+        let dir = config_dir_unix(Path::new("/home/me"));
+
+        assert_eq!(
+            dir,
+            PathBuf::from("/home/me/.config/com.lol-record-analysis-tauri.app")
+        );
+    }
+
+    #[test]
+    fn cache_file_should_be_namespaced_inside_temp_dir() {
+        let path = cache_file_in(Path::new("/tmp"), "opgg_ranked.json");
+
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/lol-record-analysis-opgg_ranked.json")
+        );
+    }
+
+    // 本模块存在的全部理由：路径不能依赖 CWD。相对路径一旦回归，下面两条立刻变红。
+    // 这正是当初 macOS 上「配置读不到也写不进」（CWD 为只读的 `/`）漏网的原因。
+    #[test]
+    fn config_file_must_be_absolute_never_cwd_relative() {
+        assert!(
+            config_file().is_absolute(),
+            "配置路径必须绝对，否则落点会随启动方式漂移：{:?}",
+            config_file()
+        );
+    }
+
+    #[test]
+    fn cache_file_must_be_absolute_never_cwd_relative() {
+        assert!(cache_file("x.json").is_absolute());
+    }
+
+    #[test]
+    fn data_file_should_sit_beside_the_config_file() {
+        let device_id = data_file("device_id");
+
+        assert!(device_id.is_absolute(), "{:?}", device_id);
+        assert_eq!(device_id.parent(), config_file().parent());
+        assert_eq!(
+            device_id.file_name().and_then(|n| n.to_str()),
+            Some("device_id")
+        );
+    }
+
+    #[test]
+    fn config_file_should_be_named_config_yaml() {
+        assert_eq!(
+            config_file().file_name().and_then(|n| n.to_str()),
+            Some("config.yaml")
+        );
+    }
+
+    #[test]
+    fn ensure_parent_dir_should_create_missing_directories() {
+        let target = std::env::temp_dir()
+            .join(format!("ra-paths-test-{}", std::process::id()))
+            .join("nested")
+            .join("config.yaml");
+        let created_root = target.parent().unwrap().parent().unwrap().to_path_buf();
+        let _ = std::fs::remove_dir_all(&created_root);
+
+        ensure_parent_dir(&target).expect("应能创建父目录");
+
+        assert!(target.parent().unwrap().is_dir());
+        let _ = std::fs::remove_dir_all(&created_root);
+    }
+}

--- a/lol-record-analysis-tauri/src-tauri/src/paths.rs
+++ b/lol-record-analysis-tauri/src-tauri/src/paths.rs
@@ -47,15 +47,16 @@ const CONFIG_FILE_NAME: &str = "config.yaml";
 /// 缓存文件名前缀，避免在多应用共用的临时目录里与别人撞名。
 const CACHE_PREFIX: &str = "lol-record-analysis-";
 
-// 三个 `config_dir_*` 按目标平台分别编译：不 cfg 门控的话，未被本平台选中的那些在
-// 普通 lib 构建里就是 dead code，而 CI 的 clippy 是 `-Dwarnings`。CI 跑
-// windows-latest + macos-latest 双矩阵，两个真实发布平台的分支都会被编译和测试。
+// 下面三个 `config_dir_*` 是**纯路径运算**，不碰任何平台专有 API，因此一律无条件编译，
+// 由 `config_dir()` 用运行时的 `cfg!()` 选择。刻意不用 `#[cfg]` 门控：那样未被选中的
+// 分支在本平台就是 dead code（撞 `clippy -Dwarnings`），且它们的测试也只能跟着门控，
+// 于是「Windows 的路径逻辑」只有 Windows runner 能验——本地怎么跑都发现不了问题。
+// 无条件编译后，任一平台的 `cargo test` 都会把三套逻辑全跑一遍。
 
 /// Windows 配置目录：exe 所在目录（便携版约定）。
 ///
 /// 传入 `current_exe()` 的结果。返回 `None` 表示无法确定（父目录缺失或为空——空父目录
 /// 意味着又要退回 CWD，正是本模块要杜绝的），调用方应回退到别处。
-#[cfg(target_os = "windows")]
 fn config_dir_windows(exe: &Path) -> Option<PathBuf> {
     exe.parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -63,7 +64,6 @@ fn config_dir_windows(exe: &Path) -> Option<PathBuf> {
 }
 
 /// macOS 配置目录：`<home>/Library/Application Support/<bundle id>`。
-#[cfg(target_os = "macos")]
 fn config_dir_macos(home: &Path) -> PathBuf {
     home.join("Library")
         .join("Application Support")
@@ -72,8 +72,7 @@ fn config_dir_macos(home: &Path) -> PathBuf {
 
 /// 其他 Unix 配置目录：`<home>/.config/<bundle id>`。
 ///
-/// 本项目只发布 Windows / macOS，此分支不在 CI 矩阵内，仅为在 Linux 上也能编译。
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+/// 本项目只发布 Windows / macOS，此分支不会在真实运行时被选中，仅为在 Linux 上也能跑。
 fn config_dir_unix(home: &Path) -> PathBuf {
     home.join(".config").join(BUNDLE_ID)
 }
@@ -97,17 +96,16 @@ pub fn config_file() -> PathBuf {
 /// CWD，是因为它至少保证「绝对且可写」；配置存在那里会随系统清理丢失，所以额外打一条
 /// 告警，便于线上发现。
 fn config_dir() -> PathBuf {
-    #[cfg(target_os = "windows")]
-    let resolved = std::env::current_exe()
-        .ok()
-        .as_deref()
-        .and_then(config_dir_windows);
-
-    #[cfg(target_os = "macos")]
-    let resolved = home_dir().map(|h| config_dir_macos(&h));
-
-    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
-    let resolved = home_dir().map(|h| config_dir_unix(&h));
+    let resolved = if cfg!(target_os = "windows") {
+        std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(config_dir_windows)
+    } else if cfg!(target_os = "macos") {
+        home_dir().map(|h| config_dir_macos(&h))
+    } else {
+        home_dir().map(|h| config_dir_unix(&h))
+    };
 
     resolved.unwrap_or_else(|| {
         let fallback = std::env::temp_dir();
@@ -120,7 +118,9 @@ fn config_dir() -> PathBuf {
 }
 
 /// 用户主目录（`$HOME`），空值视为不可用。
-#[cfg(not(target_os = "windows"))]
+///
+/// Windows 上不会被 [`config_dir`] 走到（那条分支用 exe 目录），无条件编译只是为了让
+/// `cfg!()` 的三个分支在所有平台都通过类型检查。
 fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
@@ -162,7 +162,6 @@ mod tests {
     // 路径字面量统一用 `/` 分隔：Windows 的 Path 同样接受 `/`，这样断言在 CI 的
     // windows-latest 与 macos-latest 上语义一致（`\` 在 Unix 上不是分隔符，会被当成
     // 普通字符，令 parent() 结果随平台漂移）。
-    #[cfg(target_os = "windows")]
     #[test]
     fn windows_config_dir_should_be_the_exe_directory() {
         let dir = config_dir_windows(Path::new("/AppData/Local/app/app.exe"));
@@ -170,14 +169,12 @@ mod tests {
         assert_eq!(dir, Some(PathBuf::from("/AppData/Local/app")));
     }
 
-    #[cfg(target_os = "windows")]
     #[test]
     fn windows_config_dir_should_be_none_when_exe_has_no_real_parent() {
         // 父目录为空字符串等价于「相对 CWD」，正是本模块要杜绝的，必须当作失败。
         assert_eq!(config_dir_windows(Path::new("app.exe")), None);
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn macos_config_dir_should_live_under_application_support() {
         let dir = config_dir_macos(Path::new("/Users/me"));
@@ -190,7 +187,6 @@ mod tests {
         );
     }
 
-    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
     #[test]
     fn unix_config_dir_should_live_under_dot_config() {
         let dir = config_dir_unix(Path::new("/home/me"));


### PR DESCRIPTION
## 背景：mac 上配置一直存不下来

所有持久化文件此前都是 CWD 相对路径 —— `config.yaml`、`device_id`、三个 `*_cache.json`。而 CWD **由启动方决定，不是应用能保证的**。

实测（本机，装在 `/Applications` 的 1.8.11）：

```
$ open -a /Applications/lol-record-analysis-app.app
$ lsof -a -p <pid> -d cwd
工作目录: /
$ test -w /   →  不可写（SIP 只读系统卷）
```

app bundle 内外都找不到任何 `config.yaml` —— **它一次都没成功写下来过**。

用户实际体感：改设置当次生效，一重启全回默认。丢的东西包括：

| 键 | 后果 |
|---|---|
| `dashscopeApiKey` | AI 复盘的 key 每次重启都要重填 |
| `playerNotes` / `userTags` | 本地备注标签不落盘 |
| cloud sync session | 每次启动重建一个 Supabase 匿名账号 |
| `errorReportingConsentShown` | 同意弹窗每次都弹 |

Windows 没冒烟只是因为快捷方式的「起始位置」恰好等于安装目录；从命令行、Win+R、或被其他进程拉起时同样会写去别处。

另外 `observability.rs` 的匿名设备 ID 也是相对路径 → mac 上每次启动重新生成 UUID → **Sentry 把一台机器算成无数台新设备，DAU / 设备数虚高**。

## 改法：新增 `paths` 模块，按平台分流

| 平台 | 配置目录 | 理由 |
|---|---|---|
| Windows | **exe 所在目录** | 沿用便携版（绿色软件）约定 |
| macOS | `~/Library/Application Support/<bundle id>` | 不能写进 `.app`：破坏 ad-hoc 签名，且每次更新整个 bundle 被替换 |

**两边都不需要迁移**：Windows 解析出的就是老版本那个文件本身（快捷方式启动时 CWD == exe 目录），原地不动；macOS 从来没写成功过，没有历史数据。改动同时修掉了 Windows 上几个边角启动路径的漂移。

缓存（opgg / 国服与 wiki 版本说明 / cdragon）统一进系统临时目录 —— 纯缓存丢了自动重建，不必占配置目录也不必操心写权限。`cdragon` 那个本来就在 temp，解析结果逐字节不变。

顺带把「配置文件不存在」从 `error` 降为 `info`：首次运行是正常情况，而 error 级日志会转发成 Sentry 事件，等于每个新用户刷一条纯噪音。

## 测试

新增 `paths` 模块 10 个测试，其中两条是这个 bug 的直接回归闸门：

```rust
fn config_file_must_be_absolute_never_cwd_relative()
fn cache_file_must_be_absolute_never_cwd_relative()
```

`config_dir_*` 按目标平台 cfg 门控（否则未选中的分支在 lib 构建里是 dead code，撞 `clippy -Dwarnings`）；CI 的 windows + macos 双矩阵会各自编译并测试自己那半。

`write_config_to` 是从 `write_config` 里拆出来的可测部分（后者依赖全局缓存单例，不适合并行测试里碰）。它的测试是在实现之后补的、一写就绿，所以额外做了**变异检验**确认它真的抓得住 —— 摘掉 `ensure_parent_dir` 后：

```
FAILED  父目录不存在时也应写入成功: Os { code: 2, kind: NotFound }
```

## Test plan

- [x] `npm run check` passes（0 errors）
- [x] `npm run test` passes（67 files / 714 tests）
- [x] `cargo test` passes（330 passed，较 main +8）
- [x] 以 `/` 为 CWD 跑 `cargo test paths::` —— 路径解析不受 CWD 影响
- [x] **实机**：以 CWD=`/` 启动真实二进制，日志确认
      `Config file path: /Users/…/Library/Application Support/com.lol-record-analysis-tauri.app/config.yaml`
- [ ] 手动：装 dmg → 改设置 → 重启确认还在（需要点击，我没法代跑）
- [ ] 手动：Windows 上升级一版，确认老配置仍被读到（这是本 PR 唯一需要盯的回归面）

## 一个钉住的前提

Windows 把配置放 exe 旁边，前提是 `installMode: currentUser`（装进 `%LOCALAPPDATA%`，可写）。**若哪天改成 `perMachine`，exe 目录将不可写，届时必须改用 `%APPDATA%` 并为老用户写迁移** —— 已写进 `paths.rs` 的模块文档。

## 顺带值得看一眼

云同步在 mac 上每次启动重建匿名账号，Supabase 里可能从 8 月初堆了一批垃圾设备行，建议去后台确认下。