### PR TITLE
fix(ci): migrate patch notes extraction to DashScope

### DIFF
--- a/.github/workflows/patch-notes-data.yml
+++ b/.github/workflows/patch-notes-data.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: write
-  models: read
 
 concurrency:
   group: patch-notes-data
@@ -33,7 +32,7 @@ jobs:
 
       - name: Generate patch notes data
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
         run: node scripts/patch-notes/run.mjs
 
       # ref 守卫：从非 main 分支 dispatch（如合并前验证）时绝不推送，防止把未审代码快进上 main
@@ -55,7 +54,7 @@ jobs:
           git push origin HEAD:main
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
-      # GITHUB_TOKEN 的 push 不触发 sync-gitcode（GitHub 防递归），这里自带镜像推送
+      # 用于推送的 GITHUB_TOKEN 不触发 sync-gitcode（GitHub 防递归），这里自带镜像推送
       - name: Mirror to GitCode
         if: steps.commit.outputs.pushed == 'true'
         env:

--- a/docs/superpowers/specs/2026-07-18-cn-patch-notes-ai-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-18-cn-patch-notes-ai-pipeline-design.md
@@ -14,8 +14,8 @@
    规则筛选会漏，导致中文快照停留在旧版本；
 2. **方向判定保守**：无 `X → Y` 数值对比时靠关键词启发式，误差不可控。
 
-本设计将「拉取 + 解析 + 方向判定」整体搬进 GitHub Actions，由 AI（GitHub
-Models）做语义抽取，产物为仓库内受校验的静态 JSON；客户端只消费成品数据，
+本设计将「拉取 + 解析 + 方向判定」整体搬进 GitHub Actions，由 AI（DashScope
+通义千问）做语义抽取，产物为仓库内受校验的静态 JSON；客户端只消费成品数据，
 不再包含任何 HTML 解析逻辑。脆弱环节从全体用户机器收敛到单一可观测的 CI。
 
 **非目标**：版本改动独立浏览页（archive 数据为其预留，但本期不做）；Wiki
@@ -28,7 +28,7 @@ GitHub Actions（cron 每 6h + workflow_dispatch）
   1. 拉 CMC 频道列表（target=24，官方公告频道）
   2. 宽松筛选候选文章（含「更新公告」即候选，AI 负责确认）
   3. 拉文章页 → GBK 解码 → 去标签取纯文本
-  4. GitHub Models 结构化抽取（GITHUB_TOKEN，permissions: models: read）
+  4. DashScope 结构化抽取（DASHSCOPE_API_KEY）
   5. 校验闸门（Schema + 英雄名对照 + 数量边界）
   6. docid 有变化才 commit data/patch-notes/ → push main
        └→ 现有 sync-gitcode.yml 自动镜像到 GitCode
@@ -46,9 +46,9 @@ GitHub Actions（cron 每 6h + workflow_dispatch）
   近 4 个月全部 5 期正式版本公告均带跳转链，且站内帖无稳定正文接口（CMC 详情
   端点返回 p0 error，gicp 模式 404）；不停机小补丁通常无英雄平衡改动，可接受。
 - `extract.mjs`：文章 HTML → 纯文本（GBK 解码、`<br>` 转行、去标签、实体解码——
-  逻辑自 `cn_patch_notes.rs` 平移）；调 GitHub Models
-  （`https://models.github.ai/inference/chat/completions`，模型 `openai/gpt-4o-mini`
-  级别），system prompt 要求输出严格 JSON：判断该文是否为端游版本更新公告、
+  逻辑自 `cn_patch_notes.rs` 平移）；调 DashScope OpenAI 兼容端点
+  （`https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions`，模型
+  `qwen-flash`），system prompt 要求输出严格 JSON：判断该文是否为端游版本更新公告、
   提取每个英雄的中文名 / 改动方向（buff|nerf|adjusted）/ 改动条目原文数组。
 - `validate.mjs`：校验闸门（见下）。
 - `run.mjs`：编排 + docid 对比 + 写文件。
