### PR TITLE
fix(bp): 修自动 BP 到点不执行，LCU 计时器按快照龄校正

### DIFF
--- a/rank-analysis-app/src-tauri/src/automation.rs
+++ b/rank-analysis-app/src-tauri/src/automation.rs
@@ -34,7 +34,9 @@ use tokio::time::interval;
 
 use crate::config::{extract_bool, get_config, register_on_change_callback, Value};
 use crate::constant::game::{CHAMPSELECT, LOBBY, MATCHMAKING, READYCHECK};
-use crate::lcu::api::champion_select::{get_champion_select_session, post_accept_match};
+use crate::lcu::api::champion_select::{
+    get_champion_select_session, get_fresh_champion_select_session, post_accept_match,
+};
 use crate::lcu::api::lobby::Lobby;
 use crate::lcu::api::phase::get_phase;
 use crate::opgg::data::OpggSnapshot;
@@ -375,10 +377,7 @@ async fn is_leader(members: &[crate::lcu::api::lobby::Member]) -> Result<bool, S
 ///
 /// # 逻辑流程
 ///
-/// 1. 每 1 秒检测一次游戏阶段——执行窗口 `[MIN_EXECUTE_SECS, execute_at_secs_left]`
-///    宽 2s，采样周期必须 ≤ 窗口宽度的一半才能保证命中：若仍按 2s 采样，叠加 LCU
-///    抖动，连续两次采样可能刚好跨过窗口两侧，导致整局静默不锁（常驻求值任务不
-///    受此约束，采样周期保持 2s 不变）
+/// 1. 每 1 秒检测一次游戏阶段，进入 `execute_at_secs_left` 阈值后持续尝试锁定
 /// 2. 当进入 `CHAMPSELECT` 阶段时执行选人逻辑
 /// 3. 调用 `start_select_champion()` 执行具体选人操作
 ///
