### PR TITLE
fix(bp): 限定可提交阶段、pick 提前 hover、丢弃迟到 tick

### DIFF
--- a/rank-analysis-app/src-tauri/src/automation.rs
+++ b/rank-analysis-app/src-tauri/src/automation.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tokio::time::interval;
+use tokio::time::{interval, MissedTickBehavior};
 
 use crate::config::{extract_bool, get_config, register_on_change_callback, Value};
 use crate::constant::game::{CHAMPSELECT, LOBBY, MATCHMAKING, READYCHECK};
@@ -163,6 +163,7 @@ use std::future::Future;
 async fn start_accept_match_automation() {
     log::info!("Starting accept match automation");
     let mut ticker = interval(Duration::from_millis(100));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         ticker.tick().await;
@@ -204,6 +205,10 @@ async fn start_accept_match_automation() {
 async fn start_match_automation() {
     log::info!("Starting match automation");
     let mut ticker = interval(Duration::from_secs(1));
+    // 迟到的 tick 只该丢弃，不该重放：tokio 默认的 MissedTickBehavior::Burst 会在
+    // 运行时被阻塞后把攒下的 tick 一次性补发。真机 2026-08-15 实测，自动 BP 因此在
+    // ~1 秒内连发 8 次 PATCH（tick 空档 6.2s 后以 ~18ms 间隔爆发）。
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let mut last_search_state = String::new();
     let mut auto_match_enabled = true;
 
@@ -387,6 +392,10 @@ async fn is_leader(members: &[crate::lcu::api::lobby::Member]) -> Result<bool, S
 async fn start_champion_select_automation() {
     log::info!("Starting champion select automation");
     let mut ticker = interval(Duration::from_secs(1));
+    // 迟到的 tick 只该丢弃，不该重放：tokio 默认的 MissedTickBehavior::Burst 会在
+    // 运行时被阻塞后把攒下的 tick 一次性补发。真机 2026-08-15 实测，自动 BP 因此在
+    // ~1 秒内连发 8 次 PATCH（tick 空档 6.2s 后以 ~18ms 间隔爆发）。
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         ticker.tick().await;
@@ -491,13 +500,10 @@ async fn load_ban_rules() -> Vec<crate::command::rule_config::BanRule> {
 /// 2. 快照的动作类型与本任务不符则跳过
 /// 3. 交给 `apply_bp_decision`：hover 同步 → 到点锁定
 async fn start_select_champion() -> Result<(), String> {
-    let Some(decision) = crate::bp_decision::store::read() else {
-        log::debug!("No BP decision snapshot yet, skipping this tick");
+    let Some(decision) = crate::bp_decision::store::read_pick() else {
+        log::debug!("No BP pick decision snapshot yet, skipping this tick");
         return Ok(());
     };
-    if decision.action_type != crate::bp_decision::types::BpActionType::Pick {
-        return Ok(());
-    }
     let select_session = get_fresh_champion_select_session().await?;
     apply_bp_decision(&select_session, &decision).await
 }
@@ -518,6 +524,10 @@ async fn start_select_champion() -> Result<(), String> {
 async fn start_champion_ban_automation() {
     log::info!("Starting champion ban automation");
     let mut ticker = interval(Duration::from_secs(1));
+    // 迟到的 tick 只该丢弃，不该重放：tokio 默认的 MissedTickBehavior::Burst 会在
+    // 运行时被阻塞后把攒下的 tick 一次性补发。真机 2026-08-15 实测，自动 BP 因此在
+    // ~1 秒内连发 8 次 PATCH（tick 空档 6.2s 后以 ~18ms 间隔爆发）。
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         ticker.tick().await;
@@ -598,6 +608,7 @@ async fn start_bp_decision_automation(app: tauri::AppHandle) {
 
     log::info!("Starting BP decision evaluation (always-on)");
     let mut ticker = interval(Duration::from_secs(2));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     // OP.GG 快照跨 tick 复用：选人期内只取一次（按模式），失败也只试一次——
     // 失败重试交给下一局（离开选人期时清空），避免 2s 热循环里对不可达的
@@ -663,36 +674,53 @@ async fn start_bp_decision_automation(app: tauri::AppHandle) {
         let pick_on = switch_enabled("settings.auto.pickChampionSwitch").await;
         let ban_on = switch_enabled("settings.auto.banChampionSwitch").await;
 
-        let pending = evaluate::find_my_pending_action(&session);
-        let pending_is_ban = pending
-            .map(|p| p.action_type == crate::bp_decision::types::BpActionType::Ban)
-            .unwrap_or(false);
-        let mode = if (pending_is_ban && ban_on) || (!pending_is_ban && pick_on) {
-            BpMode::Auto
-        } else {
-            BpMode::Advisory
-        };
+        use crate::bp_decision::types::BpActionType;
 
-        let ctx = evaluate::BpContext {
-            session: &session,
-            my_puuid: &my_summoner.puuid,
-            pick_rules: &pick_rules,
-            ban_rules: &ban_rules,
-            pick_pool: &pick_pool,
-            ban_pool: &ban_pool,
-            snapshot: snapshot.as_deref(),
-            mode,
-            execute_at_secs_left: DEFAULT_EXECUTE_AT_SECS_LEFT,
-            last_hovered: store::last_hovered(),
+        // ban 与 pick 各求一次值：两条执行轨道各读各的，pick 的 hover 才能在 ban
+        // 阶段就开始（真机现象「预选期不预选」的根因是两者共用了「当前那一个」动作）。
+        let last_hovered = store::last_hovered();
+        let eval_for = |action_type: BpActionType, auto_on: bool| {
+            let pending = evaluate::find_my_pending_action_of_type(&session, action_type)?;
+            let ctx = evaluate::BpContext {
+                session: &session,
+                my_puuid: &my_summoner.puuid,
+                pick_rules: &pick_rules,
+                ban_rules: &ban_rules,
+                pick_pool: &pick_pool,
+                ban_pool: &ban_pool,
+                snapshot: snapshot.as_deref(),
+                mode: if auto_on {
+                    BpMode::Auto
+                } else {
+                    BpMode::Advisory
+                },
+                execute_at_secs_left: DEFAULT_EXECUTE_AT_SECS_LEFT,
+                last_hovered,
+            };
+            let mut d = evaluate::evaluate_for_action(&ctx, pending)?;
+            // 接管标记以执行侧的粘性记录为准：一旦判定接管，即使用户随后撤回 hover
+            // (detect_override 重算为 false)，本阶段也不会再自动执行——快照必须如实
+            // 反映，否则决策带会承诺一次永远不会发生的自动锁定
+            d.user_overridden = d.user_overridden || store::is_overridden(pending.action_id);
+            Some((pending.action_id, d))
         };
-        let mut decision = evaluate::evaluate_bp_decision(&ctx);
-        // 接管标记以执行侧的粘性记录为准：一旦判定接管，即使用户随后撤回 hover
-        // (detect_override 重算为 false)，本阶段也不会再自动执行——快照必须如实
-        // 反映，否则决策带会承诺一次永远不会发生的自动锁定
-        if let (Some(d), Some(p)) = (decision.as_mut(), pending) {
-            d.user_overridden = d.user_overridden || store::is_overridden(p.action_id);
-        }
-        store::write(decision);
+        let ban_decision = eval_for(BpActionType::Ban, ban_on);
+        let pick_decision = eval_for(BpActionType::Pick, pick_on);
+
+        // 展示用的「当前」决策：复用已算好的两份，按 find_my_pending_action 的
+        // 口径挑一份，避免第三次求值。
+        let current = evaluate::find_my_pending_action(&session).and_then(|p| {
+            [ban_decision.as_ref(), pick_decision.as_ref()]
+                .into_iter()
+                .flatten()
+                .find(|(id, _)| *id == p.action_id)
+                .map(|(_, d)| d.clone())
+        });
+        store::write(
+            current,
+            ban_decision.map(|(_, d)| d),
+            pick_decision.map(|(_, d)| d),
+        );
     }
 }
 
@@ -719,11 +747,18 @@ fn should_lock(
     d: &crate::bp_decision::types::BpDecision,
     time_left_secs: f64,
     is_in_progress: bool,
+    timer_phase: &str,
 ) -> bool {
     let Some(t) = d.target.as_ref() else {
         return false;
     };
-    is_in_progress && t.lock && time_left_secs > 0.0 && time_left_secs <= d.execute_at_secs_left
+    // 阶段门不可省：PLANNING 的独立计时器同样会走进 (0, execute_at] 窗口，而那时
+    // 提交会被 LCU 静默无视（真机 2026-08-15 实测）。详见 evaluate::is_actionable_phase。
+    crate::bp_decision::evaluate::is_actionable_phase(timer_phase)
+        && is_in_progress
+        && t.lock
+        && time_left_secs > 0.0
+        && time_left_secs <= d.execute_at_secs_left
 }
 
 /// 按决策快照同步 hover 并在到点时锁定。
@@ -737,15 +772,12 @@ async fn apply_bp_decision(
 ) -> Result<(), String> {
     use crate::bp_decision::{evaluate, store, types::BpActionType};
 
-    let Some(pending) = evaluate::find_my_pending_action(session) else {
+    // 按决策自身的类型定位我的动作,而不是「当前那一个」——ban 与 pick 是两条独立
+    // 轨道,pick 的 hover 要在选人期一开始就做,不能因为 ban 尚未完成而空转。
+    let Some(pending) = evaluate::find_my_pending_action_of_type(session, decision.action_type)
+    else {
         return Ok(());
     };
-
-    // 快照最旧可比实时 session 落后一个 tick,相位切换(ban→pick)恰落在窗口里:
-    // 类型不一致时本 tick 什么都不做,等下一 tick 的新快照
-    if decision.action_type != pending.action_type {
-        return Ok(());
-    }
 
     // 接管检测用实时数据:用户在快照生成后的 2s 窗口内抢过方向盘也要立即退让。
     // 快照里的 user_overridden 是 2s 前算的,只用于展示与本 tick 的保守短路,
@@ -793,16 +825,17 @@ async fn apply_bp_decision(
     let timer = &session.timer;
     // real_time_left: 本 tick 实际参与到点判断的剩余秒数,None = 无计时器模式。
     // 只为下面的执行日志保留——那行日志是真机核对毫秒假设的唯一证据源,必须打真值。
+    let actionable = crate::bp_decision::evaluate::is_actionable_phase(&timer.phase);
     let (lock_now, real_time_left): (bool, Option<f64>) = if timer.is_infinite {
         // 无计时器模式(自定义房间等):退回「轮到我就执行」,与旧实现行为一致
-        (pending.is_in_progress && target.lock, None)
+        (actionable && pending.is_in_progress && target.lock, None)
     } else {
         let time_left = crate::bp_decision::evaluate::phase_secs_left(timer);
         if time_left <= 0.0 {
             // timer 字段缺失(serde default 全 0)或已归零:宁可不动手,但要留下现场;
-            // 只在真轮到我(is_in_progress)时才打 warn——否则一个坏 timer 的会话
-            // 会在预选期每 2s 刷屏,而那时压根还没到需要提醒的时候
-            if pending.is_in_progress {
+            // 只在真轮到我、且处于可提交阶段时才打 warn——否则 PLANNING 阶段
+            // 归零、或一个坏 timer 的会话,会在压根还没轮到动手时每 tick 刷屏
+            if actionable && pending.is_in_progress {
                 log::warn!(
                     "BP timer unusable (time_left={:.1}), skip auto lock",
                     time_left
@@ -811,7 +844,7 @@ async fn apply_bp_decision(
             (false, Some(time_left))
         } else {
             (
-                should_lock(decision, time_left, pending.is_in_progress),
+                should_lock(decision, time_left, pending.is_in_progress, &timer.phase),
                 Some(time_left),
             )
         }
@@ -857,13 +890,10 @@ async fn switch_enabled(key: &str) -> bool {
 /// 2. 快照的动作类型与本任务不符则跳过
 /// 3. 交给 `apply_bp_decision`：hover 同步 → 到点锁定
 async fn start_ban_champion() -> Result<(), String> {
-    let Some(decision) = crate::bp_decision::store::read() else {
-        log::debug!("No BP decision snapshot yet, skipping this tick");
+    let Some(decision) = crate::bp_decision::store::read_ban() else {
+        log::debug!("No BP ban decision snapshot yet, skipping this tick");
         return Ok(());
     };
-    if decision.action_type != crate::bp_decision::types::BpActionType::Ban {
-        return Ok(());
-    }
     let select_session = get_fresh_champion_select_session().await?;
     apply_bp_decision(&select_session, &decision).await
 }
@@ -1172,27 +1202,69 @@ mod bp_execution_tests {
         }
     }
 
+    /// 绝大多数用例只关心时间/回合维度，阶段固定为可提交的 BAN_PICK；
+    /// 阶段维度本身由 `should_not_lock_outside_ban_pick_phase` 单独覆盖。
+    fn lock_in_ban_pick(
+        d: &crate::bp_decision::types::BpDecision,
+        time_left: f64,
+        is_in_progress: bool,
+    ) -> bool {
+        should_lock(d, time_left, is_in_progress, "BAN_PICK")
+    }
+
     #[test]
     fn should_lock_after_reaching_threshold() {
         // 还早 → 不锁
-        assert!(!should_lock(
+        assert!(!lock_in_ban_pick(
             &decision(BpMode::Auto, 20.0, false),
             20.0,
             true
         ));
         // 到点 → 锁
-        assert!(should_lock(&decision(BpMode::Auto, 5.0, false), 5.0, true));
-        assert!(should_lock(&decision(BpMode::Auto, 3.5, false), 3.5, true));
+        assert!(lock_in_ban_pick(
+            &decision(BpMode::Auto, 5.0, false),
+            5.0,
+            true
+        ));
+        assert!(lock_in_ban_pick(
+            &decision(BpMode::Auto, 3.5, false),
+            3.5,
+            true
+        ));
         // 即使一次采样从 5s 以上跳到 3s 以下，也仍应执行
-        assert!(should_lock(&decision(BpMode::Auto, 2.9, false), 2.9, true));
+        assert!(lock_in_ban_pick(
+            &decision(BpMode::Auto, 2.9, false),
+            2.9,
+            true
+        ));
         // 已归零 → 不再发送无效请求
-        assert!(!should_lock(&decision(BpMode::Auto, 0.0, false), 0.0, true));
+        assert!(!lock_in_ban_pick(
+            &decision(BpMode::Auto, 0.0, false),
+            0.0,
+            true
+        ));
         // 没轮到我 → 不锁
-        assert!(!should_lock(
+        assert!(!lock_in_ban_pick(
             &decision(BpMode::Auto, 4.0, false),
             4.0,
             false
         ));
+    }
+
+    /// 真机回归（2026-08-15）：LCU 在 PLANNING 期间就把 ban action 标成
+    /// is_in_progress，而 PLANNING 有自己的 12 秒计时器，同样会走进执行窗口。
+    /// 当时因此发出了一次被 LCU 静默无视的 ban，20 秒后 BAN_PICK 才真正成功。
+    #[test]
+    fn should_not_lock_outside_ban_pick_phase() {
+        let d = decision(BpMode::Auto, 4.0, false);
+        assert!(
+            !should_lock(&d, 4.0, true, "PLANNING"),
+            "PLANNING 的独立倒计时进了窗口也不能提交"
+        );
+        assert!(!should_lock(&d, 4.0, true, "FINALIZATION"));
+        assert!(should_lock(&d, 4.0, true, "BAN_PICK"));
+        // 字段缺失 → 不阻拦，退回加入阶段门之前的行为
+        assert!(should_lock(&d, 4.0, true, ""));
     }
 
     // 钉死 should_lock 的实时语义:传参才是决策依据,快照里的 time_left_secs
@@ -1203,13 +1275,17 @@ mod bp_execution_tests {
     #[test]
     fn should_lock_when_real_time_param_is_within_window_even_if_snapshot_is_stale_and_early() {
         // 快照写 20s(早),但实时传参 4.0s(到点)→ 应锁
-        assert!(should_lock(&decision(BpMode::Auto, 20.0, false), 4.0, true));
+        assert!(lock_in_ban_pick(
+            &decision(BpMode::Auto, 20.0, false),
+            4.0,
+            true
+        ));
     }
 
     #[test]
     fn should_not_lock_when_real_time_param_is_early_even_if_snapshot_is_stale_and_at_threshold() {
         // 快照写 4s(到点),但实时传参 20.0s(还早)→ 不应锁
-        assert!(!should_lock(
+        assert!(!lock_in_ban_pick(
             &decision(BpMode::Auto, 4.0, false),
             20.0,
             true
@@ -1228,7 +1304,7 @@ mod bp_execution_tests {
         let mut d = decision(BpMode::Auto, 4.0, false);
         d.target.as_mut().unwrap().lock = false;
         assert!(
-            !should_lock(&d, 4.0, true),
+            !lock_in_ban_pick(&d, 4.0, true),
             "lock=false 的规则只 hover，不自动确定"
         );
     }

--- a/rank-analysis-app/src-tauri/src/bp_decision/evaluate.rs
+++ b/rank-analysis-app/src-tauri/src/bp_decision/evaluate.rs
@@ -41,6 +41,49 @@ pub fn phase_secs_left(timer: &Timer) -> f64 {
     phase_secs_left_at(timer, now_epoch_ms)
 }
 
+/// LCU 选人期真正允许提交 ban/pick 的计时器阶段。
+///
+/// `timer.phase` 会走 `PLANNING`（预选宣告）→ `BAN_PICK` → `FINALIZATION`（确认），
+/// **每个阶段都有自己独立的倒计时**。坑在于 LCU 早在 `PLANNING` 期间就把 ban
+/// action 全部标成 `isInProgress=true`，而该阶段的 12 秒计时器同样会走到 5 秒
+/// 以内——真机实测（2026-08-15）由此触发过一次无效执行：PATCH 被 LCU 静默无视，
+/// 直到 20 秒后真正的 `BAN_PICK` 阶段才成功，期间界面还显示了一个走到 0 的假倒计时。
+///
+/// 空字符串 = 字段缺失/旧客户端，此时不阻拦，退回加入本判断前的行为。
+pub fn is_actionable_phase(timer_phase: &str) -> bool {
+    timer_phase.is_empty() || timer_phase == "BAN_PICK"
+}
+
+/// 找到当前用户尚未完成的、**指定类型**的那个 BP 动作。
+///
+/// 与 [`find_my_pending_action`] 的区别：后者回答「现在该看哪个动作」（供展示），
+/// 本函数回答「我的 ban / 我的 pick 分别是哪个」（供执行）。ban 与 pick 是两条
+/// 独立轨道——pick 的 hover 应当在选人期一开始就做，不该因为 ban 尚未完成而空转。
+pub fn find_my_pending_action_of_type(
+    session: &SelectSession,
+    action_type: BpActionType,
+) -> Option<MyPendingAction> {
+    let my_cell = session.local_player_cell_id;
+    session
+        .actions
+        .iter()
+        .flatten()
+        .filter(|a| a.actor_cell_id == my_cell && !a.completed)
+        .find_map(|a| {
+            let ty = match a.action_type.as_str() {
+                "ban" => BpActionType::Ban,
+                "pick" => BpActionType::Pick,
+                _ => return None,
+            };
+            (ty == action_type).then_some(MyPendingAction {
+                action_id: a.id,
+                action_type: ty,
+                is_in_progress: a.is_in_progress,
+                champion_id: a.champion_id,
+            })
+        })
+}
+
 /// 找到当前用户尚未完成的那个 BP 动作。
 ///
 /// 优先返回 `is_in_progress` 的（轮到我了），否则返回第一个未完成的
@@ -268,6 +311,14 @@ fn rejection_for(champion_id: i32, u: Unavailable) -> BpRejected {
 /// 3. 无论走哪条路，都尝试为目标附上 evidence（面对当前阵容的最差对位）
 pub fn evaluate_bp_decision(ctx: &BpContext) -> Option<BpDecision> {
     let pending = find_my_pending_action(ctx.session)?;
+    evaluate_for_action(ctx, pending)
+}
+
+/// 针对**指定**的待办动作求值。
+///
+/// 从 [`evaluate_bp_decision`] 拆出来：ban 与 pick 是两条独立轨道，各自的执行
+/// 任务需要各自的决策，不能共用「当前那一个」动作（否则 ban 阶段 pick 全程空转）。
+pub fn evaluate_for_action(ctx: &BpContext, pending: MyPendingAction) -> Option<BpDecision> {
     let unavailable = unavailable_map(ctx.session);
     let my_position = detect_my_position(ctx.session, ctx.my_puuid);
     let enemy_ids = enemy_champion_ids(ctx.session);
@@ -367,7 +418,10 @@ pub fn evaluate_bp_decision(ctx: &BpContext) -> Option<BpDecision> {
         time_left_secs: phase_secs_left(&ctx.session.timer),
         execute_at_secs_left: ctx.execute_at_secs_left,
         user_overridden: detect_override(pending.champion_id, ctx.last_hovered),
-        is_in_progress: pending.is_in_progress,
+        // 与 is_actionable_phase 相与：LCU 在 PLANNING 期间就把 ban action 标成
+        // in-progress，但那时提交无效。对前端而言「轮到我了」必须等价于「现在
+        // 倒计时归零就真的会执行」，否则决策带又会给出不会兑现的承诺。
+        is_in_progress: pending.is_in_progress && is_actionable_phase(&ctx.session.timer.phase),
     })
 }
 
@@ -914,6 +968,45 @@ mod tests {
         assert_eq!(p.action_id, 11);
         assert_eq!(p.action_type, BpActionType::Ban);
         assert!(p.is_in_progress);
+    }
+
+    /// 真机现象：ban 阶段 pick 任务全程空转，hover 要等 ban 完成后才发生。
+    /// 根因是执行侧只会拿到「当前那一个」动作；按类型定位后两条轨道各走各的。
+    #[test]
+    fn find_pending_of_type_finds_my_pick_while_ban_in_progress() {
+        let s = session(vec![
+            vec![action(0, 11, 0, false, true, "ban", true)],
+            vec![action(0, 10, 0, false, false, "pick", true)],
+        ]);
+        let pick = find_my_pending_action_of_type(&s, BpActionType::Pick).unwrap();
+        assert_eq!(pick.action_id, 10);
+        assert!(!pick.is_in_progress, "还没轮到我 pick");
+
+        let ban = find_my_pending_action_of_type(&s, BpActionType::Ban).unwrap();
+        assert_eq!(ban.action_id, 11);
+        assert!(ban.is_in_progress);
+    }
+
+    #[test]
+    fn find_pending_of_type_skips_completed_and_others_actions() {
+        let s = session(vec![vec![
+            action(0, 10, 64, true, false, "pick", true), // 我的，已完成
+            action(1, 20, 0, false, true, "pick", true),  // 别人的
+        ]]);
+        assert!(find_my_pending_action_of_type(&s, BpActionType::Pick).is_none());
+    }
+
+    /// LCU 在 PLANNING（预选宣告）期间就把 ban action 标成 is_in_progress，
+    /// 且该阶段有自己的 12 秒计时器。真机上它走到 <=5s 时触发了一次无效执行
+    /// （PATCH 被 LCU 无视），随后真正的 BAN_PICK 阶段才成功——期间界面还显示
+    /// 了一个会走到 0 的倒计时。只有 BAN_PICK 才是可提交阶段。
+    #[test]
+    fn only_ban_pick_phase_is_actionable() {
+        assert!(is_actionable_phase("BAN_PICK"));
+        assert!(!is_actionable_phase("PLANNING"));
+        assert!(!is_actionable_phase("FINALIZATION"));
+        // 字段缺失（旧客户端/异常 payload）不阻拦，退回修改前的行为
+        assert!(is_actionable_phase(""));
     }
 
     #[test]

--- a/rank-analysis-app/src-tauri/src/bp_decision/store.rs
+++ b/rank-analysis-app/src-tauri/src/bp_decision/store.rs
@@ -1,10 +1,15 @@
 //! BP 决策快照的进程内存储。
 //!
 //! 会话级单例：常驻求值任务每 tick 覆盖写入，命令层只读。
-//! 同时保管两项跨 tick 的状态：我们最后一次主动 hover 的英雄、
-//! 以及已判定「用户接管」的 action id（按 action 作用域，阶段切换自动失效）。
 //!
-//! 锁毒化处理：锁内只存三个独立的 Option 字段，无跨字段不变量。
+//! 快照分三份：展示用的「当前」决策，以及 ban / pick 两条执行轨道各自的决策。
+//! 后两者必须分开——ban 阶段「当前」是 ban 决策，若 pick 任务也读它就会整段
+//! 空转，hover 只能等 ban 完成后才发生。
+//!
+//! 另外保管两项跨 tick 的状态：我们最后一次主动 hover 的英雄，以及已判定
+//! 「用户接管」的 action id（按 action 作用域，阶段切换自动失效）。
+//!
+//! 锁毒化处理：锁内只存彼此独立的 Option 字段，无跨字段不变量。
 //! 任何写入 panic 导致毒化时，取回数据继续用——快照是纯展示数据，
 //! 一帧旧值不值得让功能永久失能。
 
@@ -13,7 +18,16 @@ use std::sync::{OnceLock, PoisonError, RwLock};
 
 #[derive(Default)]
 struct StoreState {
+    /// 展示用的「当前」决策——对应 `find_my_pending_action` 选中的那个动作
     decision: Option<BpDecision>,
+    /// 我的 ban 动作的决策，供 ban 执行任务使用
+    ban: Option<BpDecision>,
+    /// 我的 pick 动作的决策，供 pick 执行任务使用。
+    ///
+    /// 与 `decision` 分开保存的理由：ban 阶段 `decision` 是 ban 决策，pick 任务
+    /// 若也读它就会整段空转，hover 只能等 ban 完成后才发生——真机上表现为
+    /// 「预选期不预选」。两条轨道各读各的，pick 的 hover 才能一开始就做。
+    pick: Option<BpDecision>,
     /// 我们最后一次主动 hover 的英雄 ID
     last_hovered: Option<i32>,
     /// 已判定接管的 action id。每个 ban/pick action 的 id 唯一，
@@ -37,12 +51,33 @@ pub fn read() -> Option<BpDecision> {
         .clone()
 }
 
-/// 覆盖写入快照。
-pub fn write(decision: Option<BpDecision>) {
+/// 读取我的 ban 动作的决策（执行侧用）。
+pub fn read_ban() -> Option<BpDecision> {
     store()
-        .write()
+        .read()
         .unwrap_or_else(PoisonError::into_inner)
-        .decision = decision;
+        .ban
+        .clone()
+}
+
+/// 读取我的 pick 动作的决策（执行侧用）。ban 阶段也会有值——预选期就要 hover。
+pub fn read_pick() -> Option<BpDecision> {
+    store()
+        .read()
+        .unwrap_or_else(PoisonError::into_inner)
+        .pick
+        .clone()
+}
+
+/// 覆盖写入三份快照（展示用 + 两条执行轨道）。
+///
+/// 一次写入而非三个 setter：三者由同一个求值 tick 产出，分开写会让执行侧
+/// 读到跨 tick 的混合状态。
+pub fn write(decision: Option<BpDecision>, ban: Option<BpDecision>, pick: Option<BpDecision>) {
+    let mut s = store().write().unwrap_or_else(PoisonError::into_inner);
+    s.decision = decision;
+    s.ban = ban;
+    s.pick = pick;
 }
 
 pub fn last_hovered() -> Option<i32> {


### PR DESCRIPTION
承接 #151。计时器修好后自动 BP 终于会执行了，随即在真机上暴露出三个此前被
「根本不执行」掩盖的问题——2026-08-15 一局选人期里同时出现，根因各不相同。

## 1. `PLANNING` 阶段被当成可执行窗口

LCU 的 `timer.phase` 走 `PLANNING`（预选宣告）→ `BAN_PICK` → `FINALIZATION`，
**每段各有独立倒计时**；而 LCU 早在 `PLANNING` 期间就把 10 个 ban action 全部
标成 `isInProgress=true`。于是 `PLANNING` 那 12 秒同样会走进 `<=5s` 的执行窗口。

真机实测：

```
01:01:27  phase=PLANNING   剩余 1.6s  → 执行了 ban（被 LCU 静默无视，无报错、未完成）
01:01:29  phase=BAN_PICK   计时器重置为 25s
01:01:49  phase=BAN_PICK   剩余 4.6s  → 这次才真正生效
```

期间决策带还显示了一个走到 0 却什么都没发生的倒计时——**这正是「ban 的时候在
非 ban 阶段显示倒计时」的成因**。

新增 `evaluate::is_actionable_phase` 作为闸门，`should_lock` 与快照的
`is_in_progress` 都据此收口。前端的「轮到我了」自此严格等价于
「倒计时归零就真的会执行」。

## 2. 预选期不预选：hover 要等 ban 完成后才发生

`apply_bp_decision` 用 `find_my_pending_action` 取「当前那一个」动作，ban 阶段
拿到的必然是 ban，于是 pick 任务整段空转：

```
01:01:49  ban 完成
01:01:51  BP hover sync: 0 -> 800     ← 到这才 hover
01:01:57  轮到我 pick
```

ban 与 pick 本是两条独立轨道。新增 `find_my_pending_action_of_type` 按类型定位，
`store` 分别保存两条轨道的决策，两个执行任务各读各的。pick 的 hover 自此在选人期
一开始就能做，不再被 ban 挡住。

## 3. 迟到的 tick 被重放，1 秒内连发 8 次 PATCH

`tokio::time::interval` 默认 `MissedTickBehavior::Burst`：运行时被阻塞后会把攒下的
tick 一次性补发。实测 tick 空档 6.2 秒后以 ~18ms 间隔爆发，同一个 ban 被提交 8 次：

```
01:01:20.145  starting champion ban
              ← 6.2 秒无 tick
01:01:26.367  starting champion ban / selection ×6（同一毫秒）
01:01:27.083 ~ .340  BP execute: ban 101  ×7
```

对实时 BP 循环而言迟到的 tick 只该丢弃，五处 `interval` 统一改为
`MissedTickBehavior::Skip`。

## Test plan
- [x] `npm run check` passes（0 errors）
- [x] `cargo test` passes（347 passed, 0 failed；新增 4 个）
- [x] 新增测试：`should_not_lock_outside_ban_pick_phase`（PLANNING / FINALIZATION 不提交，
      BAN_PICK 提交，字段缺失时不阻拦）、`only_ban_pick_phase_is_actionable`、
      `find_pending_of_type_finds_my_pick_while_ban_in_progress`、
      `find_pending_of_type_skips_completed_and_others_actions`
- [x] Manual: 真机复验通过（2026-08-15 02:04 一局）——选人期 02:04:47 开始，02:04:49 即完成 `BP hover sync: 0 -> 800`（ban 尚未执行）；`BP execute: ban 101 at 4.7s left` 全局仅 1 行，PLANNING 期零执行；ban 任务 tick 恢复严格每秒一拍，无 ~18ms 爆发
