### PR TITLE
docs: 修复 README 的 Star History 图（原图已失效）

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,4 +252,4 @@ This project is open-sourced under the [MIT License](./LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wnzzer/rank-analysis&type=Date)](https://star-history.com/#wnzzer/rank-analysis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wnzzer/rank-analysis&type=Date)](https://star-history.dera.page/#wnzzer/rank-analysis&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,4 +250,4 @@ cd src-tauri && cargo fmt --all -- --check && cargo clippy --all-targets --all-f
 
 ## Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wnzzer/rank-analysis&type=Date)](https://star-history.com/#wnzzer/rank-analysis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wnzzer/rank-analysis&type=Date)](https://star-history.dera.page/#wnzzer/rank-analysis&Date)


### PR DESCRIPTION
当前 Star History 图因 GitHub 星标接口限制已经无法正常渲染，会影响项目在 README 上的展示效果。本次将中英文 README 的 Star History 图与跳转链接一并更新到新地址，恢复图表显示。