@@ -492,7 +491,6 @@ async fn load_ban_rules() -> Vec<crate::command::rule_config::BanRule> {
 /// 2. 快照的动作类型与本任务不符则跳过
 /// 3. 交给 `apply_bp_decision`：hover 同步 → 到点锁定
 async fn start_select_champion() -> Result<(), String> {
-    let select_session = get_champion_select_session().await?;
     let Some(decision) = crate::bp_decision::store::read() else {
         log::debug!("No BP decision snapshot yet, skipping this tick");
         return Ok(());
@@ -500,6 +498,7 @@ async fn start_select_champion() -> Result<(), String> {
     if decision.action_type != crate::bp_decision::types::BpActionType::Pick {
         return Ok(());
     }
+    let select_session = get_fresh_champion_select_session().await?;
     apply_bp_decision(&select_session, &decision).await
 }
 
@@ -509,10 +508,7 @@ async fn start_select_champion() -> Result<(), String> {
 ///
 /// # 逻辑流程
 ///
-/// 1. 每 1 秒检测一次游戏阶段——执行窗口 `[MIN_EXECUTE_SECS, execute_at_secs_left]`
-///    宽 2s，采样周期必须 ≤ 窗口宽度的一半才能保证命中：若仍按 2s 采样，叠加 LCU
-///    抖动，连续两次采样可能刚好跨过窗口两侧，导致整局静默不锁（常驻求值任务不
-///    受此约束，采样周期保持 2s 不变）
+/// 1. 每 1 秒检测一次游戏阶段，进入 `execute_at_secs_left` 阈值后持续尝试锁定
 /// 2. 当进入 `CHAMPSELECT` 阶段时执行禁用逻辑
 /// 3. 调用 `start_ban_champion()` 执行具体禁用操作
 ///
@@ -547,9 +543,6 @@ async fn start_champion_ban_automation() {
 
 /// 默认执行阈值：剩余降到该秒数时执行锁定。
 const DEFAULT_EXECUTE_AT_SECS_LEFT: f64 = 5.0;
-
-/// 剩余不足该秒数时放弃本次自动执行，避免半吊子状态。
-pub(crate) const MIN_EXECUTE_SECS: f64 = 3.0;
 
 /// 根据分路信息推断该用哪份 OP.GG 数据。
 ///
@@ -721,8 +714,7 @@ fn should_act(d: &crate::bp_decision::types::BpDecision) -> bool {
 /// **不是**「预告后倒数 N 秒」——固定秒数在不同队列时长下会一会儿太早一会儿来不及。
 ///
 /// `time_left_secs` 必须由调用方用**实时** timer 算出（见 [`apply_bp_decision`]）——
-/// 快照里的 `d.time_left_secs` 是求值 tick 那一刻的值，叠加 session 缓存后
-/// 可能落后到让 `MIN_EXECUTE_SECS` 的保护形同虚设。
+/// 快照里的 `d.time_left_secs` 是求值 tick 那一刻的值，不能用于执行判断。
 fn should_lock(
     d: &crate::bp_decision::types::BpDecision,
     time_left_secs: f64,
@@ -731,10 +723,7 @@ fn should_lock(
     let Some(t) = d.target.as_ref() else {
         return false;
     };
-    is_in_progress
-        && t.lock
-        && time_left_secs <= d.execute_at_secs_left
-        && time_left_secs >= MIN_EXECUTE_SECS
+    is_in_progress && t.lock && time_left_secs > 0.0 && time_left_secs <= d.execute_at_secs_left
 }
 
 /// 按决策快照同步 hover 并在到点时锁定。
@@ -793,15 +782,14 @@ async fn apply_bp_decision(
         .await
         {
             Ok(()) => store::set_last_hovered(Some(target.champion_id)),
-            // hover 是「同步展示」,失败不该否决「到点执行」——执行窗口只有一次机会
+            // hover 是「同步展示」，失败不该否决后续的到点执行
             Err(e) => log::warn!("BP hover sync failed (continuing to lock check): {}", e),
         }
     }
 
     // ---- 到点执行 ----
-    // 时间判断用实时 timer,而非快照的 time_left_secs:session 有 1s 进程内缓存,
-    // 此处的 time_left 最多滞后 ~1s,仍远优于快照的 2s+ 滞后,MIN_EXECUTE_SECS
-    // 的「不足 3s 不动手」保护才站得住。
+    // 时间判断用绕过缓存的实时 timer，而非快照的 time_left_secs。进入阈值后
+    // 每 tick 都会尝试，避免轮询调度或 LCU 抖动跨过一个狭窄窗口后永久放弃。
     let timer = &session.timer;
     // real_time_left: 本 tick 实际参与到点判断的剩余秒数,None = 无计时器模式。
     // 只为下面的执行日志保留——那行日志是真机核对毫秒假设的唯一证据源,必须打真值。
@@ -869,7 +857,6 @@ async fn switch_enabled(key: &str) -> bool {
 /// 2. 快照的动作类型与本任务不符则跳过
 /// 3. 交给 `apply_bp_decision`：hover 同步 → 到点锁定
 async fn start_ban_champion() -> Result<(), String> {
-    let select_session = get_champion_select_session().await?;
     let Some(decision) = crate::bp_decision::store::read() else {
         log::debug!("No BP decision snapshot yet, skipping this tick");
         return Ok(());
@@ -877,6 +864,7 @@ async fn start_ban_champion() -> Result<(), String> {
     if decision.action_type != crate::bp_decision::types::BpActionType::Ban {
         return Ok(());
     }
+    let select_session = get_fresh_champion_select_session().await?;
     apply_bp_decision(&select_session, &decision).await
 }
 
@@ -1182,7 +1170,7 @@ mod bp_execution_tests {
     }
 
     #[test]
-    fn should_lock_only_within_threshold_window() {
+    fn should_lock_after_reaching_threshold() {
         // 还早 → 不锁
         assert!(!should_lock(
             &decision(BpMode::Auto, 20.0, false),
@@ -1192,8 +1180,10 @@ mod bp_execution_tests {
         // 到点 → 锁
         assert!(should_lock(&decision(BpMode::Auto, 5.0, false), 5.0, true));
         assert!(should_lock(&decision(BpMode::Auto, 3.5, false), 3.5, true));
-        // 不足 3s → 放弃，避免半吊子状态
-        assert!(!should_lock(&decision(BpMode::Auto, 2.9, false), 2.9, true));
+        // 即使一次采样从 5s 以上跳到 3s 以下，也仍应执行
+        assert!(should_lock(&decision(BpMode::Auto, 2.9, false), 2.9, true));
+        // 已归零 → 不再发送无效请求
+        assert!(!should_lock(&decision(BpMode::Auto, 0.0, false), 0.0, true));
         // 没轮到我 → 不锁
         assert!(!should_lock(
             &decision(BpMode::Auto, 4.0, false),

--- a/rank-analysis-app/src-tauri/src/automation.rs
+++ b/rank-analysis-app/src-tauri/src/automation.rs
@@ -1166,6 +1166,9 @@ mod bp_execution_tests {
             time_left_secs: time_left,
             execute_at_secs_left: 5.0,
             user_overridden: overridden,
+            // 执行路径不读快照的该字段（用实时 session 的 pending.is_in_progress），
+            // 这里给 true 只为构造合法快照。
+            is_in_progress: true,
         }
     }
 

--- a/rank-analysis-app/src-tauri/src/bp_decision/evaluate.rs
+++ b/rank-analysis-app/src-tauri/src/bp_decision/evaluate.rs
@@ -9,14 +9,36 @@ use crate::command::rule_config::{BanRule, PickRule, Position};
 use crate::opgg::data::OpggSnapshot;
 use crate::rule_engine::{detect_my_position, match_condition};
 
-/// LCU 的 `adjustedTimeLeftInPhase` 以**毫秒**返回，转成秒。
+/// 当前回合的真实剩余秒数。
 ///
-/// 真机核对方法：观察 `automation.rs` 里 `BP execute:` 日志打出的 time_left——
-/// 应落在 0~35s 区间且随时间递减；若实测打出的是 0.0xx 量级（例如
-/// "0.027s left"），说明 LCU 返回的其实已经是秒，去掉本函数里的 `/ 1000.0`
-/// 这一处换算即可。
+/// LCU 的 `adjustedTimeLeftInPhase`（毫秒）是**推送时刻的冻结快照**，不是实时
+/// 倒计时：2026-08-14 真机逐秒采样到它在一个 25 秒的 pick 回合里恒为 22.6、
+/// 22 秒纹丝不动，另一处冻在 25.0 十秒后直接跳到 9.0。只读这个值做「剩余
+/// ≤ N 秒就执行」的判断等于永不触发——自动 BP 整局静默的根因就在这里。
+///
+/// 同一 payload 的 `internalNowInEpochMs` 是该快照对应的时刻，扣掉快照至今
+/// 流逝的墙钟才是真实剩余。实测该式每秒精确递减 1.0s，且跨越 LCU 刷新快照
+/// 的那一跳（raw 25.0 → 9.0）修正值无缝衔接（9.5 → 8.5），不产生不连续。
+///
+/// `now_epoch_ms` 由调用方注入以保持纯函数；生产路径用 [`phase_secs_left`]。
+pub fn phase_secs_left_at(timer: &Timer, now_epoch_ms: f64) -> f64 {
+    if timer.internal_now_in_epoch_ms <= 0.0 {
+        // 字段缺失（旧客户端/异常 payload）：退回快照原值。此时宁可不准，
+        // 也不能拿 0 当基准去减——那会得出天文数字的负数，把每一帧都误判成已过期。
+        return timer.adjusted_time_left_in_phase / 1000.0;
+    }
+    // 时钟回拨/LCU 时刻略微超前时钳到 0，避免把剩余时间算得比快照还多。
+    let age_ms = (now_epoch_ms - timer.internal_now_in_epoch_ms).max(0.0);
+    (timer.adjusted_time_left_in_phase - age_ms) / 1000.0
+}
+
+/// [`phase_secs_left_at`] 的生产入口，以系统当前时刻求值。
 pub fn phase_secs_left(timer: &Timer) -> f64 {
-    timer.adjusted_time_left_in_phase / 1000.0
+    let now_epoch_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as f64)
+        .unwrap_or(0.0);
+    phase_secs_left_at(timer, now_epoch_ms)
 }
 
 /// 找到当前用户尚未完成的那个 BP 动作。
@@ -345,6 +367,7 @@ pub fn evaluate_bp_decision(ctx: &BpContext) -> Option<BpDecision> {
         time_left_secs: phase_secs_left(&ctx.session.timer),
         execute_at_secs_left: ctx.execute_at_secs_left,
         user_overridden: detect_override(pending.champion_id, ctx.last_hovered),
+        is_in_progress: pending.is_in_progress,
     })
 }
 
@@ -943,8 +966,59 @@ mod tests {
     fn phase_secs_left_converts_lcu_milliseconds() {
         let t = Timer {
             adjusted_time_left_in_phase: 27_500.0,
+            internal_now_in_epoch_ms: 1_000_000.0,
             ..Default::default()
         };
-        assert!((phase_secs_left(&t) - 27.5).abs() < 1e-9);
+        // 快照零龄（now == internalNow）→ 就是快照原值
+        assert!((phase_secs_left_at(&t, 1_000_000.0) - 27.5).abs() < 1e-9);
+    }
+
+    /// 真机回归：2026-08-14 逐秒采样到 `adjustedTimeLeftInPhase` 在一个 25 秒
+    /// 回合里冻结不动（raw 恒 25.0，快照龄一路涨到 15.5s）。只读 raw 会一直
+    /// 认为「还剩 25 秒」，永远进不了执行窗口——自动 BP 因此整局静默。
+    #[test]
+    fn phase_secs_left_subtracts_snapshot_age() {
+        let t = Timer {
+            adjusted_time_left_in_phase: 25_000.0,
+            internal_now_in_epoch_ms: 1_000_000.0,
+            ..Default::default()
+        };
+        assert!((phase_secs_left_at(&t, 1_000_000.0) - 25.0).abs() < 1e-9);
+        assert!((phase_secs_left_at(&t, 1_015_500.0) - 9.5).abs() < 1e-9);
+        // 冻结的 raw 不再能把剩余时间钉在窗口外
+        assert!(phase_secs_left_at(&t, 1_021_000.0) <= 5.0);
+    }
+
+    /// LCU 刷新快照的那一跳不得造成不连续：真机上 raw 25.0(龄 15.5) 的下一秒
+    /// 变成 raw 9.0(龄 0.5)，修正后应是 9.5 → 8.5 的平滑衔接。
+    #[test]
+    fn phase_secs_left_is_continuous_across_snapshot_refresh() {
+        let stale = Timer {
+            adjusted_time_left_in_phase: 25_000.0,
+            internal_now_in_epoch_ms: 1_000_000.0,
+            ..Default::default()
+        };
+        let fresh = Timer {
+            adjusted_time_left_in_phase: 9_000.0,
+            internal_now_in_epoch_ms: 1_016_000.0,
+            ..Default::default()
+        };
+        let before = phase_secs_left_at(&stale, 1_015_500.0);
+        let after = phase_secs_left_at(&fresh, 1_016_500.0);
+        assert!((before - 9.5).abs() < 1e-9, "before = {before}");
+        assert!((after - 8.5).abs() < 1e-9, "after = {after}");
+    }
+
+    /// 字段缺失（旧客户端/异常 payload，serde default 为 0）时退回快照原值，
+    /// 行为与修正前一致——宁可不准，也不要因为减掉一个 1970 年的时刻而得出
+    /// 天文数字的负数、把「已过期」误判成常态。
+    #[test]
+    fn phase_secs_left_falls_back_when_epoch_missing() {
+        let t = Timer {
+            adjusted_time_left_in_phase: 27_500.0,
+            internal_now_in_epoch_ms: 0.0,
+            ..Default::default()
+        };
+        assert!((phase_secs_left_at(&t, 1_755_000_000_000.0) - 27.5).abs() < 1e-9);
     }
 }

--- a/rank-analysis-app/src-tauri/src/bp_decision/types.rs
+++ b/rank-analysis-app/src-tauri/src/bp_decision/types.rs
@@ -115,4 +115,11 @@ pub struct BpDecision {
     pub execute_at_secs_left: f64,
     /// 用户已接管，本阶段不再自动执行
     pub user_overridden: bool,
+    /// 是否真的轮到我了。
+    ///
+    /// 决策快照在**还没轮到我时也会产生**（预选期要提前 hover，见
+    /// `evaluate::find_my_pending_action`），而执行只在轮到我时发生。
+    /// 前端必须据此区分，否则会在别人的回合里显示「Xs 后自动执行」
+    /// 这种不会兑现的承诺。
+    pub is_in_progress: bool,
 }

--- a/rank-analysis-app/src-tauri/src/lcu/api/champion_select.rs
+++ b/rank-analysis-app/src-tauri/src/lcu/api/champion_select.rs
@@ -249,6 +249,17 @@ pub fn derive_champ_select_view(
     )
 }
 
+async fn fetch_champion_select_session() -> Result<SelectSession, String> {
+    let uri = "lol-champ-select/v1/session";
+    let select_session = lcu_get::<SelectSession>(uri).await?;
+
+    let mut cache = SELECT_CACHE.lock().unwrap();
+    cache.last_session = Some(select_session.clone());
+    cache.last_fetch_time = Some(Instant::now());
+
+    Ok(select_session)
+}
+
 pub async fn get_champion_select_session() -> Result<SelectSession, String> {
     {
         let cache = SELECT_CACHE.lock().unwrap();
@@ -263,17 +274,15 @@ pub async fn get_champion_select_session() -> Result<SelectSession, String> {
         }
     }
 
-    let uri = "lol-champ-select/v1/session";
-    let select_session = lcu_get::<SelectSession>(uri).await?;
+    fetch_champion_select_session().await
+}
 
-    // 更新缓存
-    {
-        let mut cache = SELECT_CACHE.lock().unwrap();
-        cache.last_session = Some(select_session.clone());
-        cache.last_fetch_time = Some(Instant::now());
-    }
-
-    Ok(select_session)
+/// 获取不经过进程内缓存的选人会话。
+///
+/// 自动 BP 的执行窗口需要最新的 action 和 timer；复用 1 秒缓存会让每秒轮询
+/// 实际观察到约 2 秒一跳的数据，可能直接跨过锁定阈值。
+pub async fn get_fresh_champion_select_session() -> Result<SelectSession, String> {
+    fetch_champion_select_session().await
 }
 
 pub async fn post_accept_match() -> Result<(), String> {

--- a/rank-analysis-app/src-tauri/src/lcu/api/champion_select.rs
+++ b/rank-analysis-app/src-tauri/src/lcu/api/champion_select.rs
@@ -36,10 +36,17 @@ pub struct Action {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Timer {
+    /// **推送时刻的冻结快照**，不是实时倒计时——真机实测可在一个 25 秒回合里
+    /// 纹丝不动 22 秒。要得到真实剩余必须配合 [`Timer::internal_now_in_epoch_ms`]
+    /// 扣掉快照至今流逝的墙钟，见 `bp_decision::evaluate::phase_secs_left_at`。
     #[serde(default)]
     pub adjusted_time_left_in_phase: f64,
+    /// 上面那个快照对应的时刻（epoch 毫秒）。
+    ///
+    /// 曾误写为 `internal_now_in_phase`（camelCase 后是 `internalNowInPhase`）——
+    /// LCU 没有该字段，于是恒为 serde default 0，白白浪费了唯一能校正快照的信息。
     #[serde(default)]
-    pub internal_now_in_phase: f64,
+    pub internal_now_in_epoch_ms: f64,
     #[serde(default)]
     pub is_infinite: bool,
     #[serde(default)]

--- a/rank-analysis-app/src/components/gaming/BpDecisionBar.vue
+++ b/rank-analysis-app/src/components/gaming/BpDecisionBar.vue
@@ -45,6 +45,18 @@ const originLabel = computed(() => {
 
 const isFallback = computed(() => props.decision?.target?.origin.type === 'Fallback')
 
+/**
+ * 只有兜底来源才提供「存为规则」。
+ *
+ * 来源已经是规则时再存一条是有害的：规则遍历 first-match-wins（`evaluate.rs`
+ * 命中即 break），而保存是把新规则**追加到列表末尾**，于是新规则排在产生它的
+ * 那条老规则之后。新规则的条件（我的分路 [+ 一个关键敌方英雄]）在绝大多数
+ * 情况下是老规则的子集或等集——老规则匹配的场次新规则也匹配，先命中先 break，
+ * 新规则永远轮不到。而 `evidence` 缺失时（OP.GG 只给 top3 苦手，多数对局取不到）
+ * 草稿还会退化成一条「仅位置」的无条件规则，静默污染规则表。
+ */
+const canSaveRule = computed(() => isFallback.value)
+
 /** 负向依据文案：OP.GG 只有苦手数据，胜率恒 <50%，因此措辞是「仅 X%」 */
 const evidenceText = computed(() => {
   const e = props.decision?.target?.evidence
@@ -77,7 +89,9 @@ function rejectedText(r: BpRejected): string {
       <span class="bp-origin" :class="isFallback ? 'bp-origin-fallback' : 'bp-origin-rule'">
         ← {{ originLabel }}
       </span>
-      <button type="button" class="bp-save-rule" @click="$emit('save-rule')">存为规则</button>
+      <button v-if="canSaveRule" type="button" class="bp-save-rule" @click="$emit('save-rule')">
+        存为规则
+      </button>
     </div>
     <div v-else class="bp-main bp-empty">无可执行目标</div>
 

--- a/rank-analysis-app/src/components/gaming/BpDecisionBar.vue
+++ b/rank-analysis-app/src/components/gaming/BpDecisionBar.vue
@@ -25,12 +25,15 @@ const { getChampionUrl } = useAssetUrl()
 
 const actionLabel = computed(() => (props.decision?.action_type === 'Ban' ? 'BAN' : '选'))
 
-/** 标题：Auto 带倒计时，Advisory 降级为「建议 X」，已接管则明说 */
+/** 标题：Auto 且轮到我了才带倒计时，Advisory 降级为「建议 X」，已接管则明说 */
 const headline = computed(() => {
   const d = props.decision
   if (!d) return ''
   if (d.user_overridden) return `你已接管，本阶段不再自动${actionLabel.value}`
   if (d.mode === 'Advisory') return `建议 ${actionLabel.value}`
+  // 还没轮到我：快照照常产出（预选期就要提前 hover），但此刻计时器走的是别人
+  // 的回合，显示「Xs 后自动执行」等于给一个不会兑现的承诺。
+  if (!d.is_in_progress) return `轮到你时自动 ${actionLabel.value}`
   return `${Math.ceil(props.displaySecs)}s 后自动 ${actionLabel.value}`
 })
 

--- a/rank-analysis-app/src/components/gaming/__tests__/BpDecisionBar.spec.ts
+++ b/rank-analysis-app/src/components/gaming/__tests__/BpDecisionBar.spec.ts
@@ -24,6 +24,7 @@ function decision(overrides: Partial<BpDecision> = {}): BpDecision {
     time_left_secs: 8,
     execute_at_secs_left: 5,
     user_overridden: false,
+    is_in_progress: true,
     ...overrides
   }
 }
@@ -45,6 +46,15 @@ describe('BpDecisionBar', () => {
     const w = mountBar(decision({ mode: 'Advisory' }))
     expect(w.text()).toContain('建议 BAN')
     expect(w.text()).not.toContain('后自动')
+  })
+
+  // 回归：还没轮到我时计时器走的是别人的回合，倒计时会一路减到 0 却什么都不
+  // 发生——真机上用户先注意到的正是这个假承诺。
+  it('还没轮到我时不显示倒计时，只说明会在我的回合执行', () => {
+    const w = mountBar(decision({ is_in_progress: false }), 3)
+    expect(w.text()).toContain('轮到你时自动 BAN')
+    expect(w.text()).not.toContain('3s')
+    expect(w.text()).not.toContain('s 后自动')
   })
 
   it('Rule 来源显示规则名并用主色', () => {

--- a/rank-analysis-app/src/components/gaming/__tests__/BpDecisionBar.spec.ts
+++ b/rank-analysis-app/src/components/gaming/__tests__/BpDecisionBar.spec.ts
@@ -29,6 +29,19 @@ function decision(overrides: Partial<BpDecision> = {}): BpDecision {
   }
 }
 
+/** 兜底来源的决策——只有这种来源才该提供「存为规则」 */
+function fallbackDecision(overrides: Partial<BpDecision> = {}): BpDecision {
+  return decision({
+    target: {
+      champion_id: 64,
+      lock: true,
+      origin: { type: 'Fallback', pool_size: 8 },
+      evidence: null
+    },
+    ...overrides
+  })
+}
+
 const mountBar = (d: BpDecision | null, displaySecs = 8) =>
   mount(BpDecisionBar, { props: { decision: d, displaySecs } })
 
@@ -129,8 +142,16 @@ describe('BpDecisionBar', () => {
   })
 
   it('点击存为规则触发 emit', async () => {
-    const w = mountBar(decision())
+    const w = mountBar(fallbackDecision())
     await w.find('.bp-save-rule').trigger('click')
     expect(w.emitted('save-rule')).toHaveLength(1)
+  })
+
+  // 规则遍历是 first-match-wins（evaluate.rs 命中即 break），而保存是把新规则
+  // 追加到列表末尾。为一个「已经命中规则」的决策再存一条，产出的必然是被原规则
+  // 永久遮蔽的死规则；evidence 缺失时它还会退化成一条「仅位置」的无条件规则。
+  it('来源已是规则时不提供「存为规则」', () => {
+    const w = mountBar(decision())
+    expect(w.find('.bp-save-rule').exists()).toBe(false)
   })
 })

--- a/rank-analysis-app/src/composables/__tests__/useBpDecision.spec.ts
+++ b/rank-analysis-app/src/composables/__tests__/useBpDecision.spec.ts
@@ -82,6 +82,30 @@ describe('useBpDecision', () => {
     app.unmount()
   })
 
+  it('显示距离自动执行的时间，而不是阶段剩余时间', async () => {
+    invokeMock.mockResolvedValue(decision({ time_left_secs: 20, execute_at_secs_left: 5 }))
+    const phase = ref('ChampSelect')
+    const [result, app] = withSetup(() => useBpDecision(phase))
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(result.displaySecs.value).toBeGreaterThan(14.8)
+    expect(result.displaySecs.value).toBeLessThanOrEqual(15)
+
+    app.unmount()
+  })
+
+  it('重复读取同一后端快照时不重置插值基准', async () => {
+    invokeMock.mockResolvedValue(decision({ time_left_secs: 20, execute_at_secs_left: 5 }))
+    const phase = ref('ChampSelect')
+    const [result, app] = withSetup(() => useBpDecision(phase))
+
+    await vi.advanceTimersByTimeAsync(2100)
+    expect(invokeMock.mock.calls.length).toBeGreaterThanOrEqual(3)
+    expect(result.displaySecs.value).toBeLessThan(13.1)
+
+    app.unmount()
+  })
+
   it('阶段切换时决策归零', async () => {
     invokeMock.mockResolvedValue(decision())
     const phase = ref('ChampSelect')

--- a/rank-analysis-app/src/composables/__tests__/useBpDecision.spec.ts
+++ b/rank-analysis-app/src/composables/__tests__/useBpDecision.spec.ts
@@ -23,6 +23,7 @@ function decision(overrides: Partial<BpDecision> = {}): BpDecision {
     time_left_secs: 20,
     execute_at_secs_left: 5,
     user_overridden: false,
+    is_in_progress: true,
     ...overrides
   }
 }

--- a/rank-analysis-app/src/composables/useBpDecision.ts
+++ b/rank-analysis-app/src/composables/useBpDecision.ts
@@ -20,6 +20,7 @@ import {
 } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 import type { BpDecision } from '@renderer/types/bpDecision'
+import { deepEqual } from '@renderer/utils/deepEqual'
 
 /** 轮询间隔。比后端 2s 的产出快一档，让决策带对局面变化的反应更跟手 */
 const POLL_MS = 1000
@@ -33,7 +34,7 @@ export function useBpDecision(phase: MaybeRefOrGetter<string>): {
   displaySecs: ComputedRef<number>
 } {
   const decision = ref<BpDecision | null>(null)
-  /** 最近一次快照到达时的基准秒数与本地时刻 */
+  /** 最近一次新快照到达时，距离自动执行的基准秒数与本地时刻 */
   const baseSecs = ref(0)
   const baseAt = ref(0)
   /** 插值时钟，仅用于驱动 displaySecs 重算 */
@@ -55,9 +56,13 @@ export function useBpDecision(phase: MaybeRefOrGetter<string>): {
     try {
       const next = await invoke<BpDecision | null>('get_bp_decision')
       if (gen !== pollGeneration) return // stop() 已发生，丢弃迟到结果
+      const isNewSnapshot = next !== null && !deepEqual(next, decision.value)
       decision.value = next
-      if (next) {
-        baseSecs.value = next.time_left_secs
+      // 后端决策每 2 秒更新，前端每 1 秒轮询。同一份快照不能反复重置
+      // 插值基准，否则倒计时会每秒回跳。这里显示的是“距离自动执行”，
+      // 而不是客户端的整段 phase 剩余时间。
+      if (next && isNewSnapshot) {
+        baseSecs.value = Math.max(0, next.time_left_secs - next.execute_at_secs_left)
         baseAt.value = Date.now()
       }
     } catch {

--- a/rank-analysis-app/src/services/__tests__/bpRuleDraft.spec.ts
+++ b/rank-analysis-app/src/services/__tests__/bpRuleDraft.spec.ts
@@ -19,6 +19,7 @@ function decision(overrides: Partial<BpDecision> = {}): BpDecision {
     time_left_secs: 20,
     execute_at_secs_left: 5,
     user_overridden: false,
+    is_in_progress: true,
     ...overrides
   }
 }

--- a/rank-analysis-app/src/types/bpDecision.ts
+++ b/rank-analysis-app/src/types/bpDecision.ts
@@ -50,4 +50,11 @@ export interface BpDecision {
   time_left_secs: number
   execute_at_secs_left: number
   user_overridden: boolean
+  /**
+   * 是否真的轮到我了。
+   *
+   * 快照在还没轮到我时也会产出（预选期要提前 hover），因此倒计时类的展示
+   * 必须先看这个字段——否则会在别人的回合里承诺一个不会兑现的自动执行。
+   */
+  is_in_progress: boolean
 }


### PR DESCRIPTION
Closes #150

## 根因（真机采样定位，与本 PR 初版的归因不同）

LCU 的 `timer.adjustedTimeLeftInPhase` **是推送时刻的冻结快照，不是实时倒计时**。

2026-08-14 在国服真机上按秒直连 LCU 采样，抓到它在一个 25 秒的 pick 回合里恒为 22.6、**22 秒纹丝不动**；另一处冻在 25.0 十秒后直接跳到 9.0。执行判断 `time_left <= execute_at_secs_left`（默认 5s）拿这个死值去比，等于永远进不了窗口——自动 BP 整局静默的根因就在这里。

同一 payload 里的 `internalNowInEpochMs` 才是该快照对应的时刻，扣掉快照至今流逝的墙钟才是真实剩余：

```
真实剩余 = adjustedTimeLeftInPhase - (now - internalNowInEpochMs)
```

`Timer` 结构体原本写的是 `internal_now_in_phase`（camelCase 后是 `internalNowInPhase`）——LCU 没有这个字段，于是恒为 serde default 0，唯一能校正快照的信息被白白浪费了。

> 本 PR 初版认为病因是「1 秒 session 缓存使每秒轮询实际观察到 2 秒一跳，跨过了 `[3s,5s]` 窄窗口」。采样数据证伪了这个归因：绕过缓存拿到的仍是同一个冻结值。初版的两处改动（绕过缓存、去掉 `MIN_EXECUTE_SECS` 下限）予以保留——它们本身无害，且去掉 3 秒下限在时间源修好后仍是合理的容错。

## 改动

**时间源修复**
- `lcu/api/champion_select.rs`：`Timer` 的死字段 `internal_now_in_phase` 换成真实存在的 `internal_now_in_epoch_ms`
- `bp_decision/evaluate.rs`：新增纯函数 `phase_secs_left_at(timer, now_epoch_ms)`，按快照龄校正；字段缺失（旧客户端/异常 payload）时退回快照原值兜底

**顺带修另一个前端假承诺**
- 决策快照在还没轮到我时也会产出（预选期要提前 hover），但 `BpDecision` 没有把 `is_in_progress` 透传给前端，于是决策带在**别人的回合**里也显示「Xs 后自动执行」并一路减到 0，而后端 `should_lock` 有 `is_in_progress` 把关根本不会动手——UI 和后端对不上账
- 现在补上该字段，非本人回合改显示「轮到你时自动 BAN/选」

## 真机验证（两个独立测量互校）

```
app 日志      14:57:02.555  BP execute: pick 800 at 4.5s left
独立采样器    14:57:02.485  校正值 4.6s   (raw=15.4s  age=10.8s)
```

相差 70ms，读数在采样抖动内一致。采样器是独立进程直连 LCU、不经过 app 任何代码。**关键在 `raw=15.4s`：该值自 14:56:52 起已冻结 11 秒，旧代码在这一刻读到 15.4 判定「还早」，不动手。**

修复前后同一台机器、同一账号：
- 修复前 3 局：全程只有 `BP hover sync`，`BP execute` 一次都没有，每局都要手动选
- 修复后：`BP execute` 按时触发，且触发时刻的剩余时间与独立采样一致

## Test plan
- [x] `npm run check` passes（0 errors）
- [x] `npm run test` passes（785 tests / 81 files）
- [x] `cargo test` passes（343 passed, 0 failed）
- [x] 新增 4 个 Rust 测试，含用真机采样数据写的回归：raw 冻在 25.0、快照龄 15.5s → 必须得出 9.5s；以及跨 LCU 刷新快照的连续性（9.5 → 8.5 无跳变）
- [x] 新增 1 个前端回归测试：`is_in_progress=false` 时不显示倒计时
- [x] Manual: 真机排位选人期实测，见上方验证数据