@@ -100,11 +100,11 @@ data/patch-notes/
 ### 4. Workflow `.github/workflows/patch-notes-data.yml`
 
 - 触发：`schedule`（每 6h）+ `workflow_dispatch`；
-- `permissions: contents: write, models: read`；
+- `permissions: contents: write`；
 - 步骤：checkout → node scripts/patch-notes/run.mjs → 若 `cn-latest.json` 有
   diff 则以 bot 身份 commit + push main（commit message
   `chore(data): 更新国服英雄改动 <patchLabel>`）；
-- GITHUB_TOKEN 的 push **不会触发其他 workflow**（GitHub 防递归机制），
+- 用于推送的 GITHUB_TOKEN **不会触发其他 workflow**（GitHub 防递归机制），
   sync-gitcode 不会跟跑；因此本 workflow 自带「推 GitCode 镜像」一步，
   复用现有 `GITCODE_TOKEN` secret，与 sync-gitcode.yml 同款推法；
 - 并发组 `patch-notes-data`，`cancel-in-progress: true`。
@@ -145,7 +145,7 @@ data/patch-notes/
   （21 天整）、缓存降级链（复用现有测试模式）、command 合并优先级
   （CN 命中优先于 Wiki）；
 - 端到端验收：手动 `workflow_dispatch` 一次真跑（验证 runner 可达 qq.com 与
-  GitHub Models 配额），确认产物 JSON 落库；应用内选人页看到中文明细。
+  DashScope API 配额），确认产物 JSON 落库；应用内选人页看到中文明细。
 
 ## 里程碑
 

--- a/scripts/patch-notes/extract.mjs
+++ b/scripts/patch-notes/extract.mjs
@@ -1,19 +1,19 @@
 /**
- * 公告 HTML → 纯文本，以及 GitHub Models 结构化抽取调用。
+ * 公告 HTML → 纯文本，以及 DashScope 结构化抽取调用。
  * AI 负责「理解」：判定是否端游版本公告、提取英雄段、判方向；
  * 文本预处理只做机械转换，不做任何语义筛选。
  */
 
-export const MODELS_URL = 'https://models.github.ai/inference/chat/completions'
+/** DashScope 的 OpenAI 兼容 chat completions 端点。 */
+export const DASHSCOPE_URL =
+  'https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions'
+// 保留原导出名，兼容已有脚本；实际值与当前端点一致。
+export const MODELS_URL = DASHSCOPE_URL
 /**
- * 2026-07-29 横评（同一篇 7月30日公告，原文 11 个英雄 / 卑尔维斯 49 条改动）：
- * - gpt-4o-mini：只抽到 8 个英雄、卑尔维斯 36 条，且把加强削弱并存的改动一律判成 nerf
- * - gpt-4.1：11 个英雄，卑尔维斯 43 条，仍有遗漏
- * - gpt-4.1-mini：抽出 23 个英雄，把非英雄段落也算了进来
- * - gpt-4o：11 个英雄、卑尔维斯 49 条与原文精确对齐，direction 判定也最准，且最快
- * 属 high 档 rate limit，但只在 docid 变化时才真调模型（约每月 2 次），配额充裕。
+ * qwen-flash 是仓库内其他 AI 功能的默认模型，已验证支持该兼容端点的 JSON 模式，
+ * 且足以覆盖公告抽取所需的上下文长度。
  */
-export const MODEL_ID = 'openai/gpt-4o'
+export const MODEL_ID = 'qwen-flash'
 
 /**
  * 公告页实际出现的 HTML 实体。
@@ -91,7 +91,7 @@ export function parseModelJson(content) {
 }
 
 export async function callModel(articleText, token, fetchFn = fetch) {
-  const res = await fetchFn(MODELS_URL, {
+  const res = await fetchFn(DASHSCOPE_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({
@@ -100,16 +100,16 @@ export async function callModel(articleText, token, fetchFn = fetch) {
       response_format: { type: 'json_object' },
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
-        // 60k 字符 ≈ 30k+ token，gpt-4o-mini 128k 上限内；公告实测 20-50KB
+        // 60k 字符约 30k+ token；公告实测 20-50KB，留出 prompt 与回包空间。
         { role: 'user', content: articleText.slice(0, 60000) }
       ]
     })
   })
   if (!res.ok) {
-    throw new Error(`GitHub Models HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`)
+    throw new Error(`DashScope HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`)
   }
   const data = await res.json()
   const content = data?.choices?.[0]?.message?.content
-  if (!content) throw new Error('GitHub Models: 回包无 content')
+  if (!content) throw new Error('DashScope: 回包无 content')
   return parseModelJson(content)
 }

--- a/scripts/patch-notes/extract.test.mjs
+++ b/scripts/patch-notes/extract.test.mjs
@@ -1,6 +1,13 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { htmlToText, parseModelJson, callModel, MODELS_URL, MODEL_ID } from './extract.mjs'
+import {
+  htmlToText,
+  parseModelJson,
+  callModel,
+  DASHSCOPE_URL,
+  MODELS_URL,
+  MODEL_ID
+} from './extract.mjs'
 
 // 按真实公告页结构裁剪（与 Rust cn_patch_notes.rs 原 fixture 同源）
 const HTML = `
@@ -33,7 +40,7 @@ test('parseModelJson 容忍代码栅栏包装', () => {
   assert.deepEqual(parseModelJson('{"a":1}'), { a: 1 })
 })
 
-test('callModel 发 POST 到 GitHub Models 并解析回包', async () => {
+test('callModel 发 POST 到 DashScope 并解析回包', async () => {
   let captured = null
   const fetchFn = async (url, init) => {
     captured = { url, init }
@@ -45,7 +52,10 @@ test('callModel 发 POST 到 GitHub Models 并解析回包', async () => {
     }
   }
   const out = await callModel('正文', 'tok', fetchFn)
-  assert.equal(captured.url, MODELS_URL)
+  assert.equal(captured.url, DASHSCOPE_URL)
+  assert.equal(MODELS_URL, DASHSCOPE_URL)
+  assert.equal(captured.init.method, 'POST')
+  assert.equal(captured.init.headers['Content-Type'], 'application/json')
   assert.equal(JSON.parse(captured.init.body).model, MODEL_ID)
   assert.equal(JSON.parse(captured.init.body).temperature, 0)
   assert.equal(captured.init.headers.Authorization, 'Bearer tok')
@@ -54,5 +64,5 @@ test('callModel 发 POST 到 GitHub Models 并解析回包', async () => {
 
 test('callModel 非 200 抛错', async () => {
   const fetchFn = async () => ({ ok: false, status: 429, text: async () => 'rate limited' })
-  await assert.rejects(() => callModel('x', 'tok', fetchFn), /429/)
+  await assert.rejects(() => callModel('x', 'tok', fetchFn), /DashScope HTTP 429/)
 })

--- a/scripts/patch-notes/run.mjs
+++ b/scripts/patch-notes/run.mjs
@@ -20,9 +20,9 @@ function readExisting() {
   }
 }
 
-const token = process.env.GITHUB_TOKEN
+const token = process.env.DASHSCOPE_API_KEY
 if (!token) {
-  console.error('缺少 GITHUB_TOKEN 环境变量')
+  console.error('缺少 DASHSCOPE_API_KEY 环境变量')
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary
- replace the retired GitHub Models endpoint with the existing DashScope OpenAI-compatible endpoint
- use `qwen-flash` and `DASHSCOPE_API_KEY`, and remove the obsolete `models: read` permission
- update request tests and the patch-notes pipeline design document

## Root cause
`Patch Notes Data` started failing when a new LOL announcement triggered the model call. GitHub Models returned HTTP 410 (`github_models_retirement_brownout`) after the service retirement.

## Verification
- `node --test scripts/patch-notes/*.test.mjs` (26 passed)
- `npm run typecheck`
- YAML parse and `git diff --check`
- manual `Patch Notes Data` run successfully extracted 7 champions from the August 13 announcement