### PR TITLE
feat(search): Header 超级搜索——模糊查人与 AI 自然语言搜战绩 (#157)

### DIFF
--- a/docs/superpowers/plans/2026-09-01-super-search.md
+++ b/docs/superpowers/plans/2026-09-01-super-search.md
@@ -1,0 +1,231 @@
+# 超级搜索实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Header 搜索框升级为三合一超级搜索(精确查人 / 本地模糊查人候选 / AI 自然语言搜战绩),落地 issue #157。
+
+**Architecture:** 前端为主:`services/ai/matchSearch/` 纯函数管线(schema 校验 → prompt → 单轮 qwen-flash JSON 解析 → SGP 深分页拉取 → 本地筛选/统计),Header 换装 omnibox 组件,Record 页按 `aiq` 参数切换 AI 结果视图。Rust 仅新增 `get_friends`(LCU /lol-chat/v1/friends)。
+
+**Tech Stack:** Vue 3 + TS + vitest;现有 AI 基建 `requestAIContent`(JSON mode, qwen-flash);SGP 命令 `get_sgp_match_history_by_name`。
+
+**Spec:** `docs/superpowers/specs/2026-09-01-super-search-design.md`(接口/交互细节以 spec 为准)
+
+## Global Constraints
+
+- 质量门禁:每个任务结束 `cd rank-analysis-app && npm run check && npm run test`;Rust 改动加 `cargo test`。
+- 提交:分支 `feat/super-search`,Conventional Commits,显式路径 `git add`。
+- 英雄 id 只允许来自 `get_champion_options` 清单;统计/日期比较全部本地算,不信模型输出的数字结论。
+- AI 搜索目标固定当前登录玩家(`get_my_summoner`)+ 当前大区;上限 200 局(无时间窗 100 局),SGP 失败降级 LCU 0-49。
+
+---
+
+### Task 1: matchSearch 类型 + 校验 + 筛选纯函数
+
+**Files:**
+- Create: `rank-analysis-app/src/services/ai/matchSearch/types.ts`
+- Create: `rank-analysis-app/src/services/ai/matchSearch/schema.ts`
+- Create: `rank-analysis-app/src/services/ai/matchSearch/filter.ts`
+- Create: `rank-analysis-app/src/services/ai/matchSearch/chips.ts`
+- Test: `rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts`、`filter.spec.ts`、`chips.spec.ts`
+
+**Interfaces (Produces):**
+
+```ts
+// types.ts
+export interface ParsedMatchQuery {
+  timeRange: { from: string | null; to: string | null } // ISO 日期(仅日期部分即可)
+  selfChampionIds: number[]
+  allyChampionIds: number[]      // 队友(不含我)
+  enemyChampionIds: number[]
+  myTeamChampionIds: number[]    // 我方出现过即可(含我)
+  result: 'win' | 'loss' | 'any'
+  queueIds: number[]             // 空 = 不限
+  playerNames: string[]
+  intent: 'list' | 'count_encounters'
+}
+export interface EncounterStats {
+  total: number
+  perName: Record<string, { ally: number; enemy: number }>
+}
+export interface QueryChip { key: string; label: string } // key 供删除定位
+
+// schema.ts
+export function emptyQuery(): ParsedMatchQuery
+export function validateParsedQuery(
+  raw: unknown,
+  validChampionIds: Set<number>,
+  validQueueIds: Set<number>
+): ParsedMatchQuery // 非法字段降级为空/any,绝不 throw
+
+// filter.ts
+export function filterGames(games: Game[], q: ParsedMatchQuery): Game[]
+export function countEncounters(games: Game[], q: ParsedMatchQuery): {
+  stats: EncounterStats; games: Game[]  // games = 命中对局(时间/模式过滤后)
+}
+
+// chips.ts
+export function queryToChips(q: ParsedMatchQuery, championName: (id: number) => string, queueName: (id: number) => string): QueryChip[]
+export function removeChipFromQuery(q: ParsedMatchQuery, key: string): ParsedMatchQuery
+```
+
+**筛选语义(filter.ts 核心):**
+- 自己 = `game.participants[0]`;全队 = `game.gameDetail.participants`(与 `participantIdentities` 按下标对齐)。
+- 我方/敌方按 `teamId` 与 participants[0].teamId 对比;在 gameDetail 中定位"我"用 championId+teamId 双匹配(SGP/LCU 数据都无法保证 puuid 在 detail 中)。
+- playerNames 匹配:`gameName#tagLine` 与 `gameName` 均做大小写不敏感全等,再退化到子串。
+- 时间窗:`gameCreationDate`(ISO 字符串)与 from/to 比较,from/to 为 null 则该侧不设限;to 按当日 23:59:59 含端点。
+
+- [ ] 写 schema/filter/chips 失败测试(用例:非法 championId 剔除、from>to 归零、result 非枚举→any、ally/enemy 划分、忘我场景 myTeam 命中自己、count 同队/对面分计、chips 删除后字段清空)
+- [ ] 实现并跑绿
+- [ ] `npm run check && npm run test` 全绿后提交 `feat: AI 搜战绩查询模型与本地筛选纯函数`
+
+### Task 2: prompt 构造 + 解析(parse)
+
+**Files:**
+- Create: `rank-analysis-app/src/services/ai/matchSearch/prompt.ts`、`parse.ts`
+- Test: `__tests__/prompt.spec.ts`、`parse.spec.ts`(mock `../stream` 与 `@tauri-apps/api/core`)
+
+**Interfaces:**
+- Consumes: Task 1 `validateParsedQuery`;现有 `requestAIContent`(jsonMode)、`get_champion_options`、`getGameModesByIpc`。
+- Produces:
+
+```ts
+// prompt.ts
+export interface PromptContext {
+  today: string // YYYY-MM-DD
+  champions: { value: number; label: string; nickname: string; realName: string }[]
+  modes: { label: string; value: number }[]
+}
+export function buildMatchSearchPrompt(text: string, ctx: PromptContext): { system: string; user: string }
+
+// parse.ts
+export function extractJson(content: string): unknown | null // 容忍 ```json 围栏
+export async function parseMatchQuery(text: string): Promise<ParsedMatchQuery> // 失败 throw Error(中文可展示信息)
+```
+
+**prompt 要点:** system 固定「把玩家对战绩的自然语言描述解析为 JSON 检索条件」+ 输出 schema 说明 + 规则(只能从英雄清单选 id;日期输出绝对 ISO;不确定的字段留空;「队友有X但不记得自己玩什么」归 myTeamChampionIds);user 注入今天日期、英雄清单(`id|label|nickname|realName` 每行一个)、模式清单、原文。
+
+- [ ] 失败测试 → 实现 → 全绿(prompt 断言含日期/清单/原文;parse 断言 jsonMode 调用、校验降级、错误路径)
+- [ ] 提交 `feat: AI 搜战绩自然语言解析(qwen JSON mode)`
+
+### Task 3: SGP 深分页拉取(fetch)
+
+**Files:**
+- Create: `rank-analysis-app/src/services/ai/matchSearch/fetch.ts`
+- Test: `__tests__/fetch.spec.ts`(mock invoke)
+
+**Interfaces:**
+- Consumes: 命令 `get_my_summoner`、`get_current_sgp_region`、`get_sgp_match_history_by_name`、`get_match_history_by_puuid`。
+- Produces:
+
+```ts
+export interface FetchProgress { fetched: number; oldestDate: string | null }
+export interface FetchResult {
+  games: Game[]
+  source: 'sgp' | 'lcu'
+  truncated: boolean       // 因上限截断(结果区提示)
+  selfName: string         // gameName#tagLine
+}
+export async function fetchGamesForQuery(
+  q: ParsedMatchQuery,
+  onProgress?: (p: FetchProgress) => void
+): Promise<FetchResult>
+```
+
+**逻辑:** 每页 20 循环;停止条件 = 空页 / 页内最旧 `gameCreationDate` < timeRange.from / 累计 ≥ 200(无 from 则 100);SGP 任一页失败 → 整体降级 LCU 0-49 一次(source='lcu')。
+
+- [ ] 失败测试(停止条件×3、降级、进度回调序列)→ 实现 → 全绿
+- [ ] 提交 `feat: AI 搜战绩 SGP 深分页拉取与 LCU 降级`
+
+### Task 4: Rust `get_friends`
+
+**Files:**
+- Create: `rank-analysis-app/src-tauri/src/lcu/api/chat.rs`
+- Modify: `rank-analysis-app/src-tauri/src/lcu/api.rs`(注册 mod)、`src-tauri/src/command.rs` 或 `command/` 新增 `chat.rs` + `main.rs` 注册
+- Test: `chat.rs` 内 serde 单测
+
+**Produces:** command `get_friends() -> Result<Vec<Friend>, String>`,`Friend { game_name, tag_line, puuid }`(serde 把 LCU 的 `gameTag` alias 到 `tag_line`;camelCase 序列化给前端 `gameName/tagLine/puuid`)。
+
+- [ ] serde 失败测试(样例 JSON 含 gameTag)→ 实现 → `cargo test` 绿 → `npm run check`
+- [ ] 提交 `feat: 新增好友列表命令 get_friends`
+
+### Task 5: 候选聚合 composable
+
+**Files:**
+- Create: `rank-analysis-app/src/composables/useSearchSuggestions.ts`
+- Test: `rank-analysis-app/src/composables/useSearchSuggestions.spec.ts`
+
+**Produces:**
+
+```ts
+export function isRiotIdLike(input: string): boolean // 恰一个'#'且后有非空白
+export interface PlayerSuggestion { name: string; region?: string; source: 'friend' | 'note' | 'history' }
+export function buildPlayerSuggestions(
+  input: string,
+  sources: { friends: PlayerSuggestion[]; notes: PlayerSuggestion[]; history: PlayerSuggestion[] }
+): PlayerSuggestion[] // 去重(friend>note>history)、每源≤4、大小写不敏感子串
+// 搜索历史(localStorage key 'searchHistory.v1', 上限20, name+region 去重, 最近在前)
+export function loadSearchHistory(): { name: string; region: string; ts: number }[]
+export function pushSearchHistory(name: string, region: string): void
+// composable: 组件侧封装(懒加载好友、订阅 notes store、输入→分组候选)
+export function useSearchSuggestions(input: Ref<string>): {
+  playerSuggestions: ComputedRef<PlayerSuggestion[]>
+  riotIdLike: ComputedRef<boolean>
+}
+```
+
+- [ ] 纯函数失败测试 → 实现 → 全绿
+- [ ] 提交 `feat: 超级搜索候选聚合(历史/备注/好友)`
+
+### Task 6: SuperSearch omnibox 组件 + Header 接入
+
+**Files:**
+- Create: `rank-analysis-app/src/components/SuperSearch.vue`
+- Modify: `rank-analysis-app/src/components/Header.vue`(header-center 换 `<SuperSearch/>`,大区下拉逻辑随迁)
+
+**行为(spec 交互节):** 输入非空聚焦时弹候选面板;行序 = 精确 Riot ID 行(仅 riotIdLike)→ 玩家候选 → AI 行(恒有,输入非空时);↑↓ 换选、Enter 执行当前选中(默认:精确行 > 首个玩家候选 > AI 行)、Esc 收起;点击行执行。执行精确/候选 → `/Record?name&region&t` + `pushSearchHistory`;执行 AI 行 → 解析当前玩家名(`useGameState().summoner` 兜底 `get_my_summoner`)→ `/Record?name=<我>&aiq=<原文>&t`。样式沿用现 header-search 造型。
+
+- [ ] 实现组件与 Header 接入;`npm run check` + 手动 dev 冒烟(查人回归 + 候选 + AI 行跳转)
+- [ ] 提交 `feat: Header 超级搜索 omnibox(模糊查人 + AI 入口)`
+
+### Task 7: AI 结果视图 + Record 集成
+
+**Files:**
+- Create: `rank-analysis-app/src/composables/useAiMatchSearch.ts`(编排:parse→fetch→filter/count,暴露状态机)
+- Create: `rank-analysis-app/src/components/record/AiSearchResults.vue`
+- Modify: `rank-analysis-app/src/views/Record.vue`(`route.query.aiq` 存在时内容区渲染 AiSearchResults)
+- Test: `useAiMatchSearch.spec.ts`(mock matchSearch 各模块)
+
+**Produces:**
+
+```ts
+export type AiSearchPhase = 'idle' | 'parsing' | 'fetching' | 'done' | 'error'
+export function useAiMatchSearch(): {
+  phase: Ref<AiSearchPhase>
+  error: Ref<string>
+  progress: Ref<FetchProgress>
+  query: Ref<ParsedMatchQuery | null>
+  chips: ComputedRef<QueryChip[]>
+  results: Ref<Game[]>
+  encounterStats: Ref<EncounterStats | null>
+  meta: Ref<{ source: 'sgp' | 'lcu'; truncated: boolean; searchedCount: number } | null>
+  run(text: string): Promise<void>
+  removeChip(key: string): void   // 本地重筛,不重打模型/网络
+}
+```
+
+UI:chips 行(可删)+ 阶段态(解析中/拉取进度/错误重试/未配 key 引导)+ count 答案卡 + `RecordCard` 列表(复用 MatchHistory 的资产预载模式 provide recordAssets)+ 空态说明已搜范围。
+
+- [ ] composable 失败测试 → 实现 → 全绿;视图实现;`npm run check`
+- [ ] 提交 `feat: Record 页 AI 搜战绩结果视图(chips/进度/统计卡)`
+
+### Task 8: 真机端到端验收 + 收尾
+
+- [ ] `npm run tauri dev` + MCP bridge(ws://127.0.0.1:9223),用本机真实 LOL + env 密钥跑 issue 四个例句 + 查人回归 + 候选下拉
+- [ ] 全量门禁:`npm run check && npm run test`,`cargo test`
+- [ ] push + PR:标题 `feat(search): Header 超级搜索——模糊查人与 AI 自然语言搜战绩 (#157)`
+
+## Self-Review 备注
+
+- spec 覆盖:交互(T6)、AI 管线(T1-3)、好友(T4)、候选(T5)、呈现(T7)、测试/验收(T8)。
+- 类型一致性:ParsedMatchQuery/FetchResult/QueryChip 名称已在各任务 Interfaces 区锁定。
+- 本计划由本会话内联执行(执行者已具全部上下文),故省略每步完整代码,以接口与测试用例清单为约束;若移交无上下文执行者需先读 spec。

--- a/docs/superpowers/specs/2026-09-01-super-search-design.md
+++ b/docs/superpowers/specs/2026-09-01-super-search-design.md
@@ -1,0 +1,164 @@
+# 超级搜索(Header Omnibox + AI 自然语言搜战绩)设计
+
+> issue #157「建议增加模糊搜索战绩功能」+ 讨论扩展:名字查人也做成模糊的,
+> 把 Header 搜索框升级为大而全的超级搜索。
+
+## 目标
+
+把 Header 现有的「召唤师名#Tag 精确查人」搜索框升级为三合一 omnibox:
+
+1. **精确查人**(现有能力,保留):输入形似 Riot ID(含 `#`)→ 跳 Record 页。
+2. **模糊查人**(新):输入片段时下拉展示本地已知玩家候选(搜索历史 / 备注玩家 /
+   好友),子串匹配,点击即按精确流程搜索。
+3. **AI 自然语言搜战绩**(新,issue 主体):输入自然语言(如「这个月有一把我用
+   女警队友有金克斯最后赢了」)→ qwen 解析为结构化条件 → 深分页拉当前登录玩家
+   战绩 → 本地确定性筛选 → Record 页以条件 chips + 战绩列表呈现。
+
+## 非目标(第一期明确砍掉)
+
+- 装备/事件黑话查询(「坦克引擎」「飞身踢」→ itemId):别名表维护成本高、模型
+  幻觉率高。schema 不为其建模,后续按需加。
+- 对「当前登录玩家」以外的人做 AI 搜索(所有 issue 例句主语都是「我」)。
+- AI 搜索联动大区下拉:跨区 puuid 是不同账号,「我」在别区无意义。AI 搜索固定
+  当前登录玩家 + 当前大区。
+- 拼音/首字母模糊匹配玩家名:v1 只做大小写不敏感子串匹配。
+
+## 交互设计(Header omnibox)
+
+输入框获得焦点且有输入时,下方弹出候选面板(n-popover / 自绘下拉),分组:
+
+```
+┌──────────────────────────────────────┐
+│ ➤ 搜索召唤师「xxx#yyy」        ← 仅输入形似 Riot ID 时置顶
+│ ── 玩家 ──────────────────────       │
+│ 👤 某好友#123        (好友)          │
+│ 📝 某备注哥#456      (备注)          │
+│ 🕘 上次搜过#789      (历史)          │
+│ ── AI ───────────────────────        │
+│ ✨ AI 搜战绩:「<原文>」              │
+└──────────────────────────────────────┘
+```
+
+- **回车默认行**:形似 Riot ID → 精确查人;否则有玩家候选 → 第一条候选;
+  否则 → AI 搜战绩。上下键可换选,点击任意行执行该行。
+- **形似 Riot ID 判定**:包含恰好一个 `#` 且其后有 1+ 非空白字符(gameName
+  可含空格,不能按空格判)。
+- **候选数据源**(全部本地/毫秒级,不打网络):
+  - 搜索历史:新建,`localStorage`,记录成功执行过的精确查人
+    `{name, region, ts}`,按 name+region 去重,上限 20,最近在前。
+  - 备注玩家:`usePlayerNotesStore`,已有 `gameName`/`tagLine`。
+  - 好友:新增 Rust command `get_friends`(LCU `GET /lol-chat/v1/friends`),
+    返回 `{gameName, tagLine, puuid}`;Header 挂载后懒加载一次,失败静默降级
+    (LCU 未连时无好友组)。
+  - 匹配:`gameName#tagLine` 大小写不敏感子串;三组去重(同名玩家按
+    好友 > 备注 > 历史优先保留),每组最多 4 条。
+- AI 行选中 → 解析当前登录玩家名(`useGameState` 的 summoner,未连接时兜底
+  `get_my_summoner`)→ `router.push('/Record?name=<我>&aiq=<原文>&t=...')`
+  (带 name 让左侧 UserRecord 复用现有逻辑展示「我」;不带 region)。
+- 精确/候选行选中 → 现有流程 `/Record?name=...&region=...`,并写入搜索历史。
+
+## AI 搜索管线(`services/ai/matchSearch/`)
+
+纯前端管线,复用现有 AI 基建(`requestAIContent` + JSON mode + qwen-flash),
+不新增 Rust AI 代码。
+
+### 1. 解析(parse)
+
+单轮 qwen-flash JSON mode 调用:
+
+- prompt 注入:今天日期(绝对化「这个月/前两天」)、英雄清单(来自
+  `get_champion_options`,每行 `id|官方名|昵称|称号`,约 170 行,消灭英雄名
+  幻觉——模型只许从清单选 id)、常见队列关键词说明(单双排/灵活/大乱斗/斗魂…
+  → queueId 直接给映射表)。
+- 输出 schema(TS 手写校验,非法字段丢弃并降级):
+
+```ts
+interface ParsedMatchQuery {
+  timeRange: { from: string | null; to: string | null } // ISO 日期
+  selfChampionIds: number[]      // 我用的英雄(任一命中)
+  allyChampionIds: number[]      // 队友用的(不含我,任一命中)
+  enemyChampionIds: number[]     // 对面用的(任一命中)
+  myTeamChampionIds: number[]    // 我方出现过即可(含我;「忘了自己玩的啥」场景)
+  result: 'win' | 'loss' | 'any'
+  queueIds: number[]             // 空 = 不限模式
+  playerNames: string[]          // 「跟 XXX#XXX 碰过几次」里的名字
+  intent: 'list' | 'count_encounters'
+}
+```
+
+- 校验规则:championId 必须在清单内;日期必须合法且 from ≤ to;playerNames
+  原样保留。校验失败字段置空(宁可少筛不误筛)。
+
+### 2. 拉取(fetch)
+
+- 目标:当前登录召唤师(现有命令 `get_my_summoner`,得到 `gameName#tagLine`
+  与 puuid)。
+- 走 SGP 深分页(`get_sgp_match_history_by_name`,当前大区
+  `get_current_sgp_region`):每页 20 条循环,直到任一停止条件:
+  - 页内最旧一局 `gameCreationDate` < `timeRange.from`;
+  - 已拉满上限 **200 局**(无 timeRange 时上限 100 局);
+  - 返回空页。
+- 每页回调进度(已拉 N 局 / 已覆盖到 X 月 X 日),供 UI 展示。
+- SGP 失败(如权限/网络)降级 LCU `get_match_history_by_puuid` 0-49
+  一次性 50 局,并在结果区提示「仅搜索了最近 50 局」。
+- SGP 返回的 `MatchHistory` 全队数据在 `gameDetail.participants` +
+  `participantIdentities`,`participants[0]` 为被查玩家——满足队友/对手/
+  玩家名筛选,无需逐局 enrich。
+
+### 3. 筛选与统计(filter,纯函数)
+
+对 `Game[]` 依次应用:时间窗 → queueIds → 胜负(participants[0].stats.win)
+→ selfChampionIds(participants[0].championId)→ ally/enemy/myTeam(按
+gameDetail.participants 的 teamId 与 participants[0] 对比划分)→
+playerNames(participantIdentities 的 `gameName#tagLine` 或 `gameName`
+大小写不敏感匹配)。
+
+`intent === 'count_encounters'`:在时间窗+模式过滤后,统计 playerNames
+出现的对局数(区分同队/对面各几次),命中对局同时作为列表结果展示。
+
+### 4. 呈现(Record 页)
+
+- `Record.vue` 检测 `route.query.aiq`:内容区从 `MatchHistory` 切换为新组件
+  `AiSearchResults.vue`(左侧 UserRecord 维持展示当前登录玩家)。
+- `AiSearchResults` 自上而下:
+  - **条件 chips 行**:解析出的每个条件一枚 chip(`时间: 8月`「我用: 女警」
+    「队友: 金克斯」「结果: 胜」…),chip 可删除 → 本地重筛(不重新调模型、
+    不重新拉取);另有「重新解析」入口。用户由此看到 AI 的理解并可修正,
+    化解误解析风险。
+  - **进度态**:解析中(AI 图标脉冲)→ 拉取中(已拉 N 局/覆盖至某日)→ 完成。
+  - **统计答案卡**(仅 count 意图):「最近一个月与 XXX#XXX 相遇 5 次
+    (同队 2 / 对面 3)」。
+  - **结果列表**:复用 `RecordCard`(SGP 数据已是其可渲染形态),空态给
+    「没有找到匹配对局 + 已搜索范围说明」。
+- 错误处理:未配 API key → 引导去设置页;解析失败/超时 → 错误态 + 重试;
+  LCU 未连接 → 提示先登录客户端。
+
+## 代码落点
+
+| 位置 | 内容 |
+| --- | --- |
+| `src/services/ai/matchSearch/schema.ts` | ParsedMatchQuery 类型 + 校验(纯函数) |
+| `src/services/ai/matchSearch/prompt.ts` | prompt 构造(日期/英雄清单/队列映射注入) |
+| `src/services/ai/matchSearch/parse.ts` | 调 `requestAIContentStream` 聚合 + JSON 提取 |
+| `src/services/ai/matchSearch/fetch.ts` | SGP 分页循环 + LCU 降级 + 进度回调 |
+| `src/services/ai/matchSearch/filter.ts` | 筛选/统计纯函数 |
+| `src/components/SuperSearch.vue` | Header omnibox(输入框 + 候选面板),替换现 n-input |
+| `src/composables/useSearchSuggestions.ts` | 候选聚合(历史/备注/好友)+ 模式判定 |
+| `src/components/record/AiSearchResults.vue` | 结果页(chips/进度/答案卡/列表) |
+| `src-tauri/src/lcu/api/chat.rs` + `command/chat.rs` | `get_friends`(LCU /lol-chat/v1/friends) |
+
+## 测试
+
+- 单测(vitest):riot-id 判定与回车默认行选择;候选聚合去重/分组/上限;
+  schema 校验(非法 id/日期/枚举的降级);filter 全维度(含 ally/enemy/
+  myTeam 划分与 count 统计);fetch 停止条件(mock invoke:时间窗越界/
+  上限/空页/SGP 失败降级)。
+- prompt 构造快照式断言(注入了日期与英雄清单)。
+- Rust:`get_friends` 反序列化单测(样例 JSON)。
+- 端到端:本机真实 LOL + DashScope key,经 MCP bridge 手动验收 issue 四个例句。
+
+## 成本与性能
+
+- 每次 AI 搜索恰好 1 次 qwen-flash 调用(prompt ≈ 3-4KB,几乎免费)。
+- 大头是 SGP 分页请求(≤ 10 次/搜索),有明确上限与进度展示。
+- 候选下拉全本地,零网络。

--- a/rank-analysis-app/src-tauri/src/command.rs
+++ b/rank-analysis-app/src-tauri/src/command.rs
@@ -41,6 +41,7 @@ pub mod ai;
 pub mod asset;
 pub mod bp;
 pub mod bp_suggest;
+pub mod chat;
 pub mod cloud_sync;
 pub mod config;
 pub mod fandom;

--- a/rank-analysis-app/src-tauri/src/command/chat.rs
+++ b/rank-analysis-app/src-tauri/src/command/chat.rs
@@ -1,0 +1,16 @@
+//! # 聊天/社交命令模块
+//!
+//! 目前只有好友列表查询,供前端 Header 超级搜索做本地模糊候选。
+
+use crate::lcu::api::chat::{self, Friend};
+
+/// 获取当前登录账号的好友列表。
+///
+/// # 返回值
+///
+/// - `Ok(Vec<Friend>)`: 好友列表(`{ gameName, tagLine, puuid }`)
+/// - `Err(String)`: LCU 未连接或请求失败
+#[tauri::command]
+pub async fn get_friends() -> Result<Vec<Friend>, String> {
+    chat::get_friends().await
+}

--- a/rank-analysis-app/src-tauri/src/lcu/api.rs
+++ b/rank-analysis-app/src-tauri/src/lcu/api.rs
@@ -5,6 +5,7 @@
 
 pub mod asset;
 pub mod champion_select;
+pub mod chat;
 pub mod eog_stats;
 pub mod game_detail;
 pub mod game_queue;

--- a/rank-analysis-app/src-tauri/src/lcu/api/chat.rs
+++ b/rank-analysis-app/src-tauri/src/lcu/api/chat.rs
@@ -1,0 +1,74 @@
+//! # LCU 聊天/社交 API
+//!
+//! 对应 `lol-chat` 相关接口,目前只封装好友列表(供 Header 超级搜索做本地候选)。
+
+use crate::lcu::util::http::lcu_get;
+use serde::{Deserialize, Serialize};
+
+/// 好友条目(超级搜索候选用的精简形态)。
+///
+/// LCU `/lol-chat/v1/friends` 返回字段较多,这里只取检索需要的三个;
+/// 注意 LCU 侧标签字段名是 `gameTag` 而非 `tagLine`。
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Friend {
+    pub game_name: String,
+    #[serde(rename(deserialize = "gameTag"))]
+    pub tag_line: String,
+    #[serde(default)]
+    pub puuid: String,
+}
+
+/// 获取当前登录账号的好友列表。
+///
+/// # 返回值
+/// - `Ok(Vec<Friend>)`: 好友列表(已过滤掉没有游戏名的条目,如群聊/系统账号)
+/// - `Err(String)`: LCU 未连接或请求失败
+pub async fn get_friends() -> Result<Vec<Friend>, String> {
+    let friends = lcu_get::<Vec<Friend>>("lol-chat/v1/friends").await?;
+    Ok(friends
+        .into_iter()
+        .filter(|f| !f.game_name.trim().is_empty())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn friend_deserializes_lcu_game_tag_field() {
+        let raw = r#"{
+            "gameName": "某好友",
+            "gameTag": "12345",
+            "puuid": "abc-def",
+            "availability": "online",
+            "icon": 123
+        }"#;
+        let f: Friend = serde_json::from_str(raw).expect("好友 JSON 应可反序列化");
+        assert_eq!(f.game_name, "某好友");
+        assert_eq!(f.tag_line, "12345");
+        assert_eq!(f.puuid, "abc-def");
+    }
+
+    #[test]
+    fn friend_serializes_tag_line_for_frontend() {
+        let f = Friend {
+            game_name: "某好友".into(),
+            tag_line: "12345".into(),
+            puuid: "p".into(),
+        };
+        let json = serde_json::to_string(&f).unwrap();
+        // 前端约定统一用 tagLine,不暴露 LCU 的 gameTag 命名
+        assert!(json.contains("\"gameName\""));
+        assert!(json.contains("\"tagLine\""));
+        assert!(!json.contains("\"gameTag\""));
+    }
+
+    #[test]
+    fn friend_missing_puuid_defaults_to_empty() {
+        let raw = r#"{"gameName": "某好友", "gameTag": "12345"}"#;
+        let f: Friend = serde_json::from_str(raw).expect("缺 puuid 也应可反序列化");
+        assert_eq!(f.puuid, "");
+    }
+}

--- a/rank-analysis-app/src-tauri/src/main.rs
+++ b/rank-analysis-app/src-tauri/src/main.rs
@@ -154,6 +154,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             command::get_summoner_by_puuid,
             command::get_summoner_by_name,
             command::get_my_summoner,
+            command::chat::get_friends,
             command::rank::get_rank_by_name,
             command::rank::get_rank_by_puuid,
             command::rank::get_win_rate_by_name_mode,

--- a/rank-analysis-app/src/components/Header.vue
+++ b/rank-analysis-app/src/components/Header.vue
@@ -5,35 +5,7 @@
       <span class="header-title">Rank Analysis</span>
     </div>
     <div class="header-center">
-      <n-input
-        class="input-lolid header-search"
-        type="text"
-        size="small"
-        placeholder="召唤师名#Tag"
-        v-model:value="searchValue"
-        @keyup.enter="onClinkSearch"
-      >
-        <!-- 前缀：大区下拉（框内左侧，细分隔线隔开），整体仍是一个搜索框 -->
-        <template #prefix>
-          <n-dropdown
-            trigger="click"
-            size="small"
-            :options="regionDropdownOptions"
-            @select="onRegionSelect"
-          >
-            <button class="region-trigger" type="button" @mousedown.prevent>
-              <span class="region-trigger-label">{{ selectedRegionLabel }}</span>
-              <n-icon :size="11" class="region-trigger-caret"><ChevronDownOutline /></n-icon>
-            </button>
-          </n-dropdown>
-          <span class="region-divider" />
-        </template>
-        <template #suffix>
-          <n-button text quaternary @click="onClinkSearch" class="header-icon-btn">
-            <n-icon :component="Search" />
-          </n-button>
-        </template>
-      </n-input>
+      <SuperSearch />
     </div>
     <div class="header-right" data-tauri-drag-region>
       <!-- 升级药丸：只在探测到新版本时出现，点击直接走升级流程（不跳转关于页）。
@@ -112,16 +84,13 @@
 </template>
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import { invoke } from '@tauri-apps/api/core'
 import {
-  Search,
   LogoGithub,
   RemoveOutline,
   SquareOutline,
   CloseOutline,
   SunnyOutline,
   MoonOutline,
-  ChevronDownOutline,
   PowerOutline,
   ArrowUpCircleOutline
 } from '@vicons/ionicons5'
@@ -129,7 +98,7 @@ import { darkTheme, useMessage } from 'naive-ui'
 import { Window } from '@tauri-apps/api/window'
 import { openUrl } from '@tauri-apps/plugin-opener'
 
-import router from '@renderer/router'
+import SuperSearch from './SuperSearch.vue'
 import { useSettingsStore } from '@renderer/pinia/setting'
 import { useGameState, lcuConnected } from '@renderer/composables/useGameState'
 import { closeLeagueByIpc } from '@renderer/services/ipc'
@@ -155,35 +124,6 @@ import { GATE_SETTLE_MS, GATE_FALLBACK_MS } from '@renderer/composables/useStart
 
 /** 当前应用窗口实例，用于执行窗口控制操作 */
 const currentWindow = Window.getCurrent()
-
-/** 搜索输入框的值 */
-const searchValue = ref('')
-
-/** 选中的大区 platformId（空 = 当前区，走本地 LCU；非空走 SGP 跨区查询） */
-const selectedRegion = ref('')
-/** 大区下拉选项：当前区 + 各腾讯大区（来自后端 get_sgp_regions） */
-const regionOptions = ref<{ label: string; value: string }[]>([{ label: '当前区', value: '' }])
-
-onMounted(async () => {
-  try {
-    const regions = await invoke<{ label: string; value: string }[]>('get_sgp_regions')
-    regionOptions.value = [{ label: '当前区', value: '' }, ...regions]
-  } catch (e) {
-    console.error('加载大区列表失败', e)
-  }
-})
-
-/** n-dropdown 选项格式（key=platformId） */
-const regionDropdownOptions = computed(() =>
-  regionOptions.value.map(r => ({ label: r.label, key: r.value }))
-)
-/** 当前选中大区的显示文案（前缀按钮上的文字） */
-const selectedRegionLabel = computed(
-  () => regionOptions.value.find(r => r.value === selectedRegion.value)?.label ?? '当前区'
-)
-const onRegionSelect = (key: string): void => {
-  selectedRegion.value = key
-}
 
 /** 设置状态管理 Store */
 const settingsStore = useSettingsStore()
@@ -282,26 +222,6 @@ const openGithubLink = async (): Promise<void> => {
 }
 
 /**
- * 执行召唤师搜索
- * 将用户输入的召唤师名称作为查询参数跳转到战绩查询页面
- * 使用时间戳作为查询参数确保每次搜索都会触发页面刷新
- *
- * @example
- * 用户输入 "SummonerName" 后按回车或点击搜索按钮
- * 页面跳转到 /Record?name=SummonerName&t=1234567890
- */
-const onClinkSearch = async (): Promise<void> => {
-  if (!searchValue.value.trim()) return
-
-  await router.push({
-    path: '/Record',
-    // region 为空表示当前区，不带该参数即走原本地 LCU 流程
-    query: { name: searchValue.value, region: selectedRegion.value || undefined, t: Date.now() }
-  })
-  searchValue.value = ''
-}
-
-/**
  * 最小化应用窗口
  */
 const minimizeWindow = (): void => {
@@ -372,69 +292,6 @@ const closeWindow = (): void => {
   justify-content: center;
   max-width: 340px;
   margin: 0 auto;
-}
-
-.input-lolid {
-  -webkit-app-region: no-drag;
-  pointer-events: auto;
-}
-
-/* 单一搜索框：大区做成框内左侧下拉前缀，整体一个边框/背景/聚焦态 */
-.header-search {
-  width: 100%;
-  border-radius: var(--radius-md);
-}
-
-.header-search :deep(.n-input-wrapper) {
-  transition:
-    box-shadow var(--dur-fast) var(--ease-expo),
-    border-color var(--dur-fast) var(--ease-expo);
-}
-
-/* 聚焦时整框发光 */
-.header-center:focus-within .header-search :deep(.n-input-wrapper) {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--semantic-win) 20%, transparent);
-  border-color: color-mix(in srgb, var(--semantic-win) 35%, transparent) !important;
-}
-
-/* 前缀：大区下拉触发器（小号文字 + 箭头，hover 淡底） */
-.region-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  height: 20px;
-  padding: 0 var(--space-4);
-  border: none;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
-  line-height: 1;
-  cursor: pointer;
-  white-space: nowrap;
-  -webkit-app-region: no-drag;
-  transition:
-    color var(--dur-fast) var(--ease-expo),
-    background-color var(--dur-fast) var(--ease-expo);
-}
-
-.region-trigger:hover {
-  color: var(--text-primary);
-  background: var(--glass-bg-high);
-}
-
-.region-trigger-caret {
-  color: var(--text-tertiary);
-  flex-shrink: 0;
-}
-
-/* 前缀与输入文本之间的细分隔线 */
-.region-divider {
-  width: 1px;
-  height: 14px;
-  margin: 0 var(--space-8) 0 5px;
-  background: var(--glass-border);
-  flex-shrink: 0;
 }
 
 .header-right {

--- a/rank-analysis-app/src/components/SuperSearch.vue
+++ b/rank-analysis-app/src/components/SuperSearch.vue
@@ -5,7 +5,7 @@
       class="input-lolid header-search"
       type="text"
       size="small"
-      placeholder="召唤师名#Tag,或直接描述想找的对局"
+      placeholder="召唤师名#Tag / 描述战绩"
       v-model:value="searchValue"
       @focus="focused = true"
       @blur="focused = false"
@@ -43,7 +43,7 @@
           @mouseenter="activeIndex = i"
           @click="executeRow(row)"
         >
-          <n-icon :size="14" class="row-icon" :component="rowIcon(row)" />
+          <n-icon :size="12" class="row-icon" :component="rowIcon(row)" />
           <span class="row-label">{{ row.label }}</span>
           <span v-if="row.badge" class="row-badge">{{ row.badge }}</span>
         </div>
@@ -72,6 +72,7 @@ import {
   PersonOutline,
   TimeOutline,
   PricetagOutline,
+  GameControllerOutline,
   SparklesOutline
 } from '@vicons/ionicons5'
 import { useMessage } from 'naive-ui'
@@ -79,7 +80,7 @@ import router from '@renderer/router'
 import { useGameState } from '@renderer/composables/useGameState'
 import {
   useSearchSuggestions,
-  pushSearchHistory,
+  recordSearchHistory,
   type PlayerSuggestion
 } from '@renderer/composables/useSearchSuggestions'
 
@@ -133,7 +134,8 @@ const { playerSuggestions, riotIdLike } = useSearchSuggestions(searchValue)
 const SOURCE_BADGE: Record<PlayerSuggestion['source'], string> = {
   friend: '好友',
   note: '备注',
-  history: '历史'
+  history: '历史',
+  played: '对局过'
 }
 
 const rows = computed<SuggestRow[]>(() => {
@@ -169,6 +171,7 @@ function rowIcon(row: SuggestRow) {
   if (row.kind === 'exact') return Search
   if (row.suggestion?.source === 'history') return TimeOutline
   if (row.suggestion?.source === 'note') return PricetagOutline
+  if (row.suggestion?.source === 'played') return GameControllerOutline
   return PersonOutline
 }
 
@@ -209,7 +212,8 @@ async function executeRow(row: SuggestRow): Promise<void> {
   // 精确查人:exact 行用原文,player 行用候选的完整名字与其自带大区
   const name = row.kind === 'player' ? row.suggestion!.name : text
   const region = row.kind === 'player' ? (row.suggestion!.region ?? '') : selectedRegion.value
-  pushSearchHistory(name, region)
+  // fire-and-forget:候选行是已知玩家直接记;手输名字待验证成功后才入历史
+  void recordSearchHistory(name, region, { known: row.kind === 'player' })
   searchValue.value = ''
   inputRef.value?.blur()
   await router.push({
@@ -262,6 +266,12 @@ async function runAiSearch(text: string): Promise<void> {
   transition:
     box-shadow var(--dur-fast) var(--ease-expo),
     border-color var(--dur-fast) var(--ease-expo);
+}
+
+/* 未输入时的提示字调小一号并淡化:纯引导信息,不该有输入文字的视觉分量 */
+.header-search :deep(.n-input__placeholder) {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
 }
 
 /* 聚焦时整框发光 */
@@ -334,12 +344,14 @@ async function runAiSearch(text: string): Promise<void> {
 .suggest-row {
   display: flex;
   align-items: center;
-  gap: var(--space-8);
-  padding: var(--space-6) var(--space-8);
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-8);
   border-radius: var(--radius-sm);
   cursor: pointer;
   color: var(--text-secondary);
-  font-size: var(--font-size-sm);
+  /* 候选面板用小一号字:与 header 输入框的辅助层级一致,避免喧宾夺主 */
+  font-size: var(--font-size-xs);
+  line-height: 1.6;
   transition:
     background-color var(--dur-fast) var(--ease-expo),
     color var(--dur-fast) var(--ease-expo);

--- a/rank-analysis-app/src/components/SuperSearch.vue
+++ b/rank-analysis-app/src/components/SuperSearch.vue
@@ -1,0 +1,393 @@
+<template>
+  <div class="super-search" @keydown="onKeydown">
+    <n-input
+      ref="inputRef"
+      class="input-lolid header-search"
+      type="text"
+      size="small"
+      placeholder="召唤师名#Tag,或直接描述想找的对局"
+      v-model:value="searchValue"
+      @focus="focused = true"
+      @blur="focused = false"
+    >
+      <!-- 前缀:大区下拉(框内左侧,细分隔线隔开),整体仍是一个搜索框 -->
+      <template #prefix>
+        <n-dropdown
+          trigger="click"
+          size="small"
+          :options="regionDropdownOptions"
+          @select="onRegionSelect"
+        >
+          <button class="region-trigger" type="button" @mousedown.prevent>
+            <span class="region-trigger-label">{{ selectedRegionLabel }}</span>
+            <n-icon :size="11" class="region-trigger-caret"><ChevronDownOutline /></n-icon>
+          </button>
+        </n-dropdown>
+        <span class="region-divider" />
+      </template>
+      <template #suffix>
+        <n-button text quaternary @click="executeActive" class="header-icon-btn">
+          <n-icon :component="Search" />
+        </n-button>
+      </template>
+    </n-input>
+
+    <!-- 候选面板:聚焦且有输入时展示;mousedown.prevent 防止点击前 input 先失焦 -->
+    <Transition name="panel-fade">
+      <div v-if="panelVisible" class="suggest-panel" @mousedown.prevent>
+        <div
+          v-for="(row, i) in rows"
+          :key="row.key"
+          class="suggest-row"
+          :class="{ active: i === activeIndex, 'ai-row': row.kind === 'ai' }"
+          @mouseenter="activeIndex = i"
+          @click="executeRow(row)"
+        >
+          <n-icon :size="14" class="row-icon" :component="rowIcon(row)" />
+          <span class="row-label">{{ row.label }}</span>
+          <span v-if="row.badge" class="row-badge">{{ row.badge }}</span>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * Header 超级搜索(omnibox)
+ *
+ * 三种行为合一(issue #157):
+ * - 精确查人:输入形似 Riot ID(名#tag)→ 现有 Record 查询流程
+ * - 模糊查人:本地候选(好友/备注/搜索历史)子串匹配,点选即精确查询
+ * - AI 搜战绩:任意自然语言 → 跳 Record 页 AI 解析(?aiq=)
+ *
+ * 回车执行当前高亮行,默认高亮:精确行 > 首个玩家候选 > AI 行。
+ */
+
+import { computed, onMounted, ref, watch } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import {
+  Search,
+  ChevronDownOutline,
+  PersonOutline,
+  TimeOutline,
+  PricetagOutline,
+  SparklesOutline
+} from '@vicons/ionicons5'
+import { useMessage } from 'naive-ui'
+import router from '@renderer/router'
+import { useGameState } from '@renderer/composables/useGameState'
+import {
+  useSearchSuggestions,
+  pushSearchHistory,
+  type PlayerSuggestion
+} from '@renderer/composables/useSearchSuggestions'
+
+/** 面板中的一行(精确查人 / 玩家候选 / AI 搜索) */
+interface SuggestRow {
+  kind: 'exact' | 'player' | 'ai'
+  key: string
+  label: string
+  /** 来源角标(好友/备注/历史),仅 player 行 */
+  badge?: string
+  /** player 行携带的原始候选 */
+  suggestion?: PlayerSuggestion
+}
+
+const message = useMessage()
+const { summoner } = useGameState()
+
+const searchValue = ref('')
+const focused = ref(false)
+const inputRef = ref()
+
+// ─── 大区选择(从 Header 原样迁入) ──────────────────────────────────────────
+
+/** 选中的大区 platformId(空 = 当前区,走本地 LCU;非空走 SGP 跨区查询) */
+const selectedRegion = ref('')
+const regionOptions = ref<{ label: string; value: string }[]>([{ label: '当前区', value: '' }])
+
+onMounted(async () => {
+  try {
+    const regions = await invoke<{ label: string; value: string }[]>('get_sgp_regions')
+    regionOptions.value = [{ label: '当前区', value: '' }, ...regions]
+  } catch (e) {
+    console.error('加载大区列表失败', e)
+  }
+})
+
+const regionDropdownOptions = computed(() =>
+  regionOptions.value.map(r => ({ label: r.label, key: r.value }))
+)
+const selectedRegionLabel = computed(
+  () => regionOptions.value.find(r => r.value === selectedRegion.value)?.label ?? '当前区'
+)
+const onRegionSelect = (key: string): void => {
+  selectedRegion.value = key
+}
+
+// ─── 候选行 ──────────────────────────────────────────────────────────────────
+
+const { playerSuggestions, riotIdLike } = useSearchSuggestions(searchValue)
+
+const SOURCE_BADGE: Record<PlayerSuggestion['source'], string> = {
+  friend: '好友',
+  note: '备注',
+  history: '历史'
+}
+
+const rows = computed<SuggestRow[]>(() => {
+  const text = searchValue.value.trim()
+  if (!text) return []
+  const out: SuggestRow[] = []
+  if (riotIdLike.value) {
+    out.push({ kind: 'exact', key: 'exact', label: `搜索召唤师「${text}」` })
+  }
+  for (const s of playerSuggestions.value) {
+    out.push({
+      kind: 'player',
+      key: `player:${s.source}:${s.name}`,
+      label: s.name,
+      badge: SOURCE_BADGE[s.source],
+      suggestion: s
+    })
+  }
+  out.push({ kind: 'ai', key: 'ai', label: `AI 搜战绩:「${text}」` })
+  return out
+})
+
+const panelVisible = computed(() => focused.value && rows.value.length > 0)
+
+const activeIndex = ref(0)
+// 行集变化时重置默认高亮:精确行/首个候选都在 0 位;仅剩 AI 行时也是 0
+watch(rows, () => {
+  activeIndex.value = 0
+})
+
+function rowIcon(row: SuggestRow) {
+  if (row.kind === 'ai') return SparklesOutline
+  if (row.kind === 'exact') return Search
+  if (row.suggestion?.source === 'history') return TimeOutline
+  if (row.suggestion?.source === 'note') return PricetagOutline
+  return PersonOutline
+}
+
+// ─── 执行 ────────────────────────────────────────────────────────────────────
+
+function onKeydown(e: KeyboardEvent): void {
+  if (!panelVisible.value) {
+    if (e.key === 'Enter') executeActive()
+    return
+  }
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    activeIndex.value = (activeIndex.value + 1) % rows.value.length
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    activeIndex.value = (activeIndex.value - 1 + rows.value.length) % rows.value.length
+  } else if (e.key === 'Enter') {
+    executeActive()
+  } else if (e.key === 'Escape') {
+    inputRef.value?.blur()
+  }
+}
+
+function executeActive(): void {
+  const row = rows.value[activeIndex.value]
+  if (row) executeRow(row)
+}
+
+async function executeRow(row: SuggestRow): Promise<void> {
+  const text = searchValue.value.trim()
+  if (!text) return
+
+  if (row.kind === 'ai') {
+    await runAiSearch(text)
+    return
+  }
+
+  // 精确查人:exact 行用原文,player 行用候选的完整名字与其自带大区
+  const name = row.kind === 'player' ? row.suggestion!.name : text
+  const region = row.kind === 'player' ? (row.suggestion!.region ?? '') : selectedRegion.value
+  pushSearchHistory(name, region)
+  searchValue.value = ''
+  inputRef.value?.blur()
+  await router.push({
+    path: '/Record',
+    query: { name, region: region || undefined, t: Date.now() }
+  })
+}
+
+/** AI 行:解析当前登录玩家名后跳 Record 页(?aiq= 由结果页消费) */
+async function runAiSearch(text: string): Promise<void> {
+  let selfName = ''
+  if (summoner.value?.gameName) {
+    selfName = `${summoner.value.gameName}#${summoner.value.tagLine}`
+  } else {
+    try {
+      const me = await invoke<{ gameName: string; tagLine: string }>('get_my_summoner')
+      selfName = `${me.gameName}#${me.tagLine}`
+    } catch {
+      message.error('AI 搜战绩需要先启动并登录游戏客户端')
+      return
+    }
+  }
+  searchValue.value = ''
+  inputRef.value?.blur()
+  await router.push({
+    path: '/Record',
+    query: { name: selfName, aiq: text, t: Date.now() }
+  })
+}
+</script>
+
+<style lang="css" scoped>
+.super-search {
+  position: relative;
+  width: 100%;
+}
+
+.input-lolid {
+  -webkit-app-region: no-drag;
+  pointer-events: auto;
+}
+
+/* 单一搜索框:大区做成框内左侧下拉前缀,整体一个边框/背景/聚焦态 */
+.header-search {
+  width: 100%;
+  border-radius: var(--radius-md);
+}
+
+.header-search :deep(.n-input-wrapper) {
+  transition:
+    box-shadow var(--dur-fast) var(--ease-expo),
+    border-color var(--dur-fast) var(--ease-expo);
+}
+
+/* 聚焦时整框发光 */
+.super-search:focus-within .header-search :deep(.n-input-wrapper) {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--semantic-win) 20%, transparent);
+  border-color: color-mix(in srgb, var(--semantic-win) 35%, transparent) !important;
+}
+
+/* 前缀:大区下拉触发器(小号文字 + 箭头,hover 淡底) */
+.region-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: 20px;
+  padding: 0 var(--space-4);
+  border: none;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+  -webkit-app-region: no-drag;
+  transition:
+    color var(--dur-fast) var(--ease-expo),
+    background-color var(--dur-fast) var(--ease-expo);
+}
+
+.region-trigger:hover {
+  color: var(--text-primary);
+  background: var(--glass-bg-high);
+}
+
+.region-trigger-caret {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+/* 前缀与输入文本之间的细分隔线 */
+.region-divider {
+  width: 1px;
+  height: 14px;
+  margin: 0 var(--space-8) 0 5px;
+  background: var(--glass-border);
+  flex-shrink: 0;
+}
+
+.header-icon-btn {
+  -webkit-app-region: no-drag;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+}
+
+/* 候选面板:输入框正下方的玻璃下拉 */
+.suggest-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated, var(--bg-base));
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 8px 24px color-mix(in srgb, black 25%, transparent);
+  -webkit-app-region: no-drag;
+}
+
+.suggest-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-6) var(--space-8);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  transition:
+    background-color var(--dur-fast) var(--ease-expo),
+    color var(--dur-fast) var(--ease-expo);
+}
+
+.suggest-row.active {
+  background: var(--glass-bg-high);
+  color: var(--text-primary);
+}
+
+.row-icon {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+}
+
+.suggest-row.ai-row .row-icon {
+  color: var(--accent-gold, #c8aa6e);
+}
+
+.row-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.row-badge {
+  flex-shrink: 0;
+  font-size: var(--font-size-2xs, 10px);
+  color: var(--text-tertiary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-6);
+  line-height: 16px;
+}
+
+.panel-fade-enter-active,
+.panel-fade-leave-active {
+  transition:
+    opacity var(--dur-fast) var(--ease-expo),
+    transform var(--dur-fast) var(--ease-expo);
+}
+
+.panel-fade-enter-from,
+.panel-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/rank-analysis-app/src/components/record/AiSearchResults.vue
+++ b/rank-analysis-app/src/components/record/AiSearchResults.vue
@@ -1,0 +1,253 @@
+<template>
+  <div class="ai-search-wrap">
+    <!-- 原始描述 + 解析出的条件 chips(可删,删后本地重筛) -->
+    <div class="ai-query-bar">
+      <n-icon :size="15" class="ai-icon" :component="SparklesOutline" />
+      <span class="ai-query-text">「{{ queryText }}」</span>
+    </div>
+
+    <n-flex v-if="chips.length > 0" class="chips-row" :size="6" align="center">
+      <n-tag
+        v-for="chip in chips"
+        :key="chip.key"
+        closable
+        size="small"
+        round
+        @close="removeChip(chip.key)"
+      >
+        {{ chip.label }}
+      </n-tag>
+    </n-flex>
+
+    <!-- 阶段态 -->
+    <div v-if="phase === 'parsing'" class="phase-hint">
+      <n-spin size="small" />
+      <span>AI 正在理解你的描述…</span>
+    </div>
+    <div v-else-if="phase === 'fetching'" class="phase-hint">
+      <n-spin size="small" />
+      <span>
+        正在检索战绩,已翻 {{ progress.fetched }} 局<template v-if="oldestDateCn"
+          >,覆盖至 {{ oldestDateCn }}</template
+        >…
+      </span>
+    </div>
+    <n-empty v-else-if="phase === 'error'" :description="error" class="phase-empty">
+      <template #extra>
+        <n-button size="small" @click="retry">重试</n-button>
+      </template>
+    </n-empty>
+
+    <template v-else-if="phase === 'done'">
+      <!-- 搜索范围说明 -->
+      <div class="meta-line">
+        已在{{
+          meta?.source === 'lcu' ? '最近 50 局(跨区服务不可用,已降级)' : searchScopeCn
+        }}
+        中搜索,命中 {{ results.length }} 局<template v-if="meta?.truncated"
+          >;已达检索上限,更早的对局未包含</template
+        >
+      </div>
+
+      <!-- 相遇统计答案卡(count 意图) -->
+      <div v-if="encounterStats" class="encounter-card">
+        <div class="encounter-total">共相遇 {{ encounterStats.total }} 局</div>
+        <div v-for="(c, name) in encounterStats.perName" :key="name" class="encounter-row">
+          <span class="encounter-name">{{ name }}</span>
+          <span>同队 {{ c.ally }} 次 / 对面 {{ c.enemy }} 次</span>
+        </div>
+      </div>
+
+      <!-- 结果列表(复用战绩卡) -->
+      <n-empty
+        v-if="results.length === 0 && !encounterStats"
+        description="没有找到匹配的对局"
+        class="phase-empty"
+      />
+      <TransitionGroup v-else name="list" tag="div" class="ai-result-list">
+        <div
+          v-for="(game, index) in results"
+          :key="game.gameId"
+          :style="{ '--stagger-i': index }"
+          class="list-item"
+        >
+          <RecordCard :record-type="true" :games="game" @open-detail="openDetail(game)" />
+        </div>
+      </TransitionGroup>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * AI 自然语言搜战绩的结果视图(issue #157)
+ *
+ * Record 页在 route.query.aiq 存在时渲染本组件替代 MatchHistory。
+ * 管线状态由 useAiMatchSearch 驱动;条件 chips 可删除(本地重筛),
+ * 让用户看见并能修正 AI 的理解。
+ */
+
+import { computed, provide, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { SparklesOutline } from '@vicons/ionicons5'
+import RecordCard from './RecordCard.vue'
+import { openMatchDetailWindow } from './detailWindow'
+import { collectAssetIds } from './collectAssetIds'
+import { useRecordAssets } from '@renderer/composables/useRecordAssets'
+import { recordAssetsKey } from '@renderer/composables/recordAssetsKey'
+import { useAiMatchSearch } from '@renderer/composables/useAiMatchSearch'
+import { initModeOptions } from '@renderer/composables/useGameModes'
+import { clearParseCache } from '@renderer/services/ai/matchSearch/parse'
+import type { Game } from '@renderer/types/domain/match'
+
+const route = useRoute()
+const queryText = computed(() => (route.query.aiq as string) ?? '')
+
+const { phase, error, progress, chips, results, encounterStats, meta, run, removeChip } =
+  useAiMatchSearch()
+
+// 与 MatchHistory 相同的父级资产预载模式
+const recordAssets = useRecordAssets()
+provide(recordAssetsKey, recordAssets)
+watch(results, games => {
+  const { items, spells, perks } = collectAssetIds(games)
+  recordAssets.preload([
+    { kind: 'item', ids: items },
+    { kind: 'spell', ids: spells },
+    { kind: 'perk', ids: perks }
+  ])
+})
+
+/** 拉取进度里最旧对局日期的短格式(几月几日) */
+const oldestDateCn = computed(() => {
+  if (!progress.value.oldestDate) return ''
+  const d = new Date(progress.value.oldestDate)
+  return Number.isNaN(d.getTime()) ? '' : `${d.getMonth() + 1}月${d.getDate()}日`
+})
+
+/** done 态的搜索范围文案 */
+const searchScopeCn = computed(() => `最近 ${meta.value?.searchedCount ?? 0} 局`)
+
+async function openDetail(game: Game): Promise<void> {
+  await openMatchDetailWindow(game)
+}
+
+/** 错误重试:清掉这句的解析缓存(坏缓存会让重试原地失败)再跑一遍 */
+function retry(): void {
+  clearParseCache(queryText.value)
+  if (queryText.value) run(queryText.value)
+}
+
+// aiq 变化(新搜索)即重跑;initModeOptions 为 chips 的队列名兜底
+watch(
+  queryText,
+  async text => {
+    if (!text) return
+    await initModeOptions()
+    run(text)
+  },
+  { immediate: true }
+)
+</script>
+
+<style lang="css" scoped>
+.ai-search-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  width: 100%;
+}
+
+.ai-query-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+}
+
+.ai-icon {
+  color: var(--accent-gold, #c8aa6e);
+  flex-shrink: 0;
+}
+
+.ai-query-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chips-row {
+  flex-wrap: wrap;
+}
+
+.phase-hint {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  padding: var(--space-16) 0;
+}
+
+.phase-empty {
+  padding: var(--space-24) 0;
+}
+
+.meta-line {
+  color: var(--text-tertiary);
+  font-size: var(--font-size-xs);
+}
+
+.encounter-card {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--glass-bg-low);
+  padding: var(--space-12) var(--space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.encounter-total {
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.encounter-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-12);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.encounter-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ai-result-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.list-enter-active {
+  transition:
+    opacity var(--dur-normal) var(--ease-expo),
+    transform var(--dur-normal) var(--ease-expo);
+  transition-delay: calc(var(--stagger) * var(--stagger-i, 0));
+}
+
+.list-enter-from {
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+.list-move {
+  transition: transform var(--dur-normal) var(--ease-expo);
+}
+</style>

--- a/rank-analysis-app/src/components/record/AiSearchResults.vue
+++ b/rank-analysis-app/src/components/record/AiSearchResults.vue
@@ -40,14 +40,7 @@
 
     <template v-else-if="phase === 'done'">
       <!-- 搜索范围说明 -->
-      <div class="meta-line">
-        已在{{
-          meta?.source === 'lcu' ? '最近 50 局(跨区服务不可用,已降级)' : searchScopeCn
-        }}
-        中搜索,命中 {{ results.length }} 局<template v-if="meta?.truncated"
-          >;已达检索上限,更早的对局未包含</template
-        >
-      </div>
+      <div class="meta-line">{{ metaLineCn }}</div>
 
       <!-- 相遇统计答案卡(count 意图) -->
       <div v-if="encounterStats" class="encounter-card">
@@ -125,8 +118,15 @@ const oldestDateCn = computed(() => {
   return Number.isNaN(d.getTime()) ? '' : `${d.getMonth() + 1}月${d.getDate()}日`
 })
 
-/** done 态的搜索范围文案 */
-const searchScopeCn = computed(() => `最近 ${meta.value?.searchedCount ?? 0} 局`)
+/** done 态的搜索范围整句文案(computed 拼接,避免模板断行产生多余空格) */
+const metaLineCn = computed(() => {
+  const scope =
+    meta.value?.source === 'lcu'
+      ? '最近 50 局(跨区服务不可用,已降级)'
+      : `最近 ${meta.value?.searchedCount ?? 0} 局`
+  const truncated = meta.value?.truncated ? ';已达检索上限,更早的对局未包含' : ''
+  return `已在${scope}中搜索,命中 ${results.value.length} 局${truncated}`
+})
 
 async function openDetail(game: Game): Promise<void> {
   await openMatchDetailWindow(game)

--- a/rank-analysis-app/src/components/record/AiSearchResults.vue
+++ b/rank-analysis-app/src/components/record/AiSearchResults.vue
@@ -91,10 +91,11 @@ import { recordAssetsKey } from '@renderer/composables/recordAssetsKey'
 import { useAiMatchSearch } from '@renderer/composables/useAiMatchSearch'
 import { initModeOptions } from '@renderer/composables/useGameModes'
 import { clearParseCache } from '@renderer/services/ai/matchSearch/parse'
+import { firstQueryValue } from '@renderer/utils/navigation'
 import type { Game } from '@renderer/types/domain/match'
 
 const route = useRoute()
-const queryText = computed(() => (route.query.aiq as string) ?? '')
+const queryText = computed(() => firstQueryValue(route.query.aiq))
 
 const { phase, error, progress, chips, results, encounterStats, meta, run, removeChip } =
   useAiMatchSearch()

--- a/rank-analysis-app/src/components/record/MatchHistory.vue
+++ b/rank-analysis-app/src/components/record/MatchHistory.vue
@@ -112,6 +112,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { championOption } from '../type'
 import type { Game, MatchHistory } from './match'
 import { openMatchDetailWindow } from './detailWindow'
+import { collectAssetIds } from './collectAssetIds'
 import { useRecordAssets } from '@renderer/composables/useRecordAssets'
 import { recordAssetsKey } from '@renderer/composables/recordAssetsKey'
 
@@ -121,37 +122,6 @@ import { recordAssetsKey } from '@renderer/composables/recordAssetsKey'
  */
 const recordAssets = useRecordAssets()
 provide(recordAssetsKey, recordAssets)
-
-function collectAssetIds(games: Game[] | undefined) {
-  const items = new Set<number>()
-  const spells = new Set<number>()
-  const perks = new Set<number>()
-  for (const g of games ?? []) {
-    const s = g.participants[0]?.stats
-    if (!s) continue
-    ;[s.item0, s.item1, s.item2, s.item3, s.item4, s.item5, s.item6].forEach(id => {
-      if (id > 0) items.add(id)
-    })
-    ;[g.participants[0].spell1Id, g.participants[0].spell2Id].forEach(id => {
-      if (id > 0) spells.add(id)
-    })
-    ;[
-      s.playerAugment1,
-      s.playerAugment2,
-      s.playerAugment3,
-      s.playerAugment4,
-      s.playerAugment5,
-      s.playerAugment6
-    ].forEach(id => {
-      if (id > 0) perks.add(id)
-    })
-  }
-  return {
-    items: [...items],
-    spells: [...spells],
-    perks: [...perks]
-  }
-}
 
 const filterQueueId = ref(0)
 const filterChampionId = ref(-1)

--- a/rank-analysis-app/src/components/record/collectAssetIds.ts
+++ b/rank-analysis-app/src/components/record/collectAssetIds.ts
@@ -1,0 +1,43 @@
+/**
+ * 从一批对局中收集需要预载的资产 ID(装备/召唤师技能/符文强化)
+ *
+ * 战绩列表(MatchHistory / AiSearchResults)在父级一次性去重收集后下发 IPC,
+ * 子 RecordCard 经 inject 共享,跳过自身 preload。
+ */
+
+import type { Game } from '@renderer/types/domain/match'
+
+export function collectAssetIds(games: Game[] | undefined): {
+  items: number[]
+  spells: number[]
+  perks: number[]
+} {
+  const items = new Set<number>()
+  const spells = new Set<number>()
+  const perks = new Set<number>()
+  for (const g of games ?? []) {
+    const s = g.participants[0]?.stats
+    if (!s) continue
+    ;[s.item0, s.item1, s.item2, s.item3, s.item4, s.item5, s.item6].forEach(id => {
+      if (id > 0) items.add(id)
+    })
+    ;[g.participants[0].spell1Id, g.participants[0].spell2Id].forEach(id => {
+      if (id > 0) spells.add(id)
+    })
+    ;[
+      s.playerAugment1,
+      s.playerAugment2,
+      s.playerAugment3,
+      s.playerAugment4,
+      s.playerAugment5,
+      s.playerAugment6
+    ].forEach(id => {
+      if (id > 0) perks.add(id)
+    })
+  }
+  return {
+    items: [...items],
+    spells: [...spells],
+    perks: [...perks]
+  }
+}

--- a/rank-analysis-app/src/composables/useAiMatchSearch.spec.ts
+++ b/rank-analysis-app/src/composables/useAiMatchSearch.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@renderer/services/ai/matchSearch/parse', () => ({ parseMatchQuery: vi.fn() }))
+vi.mock('@renderer/services/ai/matchSearch/fetch', () => ({ fetchGamesForQuery: vi.fn() }))
+vi.mock('@renderer/services/ai/champion-names', () => ({
+  loadChampionNames: vi.fn().mockResolvedValue(undefined),
+  getChampionName: (id: number) => `英雄${id}`
+}))
+
+import type { Game } from '@renderer/types/domain/match'
+import { parseMatchQuery } from '@renderer/services/ai/matchSearch/parse'
+import { fetchGamesForQuery } from '@renderer/services/ai/matchSearch/fetch'
+import { emptyQuery } from '@renderer/services/ai/matchSearch/schema'
+import { useAiMatchSearch } from './useAiMatchSearch'
+
+const mockParse = parseMatchQuery as ReturnType<typeof vi.fn>
+const mockFetch = fetchGamesForQuery as ReturnType<typeof vi.fn>
+
+/** 最小对局:自己用 championId,可选带一个队友 */
+function gameOf(opts: { championId: number; win?: boolean; allyName?: string }): Game {
+  const players = [
+    { championId: opts.championId, teamId: 100, name: '我', tag: '1' },
+    ...(opts.allyName ? [{ championId: 999, teamId: 100, name: opts.allyName, tag: '2' }] : [])
+  ]
+  return {
+    gameId: Math.random(),
+    gameCreationDate: '2026-08-15T12:00:00.000Z',
+    queueId: 420,
+    participants: [
+      {
+        teamId: 100,
+        championId: opts.championId,
+        stats: { win: opts.win ?? true }
+      }
+    ],
+    gameDetail: {
+      participants: players.map((p, i) => ({
+        participantId: i + 1,
+        teamId: p.teamId,
+        championId: p.championId,
+        stats: { win: opts.win ?? true }
+      })),
+      participantIdentities: players.map((p, i) => ({
+        player: { gameName: p.name, tagLine: p.tag, puuid: `p${i}` }
+      }))
+    }
+  } as unknown as Game
+}
+
+beforeEach(() => {
+  mockParse.mockReset()
+  mockFetch.mockReset()
+})
+
+describe('useAiMatchSearch', () => {
+  it('happy path:parsing → fetching → done,按条件过滤结果', async () => {
+    mockParse.mockResolvedValue({ ...emptyQuery(), selfChampionIds: [51] })
+    mockFetch.mockResolvedValue({
+      games: [gameOf({ championId: 51 }), gameOf({ championId: 64 })],
+      source: 'sgp',
+      truncated: false,
+      selfName: '我#1'
+    })
+    const s = useAiMatchSearch()
+    await s.run('我用女警那把')
+    expect(s.phase.value).toBe('done')
+    expect(s.results.value).toHaveLength(1)
+    expect(s.results.value[0].participants[0].championId).toBe(51)
+    expect(s.meta.value).toMatchObject({ source: 'sgp', truncated: false, searchedCount: 2 })
+    expect(s.chips.value.map(c => c.key)).toContain('self:51')
+  })
+
+  it('解析失败进入 error 态并带可展示信息', async () => {
+    mockParse.mockRejectedValue(new Error('AI 未能解析'))
+    const s = useAiMatchSearch()
+    await s.run('???')
+    expect(s.phase.value).toBe('error')
+    expect(s.error.value).toContain('AI 未能解析')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('拉取失败进入 error 态', async () => {
+    mockParse.mockResolvedValue(emptyQuery())
+    mockFetch.mockRejectedValue(new Error('无法获取当前召唤师'))
+    const s = useAiMatchSearch()
+    await s.run('x')
+    expect(s.phase.value).toBe('error')
+    expect(s.error.value).toContain('召唤师')
+  })
+
+  it('count 意图产出相遇统计', async () => {
+    mockParse.mockResolvedValue({
+      ...emptyQuery(),
+      playerNames: ['老熟人#2'],
+      intent: 'count_encounters'
+    })
+    mockFetch.mockResolvedValue({
+      games: [gameOf({ championId: 51, allyName: '老熟人' }), gameOf({ championId: 51 })],
+      source: 'sgp',
+      truncated: false,
+      selfName: '我#1'
+    })
+    const s = useAiMatchSearch()
+    await s.run('跟老熟人碰过几次')
+    expect(s.encounterStats.value?.total).toBe(1)
+    expect(s.results.value).toHaveLength(1)
+  })
+
+  it('removeChip 本地重筛,不再调用 parse/fetch', async () => {
+    mockParse.mockResolvedValue({ ...emptyQuery(), selfChampionIds: [51], result: 'win' })
+    mockFetch.mockResolvedValue({
+      games: [gameOf({ championId: 51, win: true }), gameOf({ championId: 64, win: true })],
+      source: 'sgp',
+      truncated: false,
+      selfName: '我#1'
+    })
+    const s = useAiMatchSearch()
+    await s.run('x')
+    expect(s.results.value).toHaveLength(1)
+
+    s.removeChip('self:51')
+    expect(s.results.value).toHaveLength(2)
+    expect(mockParse).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('拉取进度透传到 progress', async () => {
+    mockParse.mockResolvedValue(emptyQuery())
+    mockFetch.mockImplementation(async (_q, onProgress) => {
+      onProgress?.({ fetched: 20, oldestDate: '2026-08-01T00:00:00.000Z' })
+      return { games: [], source: 'sgp', truncated: false, selfName: '我#1' }
+    })
+    const s = useAiMatchSearch()
+    await s.run('x')
+    expect(s.progress.value.fetched).toBe(20)
+  })
+})

--- a/rank-analysis-app/src/composables/useAiMatchSearch.ts
+++ b/rank-analysis-app/src/composables/useAiMatchSearch.ts
@@ -1,0 +1,132 @@
+/**
+ * AI 搜战绩的编排状态机(Record 页 AiSearchResults 使用)
+ *
+ * run(text) 驱动:parsing(qwen 解析)→ fetching(SGP 分页拉取)→ done。
+ * 拉到的原始对局保留在内存,删 chip 只做本地重筛,不重打模型/网络。
+ */
+
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+import { parseMatchQuery } from '@renderer/services/ai/matchSearch/parse'
+import { fetchGamesForQuery, type FetchProgress } from '@renderer/services/ai/matchSearch/fetch'
+import { filterGames, countEncounters } from '@renderer/services/ai/matchSearch/filter'
+import { queryToChips, removeChipFromQuery } from '@renderer/services/ai/matchSearch/chips'
+import type {
+  ParsedMatchQuery,
+  EncounterStats,
+  QueryChip
+} from '@renderer/services/ai/matchSearch/types'
+import { loadChampionNames, getChampionName } from '@renderer/services/ai/champion-names'
+import { modeOptions } from '@renderer/composables/useGameModes'
+import type { Game } from '@renderer/types/domain/match'
+
+export type AiSearchPhase = 'idle' | 'parsing' | 'fetching' | 'done' | 'error'
+
+/** 搜索结果的元信息(数据源/是否截断/实际搜索局数,供结果区说明) */
+export interface AiSearchMeta {
+  source: 'sgp' | 'lcu'
+  truncated: boolean
+  searchedCount: number
+}
+
+export function useAiMatchSearch(): {
+  phase: Ref<AiSearchPhase>
+  error: Ref<string>
+  progress: Ref<FetchProgress>
+  query: Ref<ParsedMatchQuery | null>
+  chips: ComputedRef<QueryChip[]>
+  results: Ref<Game[]>
+  encounterStats: Ref<EncounterStats | null>
+  meta: Ref<AiSearchMeta | null>
+  run(text: string): Promise<void>
+  removeChip(key: string): void
+} {
+  const phase = ref<AiSearchPhase>('idle')
+  const error = ref('')
+  const progress = ref<FetchProgress>({ fetched: 0, oldestDate: null })
+  const query = ref<ParsedMatchQuery | null>(null)
+  const results = ref<Game[]>([])
+  const encounterStats = ref<EncounterStats | null>(null)
+  const meta = ref<AiSearchMeta | null>(null)
+
+  /** 拉取到的原始对局(筛选前),供删 chip 后本地重筛 */
+  let rawGames: Game[] = []
+
+  const queueName = (id: number): string =>
+    modeOptions.value.find(m => m.value === id)?.label ?? `队列${id}`
+
+  const chips = computed<QueryChip[]>(() =>
+    query.value ? queryToChips(query.value, getChampionName, queueName) : []
+  )
+
+  /** 按当前 query 对 rawGames 重算结果(list 与 count 两种意图) */
+  function applyFilter(): void {
+    const q = query.value
+    if (!q) return
+    if (q.intent === 'count_encounters' && q.playerNames.length > 0) {
+      const { stats, games } = countEncounters(rawGames, q)
+      encounterStats.value = stats
+      results.value = games
+    } else {
+      encounterStats.value = null
+      results.value = filterGames(rawGames, q)
+    }
+  }
+
+  async function run(text: string): Promise<void> {
+    phase.value = 'parsing'
+    error.value = ''
+    progress.value = { fetched: 0, oldestDate: null }
+    results.value = []
+    encounterStats.value = null
+    meta.value = null
+
+    try {
+      query.value = await parseMatchQuery(text)
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e)
+      phase.value = 'error'
+      return
+    }
+
+    phase.value = 'fetching'
+    try {
+      const fetched = await fetchGamesForQuery(query.value, p => {
+        progress.value = p
+      })
+      rawGames = fetched.games
+      meta.value = {
+        source: fetched.source,
+        truncated: fetched.truncated,
+        searchedCount: fetched.games.length
+      }
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e)
+      phase.value = 'error'
+      return
+    }
+
+    // chips 展示需要英雄中文名(懒加载一次,失败也不阻塞结果)
+    await loadChampionNames()
+    applyFilter()
+    phase.value = 'done'
+  }
+
+  function removeChip(key: string): void {
+    if (!query.value) return
+    query.value = removeChipFromQuery(query.value, key)
+    applyFilter()
+  }
+
+  return {
+    phase,
+    error,
+    progress,
+    query,
+    chips,
+    results,
+    encounterStats,
+    meta,
+    run,
+    removeChip
+  }
+}

--- a/rank-analysis-app/src/composables/useAiMatchSearch.ts
+++ b/rank-analysis-app/src/composables/useAiMatchSearch.ts
@@ -81,7 +81,10 @@ export function useAiMatchSearch(): {
     meta.value = null
 
     try {
-      query.value = await parseMatchQuery(text)
+      // 英雄名与解析并行加载:chips computed 不依赖名字表的响应式,
+      // 必须保证 query 赋值(触发 chips 首次渲染)前名字表已就绪
+      const [parsed] = await Promise.all([parseMatchQuery(text), loadChampionNames()])
+      query.value = parsed
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e)
       phase.value = 'error'
@@ -105,8 +108,6 @@ export function useAiMatchSearch(): {
       return
     }
 
-    // chips 展示需要英雄中文名(懒加载一次,失败也不阻塞结果)
-    await loadChampionNames()
     applyFilter()
     phase.value = 'done'
   }

--- a/rank-analysis-app/src/composables/useSearchSuggestions.spec.ts
+++ b/rank-analysis-app/src/composables/useSearchSuggestions.spec.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+
+import { invoke } from '@tauri-apps/api/core'
+import type { Game } from '@renderer/types/domain/match'
 import {
   isRiotIdLike,
   buildPlayerSuggestions,
   loadSearchHistory,
   pushSearchHistory,
+  recordSearchHistory,
+  extractRecentPlayers,
   type PlayerSuggestion
 } from './useSearchSuggestions'
+
+const mockInvoke = invoke as ReturnType<typeof vi.fn>
 
 describe('isRiotIdLike', () => {
   it('名字#tag 形态判定为 Riot ID', () => {
@@ -41,9 +50,21 @@ describe('buildPlayerSuggestions', () => {
     expect(out[0].source).toBe('friend')
   })
 
-  it('分组排序:好友 → 备注 → 历史', () => {
-    const out = buildPlayerSuggestions('', sources)
-    expect(out.map(s => s.source)).toEqual(['friend', 'friend', 'note', 'history'])
+  it('分组排序:好友 → 备注 → 历史 → 对局过', () => {
+    const out = buildPlayerSuggestions('', {
+      ...sources,
+      played: [{ name: '路人王#555', source: 'played' }]
+    })
+    expect(out.map(s => s.source)).toEqual(['friend', 'friend', 'note', 'history', 'played'])
+  })
+
+  it('对局过的玩家与好友重名时保留好友来源', () => {
+    const out = buildPlayerSuggestions('好友甲', {
+      ...sources,
+      played: [{ name: '好友甲#111', source: 'played' }]
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0].source).toBe('friend')
   })
 
   it('无匹配返回空数组', () => {
@@ -84,5 +105,89 @@ describe('searchHistory (localStorage)', () => {
   it('存储损坏时返回空数组', () => {
     localStorage.setItem('searchHistory.v1', '{oops')
     expect(loadSearchHistory()).toEqual([])
+  })
+})
+
+describe('recordSearchHistory (成功后写入)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockInvoke.mockReset()
+  })
+
+  it('已知玩家(候选行)直接写入,不发验证请求', async () => {
+    await recordSearchHistory('好友甲#111', '', { known: true })
+    expect(loadSearchHistory()[0]?.name).toBe('好友甲#111')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('当前区手输名字:召唤师存在才写入', async () => {
+    mockInvoke.mockResolvedValue({ puuid: 'p' })
+    await recordSearchHistory('真实存在#123', '')
+    expect(mockInvoke).toHaveBeenCalledWith('get_summoner_by_name', { name: '真实存在#123' })
+    expect(loadSearchHistory()[0]?.name).toBe('真实存在#123')
+  })
+
+  it('当前区手输名字:召唤师不存在不写入', async () => {
+    mockInvoke.mockRejectedValue(new Error('SummonerNotFound'))
+    await recordSearchHistory('打错的名字#000', '')
+    expect(loadSearchHistory()).toEqual([])
+  })
+
+  it('跨区搜索无法便宜验证,直接写入', async () => {
+    await recordSearchHistory('跨区玩家#123', 'HN1')
+    expect(loadSearchHistory()[0]?.region).toBe('HN1')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('extractRecentPlayers', () => {
+  function gameWith(names: [string, string][], date: string): Game {
+    return {
+      gameCreationDate: date,
+      participants: [],
+      gameDetail: {
+        participants: [],
+        participantIdentities: names.map(([n, t], i) => ({
+          player: { gameName: n, tagLine: t, puuid: n === '我' ? 'me' : `p${n}${i}` }
+        }))
+      }
+    } as unknown as Game
+  }
+
+  it('提取全部同局玩家,排除自己,按出现顺序去重', () => {
+    const games = [
+      gameWith(
+        [
+          ['我', '1'],
+          ['甲', '2'],
+          ['乙', '3']
+        ],
+        '2026-08-30T10:00:00.000Z'
+      ),
+      gameWith(
+        [
+          ['甲', '2'],
+          ['我', '1'],
+          ['丙', '4']
+        ],
+        '2026-08-29T10:00:00.000Z'
+      )
+    ]
+    const out = extractRecentPlayers(games, 'me')
+    expect(out.map(s => s.name)).toEqual(['甲#2', '乙#3', '丙#4'])
+    expect(out.every(s => s.source === 'played')).toBe(true)
+  })
+
+  it('跳过没有 gameName 的条目(人机等)', () => {
+    const games = [
+      gameWith(
+        [
+          ['我', '1'],
+          ['', '0']
+        ],
+        '2026-08-30T10:00:00.000Z'
+      )
+    ]
+    expect(extractRecentPlayers(games, 'me')).toEqual([])
   })
 })

--- a/rank-analysis-app/src/composables/useSearchSuggestions.spec.ts
+++ b/rank-analysis-app/src/composables/useSearchSuggestions.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isRiotIdLike,
+  buildPlayerSuggestions,
+  loadSearchHistory,
+  pushSearchHistory,
+  type PlayerSuggestion
+} from './useSearchSuggestions'
+
+describe('isRiotIdLike', () => {
+  it('名字#tag 形态判定为 Riot ID', () => {
+    expect(isRiotIdLike('某玩家#12345')).toBe(true)
+    expect(isRiotIdLike('name with space#CN1')).toBe(true)
+  })
+
+  it('自然语言/缺 tag/多个 # 不算', () => {
+    expect(isRiotIdLike('这个月我用女警赢的那把')).toBe(false)
+    expect(isRiotIdLike('某玩家#')).toBe(false)
+    expect(isRiotIdLike('#12345')).toBe(false)
+    expect(isRiotIdLike('a#b#c')).toBe(false)
+    expect(isRiotIdLike('')).toBe(false)
+  })
+})
+
+describe('buildPlayerSuggestions', () => {
+  const sources = {
+    friends: [
+      { name: '好友甲#111', source: 'friend' },
+      { name: '好友乙#222', source: 'friend' }
+    ] as PlayerSuggestion[],
+    notes: [
+      { name: '好友甲#111', source: 'note' },
+      { name: '备注哥#333', source: 'note' }
+    ] as PlayerSuggestion[],
+    history: [{ name: '历史姐#444', region: 'HN1', source: 'history' }] as PlayerSuggestion[]
+  }
+
+  it('大小写不敏感子串匹配,好友优先去重', () => {
+    const out = buildPlayerSuggestions('好友甲', sources)
+    expect(out).toHaveLength(1)
+    expect(out[0].source).toBe('friend')
+  })
+
+  it('分组排序:好友 → 备注 → 历史', () => {
+    const out = buildPlayerSuggestions('', sources)
+    expect(out.map(s => s.source)).toEqual(['friend', 'friend', 'note', 'history'])
+  })
+
+  it('无匹配返回空数组', () => {
+    expect(buildPlayerSuggestions('不存在', sources)).toEqual([])
+  })
+
+  it('每个来源最多 4 条', () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      name: `好友${i}#000`,
+      source: 'friend' as const
+    }))
+    const out = buildPlayerSuggestions('好友', { friends: many, notes: [], history: [] })
+    expect(out).toHaveLength(4)
+  })
+})
+
+describe('searchHistory (localStorage)', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('push 后可读回,最近在前', () => {
+    pushSearchHistory('甲#1', '')
+    pushSearchHistory('乙#2', 'HN1')
+    const h = loadSearchHistory()
+    expect(h[0].name).toBe('乙#2')
+    expect(h[0].region).toBe('HN1')
+    expect(h[1].name).toBe('甲#1')
+  })
+
+  it('同名同区去重(提升到最前),上限 20', () => {
+    for (let i = 0; i < 25; i++) pushSearchHistory(`玩家${i}#0`, '')
+    pushSearchHistory('玩家3#0', '')
+    const h = loadSearchHistory()
+    expect(h).toHaveLength(20)
+    expect(h[0].name).toBe('玩家3#0')
+    expect(h.filter(e => e.name === '玩家3#0')).toHaveLength(1)
+  })
+
+  it('存储损坏时返回空数组', () => {
+    localStorage.setItem('searchHistory.v1', '{oops')
+    expect(loadSearchHistory()).toEqual([])
+  })
+})

--- a/rank-analysis-app/src/composables/useSearchSuggestions.ts
+++ b/rank-analysis-app/src/composables/useSearchSuggestions.ts
@@ -1,0 +1,175 @@
+/**
+ * Header 超级搜索的候选聚合
+ *
+ * 三个本地数据源(全部毫秒级,不打网络):
+ * - 好友列表(get_friends,首次有输入时懒加载一次,失败静默降级)
+ * - 备注玩家(usePlayerNotesStore.list)
+ * - 搜索历史(localStorage,精确查人成功后写入)
+ *
+ * 纯函数(isRiotIdLike / buildPlayerSuggestions / 历史读写)单独导出便于测试,
+ * composable 只做数据源接线。
+ */
+
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+
+/** 单条玩家候选 */
+export interface PlayerSuggestion {
+  /** 完整 Riot ID:名字#tag */
+  name: string
+  /** 历史来源可携带当时的大区(platformId),其余来源为空 = 当前区 */
+  region?: string
+  source: 'friend' | 'note' | 'history'
+}
+
+/** 每个来源最多展示的候选数 */
+const MAX_PER_SOURCE = 4
+
+/**
+ * 输入是否形似 Riot ID:恰好一个 `#`,号前有名字、号后有非空白 tag。
+ * gameName 可含空格,不能按空格判断。
+ */
+export function isRiotIdLike(input: string): boolean {
+  const s = input.trim()
+  const first = s.indexOf('#')
+  if (first <= 0 || first !== s.lastIndexOf('#')) return false
+  return /\S/.test(s.slice(first + 1))
+}
+
+/**
+ * 聚合三个来源的候选:大小写不敏感子串匹配、跨来源按名字去重
+ * (好友 > 备注 > 历史)、每来源截断到 {@link MAX_PER_SOURCE}。
+ * @param input - 当前输入(空串 = 不过滤,用于展示默认候选)
+ */
+export function buildPlayerSuggestions(
+  input: string,
+  sources: {
+    friends: PlayerSuggestion[]
+    notes: PlayerSuggestion[]
+    history: PlayerSuggestion[]
+  }
+): PlayerSuggestion[] {
+  const needle = input.trim().toLowerCase()
+  const seen = new Set<string>()
+  const out: PlayerSuggestion[] = []
+
+  for (const group of [sources.friends, sources.notes, sources.history]) {
+    let taken = 0
+    for (const s of group) {
+      if (taken >= MAX_PER_SOURCE) break
+      const key = s.name.toLowerCase()
+      if (seen.has(key)) continue
+      if (needle && !key.includes(needle)) continue
+      seen.add(key)
+      out.push(s)
+      taken++
+    }
+  }
+  return out
+}
+
+// ─── 搜索历史(localStorage) ─────────────────────────────────────────────────
+
+const HISTORY_KEY = 'searchHistory.v1'
+const HISTORY_LIMIT = 20
+
+export interface SearchHistoryEntry {
+  name: string
+  region: string
+  ts: number
+}
+
+/** 读取搜索历史(最近在前);存储缺失/损坏返回空数组 */
+export function loadSearchHistory(): SearchHistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (e): e is SearchHistoryEntry => typeof e?.name === 'string' && typeof e?.region === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+/** 记录一次成功的精确查人(name+region 去重提升到最前,上限 20) */
+export function pushSearchHistory(name: string, region: string): void {
+  try {
+    const rest = loadSearchHistory().filter(e => !(e.name === name && e.region === region))
+    const next = [{ name, region, ts: Date.now() }, ...rest].slice(0, HISTORY_LIMIT)
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(next))
+  } catch {
+    // 存储不可用(隐私模式等)时静默放弃,搜索功能本身不受影响
+  }
+}
+
+// ─── composable ──────────────────────────────────────────────────────────────
+
+interface FriendLite {
+  gameName: string
+  tagLine: string
+  puuid: string
+}
+
+/**
+ * 组件侧候选接线:输入 ref → 响应式候选列表 + Riot ID 判定
+ * @param input - 搜索框输入
+ */
+export function useSearchSuggestions(input: Ref<string>): {
+  playerSuggestions: ComputedRef<PlayerSuggestion[]>
+  riotIdLike: ComputedRef<boolean>
+} {
+  const notesStore = usePlayerNotesStore()
+  const friends = ref<PlayerSuggestion[]>([])
+
+  // 好友列表懒加载:首次出现非空输入时拉一次;LCU 未连接等失败静默(无好友组)
+  let friendsLoaded = false
+  watch(
+    input,
+    async v => {
+      if (friendsLoaded || !v.trim()) return
+      friendsLoaded = true
+      try {
+        const list = await invoke<FriendLite[]>('get_friends')
+        friends.value = list
+          .filter(f => f.gameName && f.tagLine)
+          .map(f => ({ name: `${f.gameName}#${f.tagLine}`, source: 'friend' as const }))
+      } catch (e) {
+        console.warn('[SuperSearch] 好友列表加载失败(候选降级):', e)
+      }
+    },
+    { immediate: true }
+  )
+
+  const noteSuggestions = computed<PlayerSuggestion[]>(() =>
+    notesStore.list
+      .filter(n => n.gameName && n.tagLine)
+      .map(n => ({ name: `${n.gameName}#${n.tagLine}`, source: 'note' as const }))
+  )
+
+  const historySuggestions = computed<PlayerSuggestion[]>(() =>
+    // input 变化时重读:pushSearchHistory 写的是 localStorage,没有响应式信号
+    input.value !== undefined
+      ? loadSearchHistory().map(h => ({
+          name: h.name,
+          region: h.region || undefined,
+          source: 'history' as const
+        }))
+      : []
+  )
+
+  const playerSuggestions = computed(() =>
+    buildPlayerSuggestions(input.value, {
+      friends: friends.value,
+      notes: noteSuggestions.value,
+      history: historySuggestions.value
+    })
+  )
+
+  const riotIdLike = computed(() => isRiotIdLike(input.value))
+
+  return { playerSuggestions, riotIdLike }
+}

--- a/rank-analysis-app/src/composables/useSearchSuggestions.ts
+++ b/rank-analysis-app/src/composables/useSearchSuggestions.ts
@@ -1,10 +1,11 @@
 /**
  * Header 超级搜索的候选聚合
  *
- * 三个本地数据源(全部毫秒级,不打网络):
+ * 四个本地数据源:
  * - 好友列表(get_friends,首次有输入时懒加载一次,失败静默降级)
  * - 备注玩家(usePlayerNotesStore.list)
- * - 搜索历史(localStorage,精确查人成功后写入)
+ * - 搜索历史(localStorage,精确查人确认成功后写入)
+ * - 近期对局同场过的玩家(get_match_history_by_puuid 近 20 局派生,懒加载)
  *
  * 纯函数(isRiotIdLike / buildPlayerSuggestions / 历史读写)单独导出便于测试,
  * composable 只做数据源接线。
@@ -13,6 +14,7 @@
 import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 import { usePlayerNotesStore } from '@renderer/pinia/playerNotes'
+import type { Game, MatchHistory } from '@renderer/types/domain/match'
 
 /** 单条玩家候选 */
 export interface PlayerSuggestion {
@@ -20,7 +22,7 @@ export interface PlayerSuggestion {
   name: string
   /** 历史来源可携带当时的大区(platformId),其余来源为空 = 当前区 */
   region?: string
-  source: 'friend' | 'note' | 'history'
+  source: 'friend' | 'note' | 'history' | 'played'
 }
 
 /** 每个来源最多展示的候选数 */
@@ -38,8 +40,8 @@ export function isRiotIdLike(input: string): boolean {
 }
 
 /**
- * 聚合三个来源的候选:大小写不敏感子串匹配、跨来源按名字去重
- * (好友 > 备注 > 历史)、每来源截断到 {@link MAX_PER_SOURCE}。
+ * 聚合各来源的候选:大小写不敏感子串匹配、跨来源按名字去重
+ * (好友 > 备注 > 历史 > 对局过)、每来源截断到 {@link MAX_PER_SOURCE}。
  * @param input - 当前输入(空串 = 不过滤,用于展示默认候选)
  */
 export function buildPlayerSuggestions(
@@ -48,13 +50,15 @@ export function buildPlayerSuggestions(
     friends: PlayerSuggestion[]
     notes: PlayerSuggestion[]
     history: PlayerSuggestion[]
+    /** 近期对局里同场过的玩家(可选来源) */
+    played?: PlayerSuggestion[]
   }
 ): PlayerSuggestion[] {
   const needle = input.trim().toLowerCase()
   const seen = new Set<string>()
   const out: PlayerSuggestion[] = []
 
-  for (const group of [sources.friends, sources.notes, sources.history]) {
+  for (const group of [sources.friends, sources.notes, sources.history, sources.played ?? []]) {
     let taken = 0
     for (const s of group) {
       if (taken >= MAX_PER_SOURCE) break
@@ -106,6 +110,52 @@ export function pushSearchHistory(name: string, region: string): void {
   }
 }
 
+/**
+ * 记录一次「确认成功」的精确查人(spec:搜索历史只存成功的搜索)。
+ * - 候选行/跨区搜索:玩家已知或无法便宜验证,直接写入
+ * - 当前区手输名字:先验证召唤师存在(get_summoner_by_name 有 Rust 侧缓存,
+ *   Record 页随后的同名查询会命中缓存,不算额外开销),不存在则不污染历史
+ */
+export async function recordSearchHistory(
+  name: string,
+  region: string,
+  opts: { known?: boolean } = {}
+): Promise<void> {
+  if (opts.known || region) {
+    pushSearchHistory(name, region)
+    return
+  }
+  try {
+    const { invoke } = await import('@tauri-apps/api/core')
+    await invoke('get_summoner_by_name', { name })
+    pushSearchHistory(name, region)
+  } catch {
+    // 召唤师不存在/LCU 不可用:不写历史,搜索本身的失败由 Record 页展示
+  }
+}
+
+/**
+ * 从近期对局提取同场过的玩家(排除自己与无名条目,按出现顺序去重)
+ * @param games - 近期对局(需已带 gameDetail.participantIdentities)
+ * @param myPuuid - 当前玩家 puuid
+ */
+export function extractRecentPlayers(games: Game[], myPuuid: string): PlayerSuggestion[] {
+  const seen = new Set<string>()
+  const out: PlayerSuggestion[] = []
+  for (const g of games) {
+    for (const idn of g.gameDetail?.participantIdentities ?? []) {
+      const p = idn.player
+      if (!p?.gameName || !p.tagLine || p.puuid === myPuuid) continue
+      const name = `${p.gameName}#${p.tagLine}`
+      const key = name.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push({ name, source: 'played' })
+    }
+  }
+  return out
+}
+
 // ─── composable ──────────────────────────────────────────────────────────────
 
 interface FriendLite {
@@ -124,22 +174,33 @@ export function useSearchSuggestions(input: Ref<string>): {
 } {
   const notesStore = usePlayerNotesStore()
   const friends = ref<PlayerSuggestion[]>([])
+  const played = ref<PlayerSuggestion[]>([])
 
-  // 好友列表懒加载:首次出现非空输入时拉一次;LCU 未连接等失败静默(无好友组)
-  let friendsLoaded = false
+  // 好友与近期同场玩家懒加载:首次出现非空输入时各拉一次;失败静默(该来源为空)
+  let lazyLoaded = false
   watch(
     input,
-    async v => {
-      if (friendsLoaded || !v.trim()) return
-      friendsLoaded = true
-      try {
-        const list = await invoke<FriendLite[]>('get_friends')
-        friends.value = list
-          .filter(f => f.gameName && f.tagLine)
-          .map(f => ({ name: `${f.gameName}#${f.tagLine}`, source: 'friend' as const }))
-      } catch (e) {
-        console.warn('[SuperSearch] 好友列表加载失败(候选降级):', e)
-      }
+    v => {
+      if (lazyLoaded || !v.trim()) return
+      lazyLoaded = true
+      invoke<FriendLite[]>('get_friends')
+        .then(list => {
+          friends.value = list
+            .filter(f => f.gameName && f.tagLine)
+            .map(f => ({ name: `${f.gameName}#${f.tagLine}`, source: 'friend' as const }))
+        })
+        .catch(e => console.warn('[SuperSearch] 好友列表加载失败(候选降级):', e))
+      invoke<FriendLite>('get_my_summoner')
+        .then(me =>
+          invoke<MatchHistory>('get_match_history_by_puuid', {
+            puuid: me.puuid,
+            begIndex: 0,
+            endIndex: 19
+          }).then(h => {
+            played.value = extractRecentPlayers((h.games?.games ?? []) as Game[], me.puuid)
+          })
+        )
+        .catch(e => console.warn('[SuperSearch] 近期同场玩家加载失败(候选降级):', e))
     },
     { immediate: true }
   )
@@ -165,7 +226,8 @@ export function useSearchSuggestions(input: Ref<string>): {
     buildPlayerSuggestions(input.value, {
       friends: friends.value,
       notes: noteSuggestions.value,
-      history: historySuggestions.value
+      history: historySuggestions.value,
+      played: played.value
     })
   )
 

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/chips.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/chips.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { emptyQuery } from '../schema'
+import { queryToChips, removeChipFromQuery } from '../chips'
+
+const championName = (id: number) => ({ 51: '皮城女警', 222: '暴走萝莉' })[id] ?? `英雄${id}`
+const queueName = (id: number) => ({ 420: '单双排位' })[id] ?? `队列${id}`
+
+function fullQuery() {
+  return {
+    ...emptyQuery(),
+    timeRange: { from: '2026-08-01', to: '2026-08-31' },
+    selfChampionIds: [51],
+    allyChampionIds: [222],
+    enemyChampionIds: [36],
+    myTeamChampionIds: [64],
+    result: 'win' as const,
+    queueIds: [420],
+    playerNames: ['某人#123'],
+    intent: 'count_encounters' as const
+  }
+}
+
+describe('queryToChips', () => {
+  it('空条件不产 chips', () => {
+    expect(queryToChips(emptyQuery(), championName, queueName)).toEqual([])
+  })
+
+  it('每个条件维度一枚 chip,带人类可读 label', () => {
+    const chips = queryToChips(fullQuery(), championName, queueName)
+    const labels = chips.map(c => c.label).join('|')
+    expect(labels).toContain('2026-08-01')
+    expect(labels).toContain('皮城女警')
+    expect(labels).toContain('暴走萝莉')
+    expect(labels).toContain('单双排位')
+    expect(labels).toContain('胜')
+    expect(labels).toContain('某人#123')
+    // key 唯一
+    expect(new Set(chips.map(c => c.key)).size).toBe(chips.length)
+  })
+
+  it('仅 from 或仅 to 的时间窗也能产出可读 chip', () => {
+    const chips = queryToChips(
+      { ...emptyQuery(), timeRange: { from: '2026-08-01', to: null } },
+      championName,
+      queueName
+    )
+    expect(chips).toHaveLength(1)
+    expect(chips[0].label).toContain('2026-08-01')
+  })
+})
+
+describe('removeChipFromQuery', () => {
+  it('删除 chip 后对应条件被清空,其余保留', () => {
+    const q = fullQuery()
+    const chips = queryToChips(q, championName, queueName)
+    const allyChip = chips.find(c => c.key === 'ally:222')!
+    const next = removeChipFromQuery(q, allyChip.key)
+    expect(next.allyChampionIds).toEqual([])
+    expect(next.selfChampionIds).toEqual([51])
+    // 原对象不被修改
+    expect(q.allyChampionIds).toEqual([222])
+  })
+
+  it('删除时间 chip 清空整个时间窗', () => {
+    const next = removeChipFromQuery(fullQuery(), 'time')
+    expect(next.timeRange).toEqual({ from: null, to: null })
+  })
+
+  it('删除玩家名 chip 时 count 意图退回 list', () => {
+    const q = fullQuery()
+    const next = removeChipFromQuery(q, 'player:某人#123')
+    expect(next.playerNames).toEqual([])
+    expect(next.intent).toBe('list')
+  })
+
+  it('未知 key 原样返回', () => {
+    const q = fullQuery()
+    expect(removeChipFromQuery(q, 'nope')).toEqual(q)
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/fetch.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/fetch.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+
+import { invoke } from '@tauri-apps/api/core'
+import type { Game } from '@renderer/types/domain/match'
+import { emptyQuery } from '../schema'
+import { fetchGamesForQuery, PAGE_SIZE, MAX_GAMES_WITH_RANGE, MAX_GAMES_NO_RANGE } from '../fetch'
+
+const mockInvoke = invoke as ReturnType<typeof vi.fn>
+
+/** 造 n 局对局,日期从 startDay 起每局往前推 1 天(新→旧) */
+function gamesFrom(startDay: string, n: number): Game[] {
+  const start = new Date(`${startDay}T12:00:00.000Z`).getTime()
+  return Array.from({ length: n }, (_, i) => {
+    return {
+      gameId: start - i,
+      gameCreationDate: new Date(start - i * 24 * 3600 * 1000).toISOString()
+    } as Game
+  })
+}
+
+/** 按「完整战绩序列」实现 SGP mock:begIndex/count 切片 */
+function mockSgpFromTimeline(all: Game[]) {
+  mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === 'get_my_summoner') return { gameName: '我', tagLine: '10000', puuid: 'me' }
+    if (cmd === 'get_current_sgp_region') return 'HN1'
+    if (cmd === 'get_sgp_match_history_by_name') {
+      const beg = args!.begIndex as number
+      const count = args!.count as number
+      return { games: { games: all.slice(beg, beg + count) } }
+    }
+    throw new Error(`unexpected cmd ${cmd}`)
+  })
+}
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+})
+
+describe('fetchGamesForQuery', () => {
+  it('页内最旧一局越过时间下限即停止翻页', async () => {
+    // 120 局,每天一局:第一页(20 局)就覆盖到 20 天前
+    mockSgpFromTimeline(gamesFrom('2026-09-01', 120))
+    const q = { ...emptyQuery(), timeRange: { from: '2026-08-25', to: null } }
+    const r = await fetchGamesForQuery(q)
+    expect(r.source).toBe('sgp')
+    expect(r.truncated).toBe(false)
+    expect(r.games).toHaveLength(PAGE_SIZE) // 只翻了一页
+    const sgpCalls = mockInvoke.mock.calls.filter(c => c[0] === 'get_sgp_match_history_by_name')
+    expect(sgpCalls).toHaveLength(1)
+  })
+
+  it('无时间窗按 MAX_GAMES_NO_RANGE 截断并标记 truncated', async () => {
+    mockSgpFromTimeline(gamesFrom('2026-09-01', MAX_GAMES_NO_RANGE + 50))
+    const r = await fetchGamesForQuery(emptyQuery())
+    expect(r.games).toHaveLength(MAX_GAMES_NO_RANGE)
+    expect(r.truncated).toBe(true)
+  })
+
+  it('有时间窗上限为 MAX_GAMES_WITH_RANGE', async () => {
+    // 500 局全部在时间窗内(from 很早)
+    mockSgpFromTimeline(gamesFrom('2026-09-01', 500))
+    const q = { ...emptyQuery(), timeRange: { from: '2020-01-01', to: null } }
+    const r = await fetchGamesForQuery(q)
+    expect(r.games).toHaveLength(MAX_GAMES_WITH_RANGE)
+    expect(r.truncated).toBe(true)
+  })
+
+  it('短页(到头)自然停止,不算截断', async () => {
+    mockSgpFromTimeline(gamesFrom('2026-09-01', 7))
+    const r = await fetchGamesForQuery(emptyQuery())
+    expect(r.games).toHaveLength(7)
+    expect(r.truncated).toBe(false)
+  })
+
+  it('SGP 失败降级 LCU 最近 50 局', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_my_summoner') return { gameName: '我', tagLine: '10000', puuid: 'me' }
+      if (cmd === 'get_current_sgp_region') throw new Error('无法确定当前大区')
+      if (cmd === 'get_match_history_by_puuid') {
+        return { games: { games: gamesFrom('2026-09-01', 50) } }
+      }
+      throw new Error(`unexpected cmd ${cmd}`)
+    })
+    const r = await fetchGamesForQuery(emptyQuery())
+    expect(r.source).toBe('lcu')
+    expect(r.games).toHaveLength(50)
+    expect(r.selfName).toBe('我#10000')
+  })
+
+  it('进度回调随翻页递增并带最旧日期', async () => {
+    mockSgpFromTimeline(gamesFrom('2026-09-01', 45))
+    const seen: number[] = []
+    let lastOldest: string | null = null
+    await fetchGamesForQuery(emptyQuery(), p => {
+      seen.push(p.fetched)
+      lastOldest = p.oldestDate
+    })
+    expect(seen).toEqual([20, 40, 45])
+    expect(lastOldest).not.toBeNull()
+  })
+
+  it('LCU 未连接(get_my_summoner 失败)时抛可展示错误', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_my_summoner') throw new Error('conn refused')
+      return null
+    })
+    await expect(fetchGamesForQuery(emptyQuery())).rejects.toThrow('客户端')
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/filter.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/filter.spec.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest'
+import type { Game } from '@renderer/types/domain/match'
+import { emptyQuery } from '../schema'
+import { filterGames, countEncounters } from '../filter'
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+interface PlayerSpec {
+  championId: number
+  teamId: number
+  gameName?: string
+  tagLine?: string
+}
+
+/**
+ * 造一局对局:players[0] 视为「我」(同时充当顶层 participants[0] 与
+ * gameDetail 中的对应成员),其余为全队/对面成员。
+ */
+function gameOf(opts: {
+  gameId?: number
+  date?: string
+  queueId?: number
+  win?: boolean
+  players: PlayerSpec[]
+}): Game {
+  const me = opts.players[0]
+  const stats = (win: boolean) => ({ win }) as Game['participants'][0]['stats']
+  return {
+    mvp: '',
+    gameId: opts.gameId ?? Math.floor(Math.random() * 1e9),
+    gameCreationDate: opts.date ?? '2026-08-15T12:00:00.000Z',
+    gameDuration: 1800,
+    gameMode: 'CLASSIC',
+    gameType: 'MATCHED_GAME',
+    mapId: 11,
+    queueId: opts.queueId ?? 420,
+    queueName: '',
+    platformId: 'HN1',
+    participants: [
+      {
+        win: opts.win ?? true,
+        participantId: 1,
+        teamId: me.teamId,
+        championId: me.championId,
+        spell1Id: 4,
+        spell2Id: 14,
+        stats: stats(opts.win ?? true)
+      }
+    ],
+    participantIdentities: [],
+    gameDetail: {
+      endOfGameResult: 'GameComplete',
+      participants: opts.players.map((p, i) => ({
+        win: p.teamId === me.teamId ? (opts.win ?? true) : !(opts.win ?? true),
+        participantId: i + 1,
+        teamId: p.teamId,
+        championId: p.championId,
+        spell1Id: 4,
+        spell2Id: 14,
+        stats: stats(p.teamId === me.teamId ? (opts.win ?? true) : !(opts.win ?? true))
+      })),
+      participantIdentities: opts.players.map((p, i) => ({
+        player: {
+          accountId: i,
+          platformId: 'HN1',
+          gameName: p.gameName ?? `player${i}`,
+          tagLine: p.tagLine ?? '10000',
+          summonerName: p.gameName ?? `player${i}`,
+          summonerId: i,
+          puuid: `puuid-${i}`
+        }
+      }))
+    }
+  }
+}
+
+/** 常用布阵:我(51 女警) + 队友(222 金克丝, 64 盲僧) vs 对面(36 蒙多, 1 安妮) */
+function standardGame(opts: { date?: string; queueId?: number; win?: boolean } = {}): Game {
+  return gameOf({
+    ...opts,
+    players: [
+      { championId: 51, teamId: 100, gameName: '我自己', tagLine: '11111' },
+      { championId: 222, teamId: 100, gameName: '金克丝队友', tagLine: '22222' },
+      { championId: 64, teamId: 100, gameName: '打野哥', tagLine: '33333' },
+      { championId: 36, teamId: 200, gameName: '蒙多对面', tagLine: '44444' },
+      { championId: 1, teamId: 200, gameName: '安妮对面', tagLine: '55555' }
+    ]
+  })
+}
+
+// ─── filterGames ─────────────────────────────────────────────────────────────
+
+describe('filterGames', () => {
+  it('空条件返回全部', () => {
+    const games = [standardGame(), standardGame()]
+    expect(filterGames(games, emptyQuery())).toHaveLength(2)
+  })
+
+  it('按我用的英雄筛选(任一命中)', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), selfChampionIds: [51] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), selfChampionIds: [64] })).toHaveLength(0)
+    // 多个 = 或的关系(可能是这几个英雄之一)
+    expect(filterGames(games, { ...emptyQuery(), selfChampionIds: [64, 51] })).toHaveLength(1)
+  })
+
+  it('队友英雄不含我:队友有金克丝命中,队友有女警(是我自己)不命中', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), allyChampionIds: [222] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), allyChampionIds: [51] })).toHaveLength(0)
+  })
+
+  it('队友多英雄是且的关系:222+64 命中,222+36(36 在对面)不命中', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), allyChampionIds: [222, 64] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), allyChampionIds: [222, 36] })).toHaveLength(0)
+  })
+
+  it('对面英雄筛选', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), enemyChampionIds: [36] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), enemyChampionIds: [222] })).toHaveLength(0)
+  })
+
+  it('我方(含我)筛选:「忘了自己玩的啥」场景女警+金克丝都在我方即命中', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), myTeamChampionIds: [51, 222] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), myTeamChampionIds: [51, 36] })).toHaveLength(0)
+  })
+
+  it('按胜负筛选', () => {
+    const games = [standardGame({ win: true }), standardGame({ win: false })]
+    expect(filterGames(games, { ...emptyQuery(), result: 'win' })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), result: 'loss' })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), result: 'any' })).toHaveLength(2)
+  })
+
+  it('按队列筛选', () => {
+    const games = [standardGame({ queueId: 420 }), standardGame({ queueId: 450 })]
+    expect(filterGames(games, { ...emptyQuery(), queueIds: [450] })).toHaveLength(1)
+  })
+
+  it('时间窗含端点:to 当天整天算在内', () => {
+    const games = [
+      standardGame({ date: '2026-08-01T00:30:00.000Z' }),
+      standardGame({ date: '2026-08-31T23:00:00.000Z' }),
+      standardGame({ date: '2026-09-01T08:00:00.000Z' })
+    ]
+    const q = { ...emptyQuery(), timeRange: { from: '2026-08-01', to: '2026-08-31' } }
+    expect(filterGames(games, q)).toHaveLength(2)
+  })
+
+  it('玩家名匹配:全名#tag、纯名、大小写不敏感均可', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), playerNames: ['金克丝队友#22222'] })).toHaveLength(
+      1
+    )
+    expect(filterGames(games, { ...emptyQuery(), playerNames: ['蒙多对面'] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), playerNames: ['不存在的人'] })).toHaveLength(0)
+  })
+
+  it('gameDetail 缺全队数据时,队友/对面条件按不命中处理而非报错', () => {
+    const g = standardGame()
+    g.gameDetail.participants = []
+    g.gameDetail.participantIdentities = []
+    expect(() => filterGames([g], { ...emptyQuery(), allyChampionIds: [222] })).not.toThrow()
+    expect(filterGames([g], { ...emptyQuery(), allyChampionIds: [222] })).toHaveLength(0)
+    // 但只有 self 条件时仍可命中(顶层 participants[0] 可用)
+    expect(filterGames([g], { ...emptyQuery(), selfChampionIds: [51] })).toHaveLength(1)
+  })
+})
+
+// ─── countEncounters ─────────────────────────────────────────────────────────
+
+describe('countEncounters', () => {
+  it('统计与指定玩家的相遇次数,分同队/对面', () => {
+    const asAlly = standardGame({ date: '2026-08-10T10:00:00.000Z' })
+    const asEnemy = gameOf({
+      date: '2026-08-12T10:00:00.000Z',
+      players: [
+        { championId: 51, teamId: 100, gameName: '我自己', tagLine: '11111' },
+        { championId: 64, teamId: 100, gameName: '打野哥', tagLine: '33333' },
+        { championId: 222, teamId: 200, gameName: '金克丝队友', tagLine: '22222' }
+      ]
+    })
+    const unrelated = gameOf({
+      date: '2026-08-13T10:00:00.000Z',
+      players: [
+        { championId: 51, teamId: 100, gameName: '我自己', tagLine: '11111' },
+        { championId: 36, teamId: 200, gameName: '路人', tagLine: '66666' }
+      ]
+    })
+    const q = {
+      ...emptyQuery(),
+      playerNames: ['金克丝队友#22222'],
+      intent: 'count_encounters' as const
+    }
+    const { stats, games } = countEncounters([asAlly, asEnemy, unrelated], q)
+    expect(stats.total).toBe(2)
+    expect(stats.perName['金克丝队友#22222']).toEqual({ ally: 1, enemy: 1 })
+    expect(games).toHaveLength(2)
+  })
+
+  it('先应用时间窗与队列过滤再统计', () => {
+    const inRange = standardGame({ date: '2026-08-10T10:00:00.000Z' })
+    const outOfRange = standardGame({ date: '2026-07-01T10:00:00.000Z' })
+    const q = {
+      ...emptyQuery(),
+      playerNames: ['金克丝队友'],
+      timeRange: { from: '2026-08-01', to: null },
+      intent: 'count_encounters' as const
+    }
+    const { stats } = countEncounters([inRange, outOfRange], q)
+    expect(stats.total).toBe(1)
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
@@ -13,7 +13,7 @@ vi.mock('@renderer/services/ipc', () => ({
 import { invoke } from '@tauri-apps/api/core'
 import { requestAIContent } from '@renderer/services/ai/stream'
 import { getGameModesByIpc } from '@renderer/services/ipc'
-import { extractJson, parseMatchQuery, __resetParseCachesForTests } from '../parse'
+import { extractJson, parseMatchQuery, clearParseCache, __resetParseCachesForTests } from '../parse'
 
 const mockInvoke = invoke as ReturnType<typeof vi.fn>
 const mockRequest = requestAIContent as ReturnType<typeof vi.fn>
@@ -91,6 +91,16 @@ describe('parseMatchQuery', () => {
   it('返回内容不是 JSON 时抛错', async () => {
     mockRequest.mockResolvedValue({ success: true, content: '抱歉我做不到' })
     await expect(parseMatchQuery('x')).rejects.toThrow()
+  })
+
+  it('clearParseCache 清掉该句的 sessionStorage 缓存', async () => {
+    mockRequest.mockResolvedValue({ success: true, content: '{}' })
+    await parseMatchQuery('同一句')
+    // requestAIContent 被 mock,真正的缓存 key 由 parse 传入其第二参
+    const cacheKey = mockRequest.mock.calls[0][1] as string
+    sessionStorage.setItem(cacheKey, '{}')
+    clearParseCache('同一句')
+    expect(sessionStorage.getItem(cacheKey)).toBeNull()
   })
 
   it('英雄/模式清单只加载一次(模块级缓存)', async () => {

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
@@ -93,6 +93,24 @@ describe('parseMatchQuery', () => {
     await expect(parseMatchQuery('x')).rejects.toThrow()
   })
 
+  it('时间窗钳制:to 晚于今天则置空;from 晚于今天则整窗作废', async () => {
+    const today = new Date().toISOString().slice(0, 10)
+    mockRequest.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify({ timeRange: { from: '2020-01-01', to: '2999-12-31' } })
+    })
+    const q1 = await parseMatchQuery('to 在未来')
+    expect(q1.timeRange).toEqual({ from: '2020-01-01', to: null })
+
+    mockRequest.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify({ timeRange: { from: '2999-01-01', to: '2999-12-31' } })
+    })
+    const q2 = await parseMatchQuery('from 在未来')
+    expect(q2.timeRange).toEqual({ from: null, to: null })
+    expect(today <= '2999-01-01').toBe(true)
+  })
+
   it('clearParseCache 清掉该句的 sessionStorage 缓存', async () => {
     mockRequest.mockResolvedValue({ success: true, content: '{}' })
     await parseMatchQuery('同一句')

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mocks BEFORE importing the module under test
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@renderer/services/ai/stream', () => ({
+  requestAIContent: vi.fn(),
+  DEFAULT_MODEL: 'qwen-flash'
+}))
+vi.mock('@renderer/services/ipc', () => ({
+  getGameModesByIpc: vi.fn()
+}))
+
+import { invoke } from '@tauri-apps/api/core'
+import { requestAIContent } from '@renderer/services/ai/stream'
+import { getGameModesByIpc } from '@renderer/services/ipc'
+import { extractJson, parseMatchQuery, __resetParseCachesForTests } from '../parse'
+
+const mockInvoke = invoke as ReturnType<typeof vi.fn>
+const mockRequest = requestAIContent as ReturnType<typeof vi.fn>
+const mockModes = getGameModesByIpc as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+  mockRequest.mockReset()
+  mockModes.mockReset()
+  __resetParseCachesForTests()
+  mockInvoke.mockImplementation((cmd: string) => {
+    if (cmd === 'get_champion_options') {
+      return [
+        { value: 51, label: '皮城女警', nickname: '女警 (Caitlyn)', realName: '凯特琳' },
+        { value: 222, label: '暴走萝莉', nickname: '金克丝 (Jinx)', realName: '金克丝' }
+      ]
+    }
+    throw new Error(`unexpected cmd ${cmd}`)
+  })
+  mockModes.mockResolvedValue([
+    { label: '全部', value: 0 },
+    { label: '单双排位', value: 420 }
+  ])
+})
+
+describe('extractJson', () => {
+  it('裸 JSON 直接解析', () => {
+    expect(extractJson('{"a":1}')).toEqual({ a: 1 })
+  })
+
+  it('容忍 ```json 围栏与前后闲话', () => {
+    expect(extractJson('好的,结果如下:\n```json\n{"a":1}\n```\n请查收')).toEqual({ a: 1 })
+  })
+
+  it('无 JSON 时返回 null', () => {
+    expect(extractJson('我不知道')).toBeNull()
+  })
+})
+
+describe('parseMatchQuery', () => {
+  it('happy path:jsonMode 调用 → 校验后的查询对象', async () => {
+    mockRequest.mockResolvedValue({
+      success: true,
+      content: JSON.stringify({
+        timeRange: { from: '2026-08-01', to: '2026-08-31' },
+        selfChampionIds: [51],
+        allyChampionIds: [222],
+        result: 'win',
+        intent: 'list'
+      })
+    })
+    const q = await parseMatchQuery('这个月我用女警队友金克丝赢的')
+    expect(q.selfChampionIds).toEqual([51])
+    expect(q.allyChampionIds).toEqual([222])
+    expect(q.result).toBe('win')
+    // jsonMode 必须开启
+    const opts = mockRequest.mock.calls[0].at(-1)
+    expect(opts).toMatchObject({ jsonMode: true })
+  })
+
+  it('模型编造的英雄 id 被清单过滤掉', async () => {
+    mockRequest.mockResolvedValue({
+      success: true,
+      content: JSON.stringify({ selfChampionIds: [51, 9999] })
+    })
+    const q = await parseMatchQuery('随便')
+    expect(q.selfChampionIds).toEqual([51])
+  })
+
+  it('AI 请求失败时抛出可展示错误', async () => {
+    mockRequest.mockResolvedValue({ success: false, error: '网络错误' })
+    await expect(parseMatchQuery('x')).rejects.toThrow('网络错误')
+  })
+
+  it('返回内容不是 JSON 时抛错', async () => {
+    mockRequest.mockResolvedValue({ success: true, content: '抱歉我做不到' })
+    await expect(parseMatchQuery('x')).rejects.toThrow()
+  })
+
+  it('英雄/模式清单只加载一次(模块级缓存)', async () => {
+    mockRequest.mockResolvedValue({ success: true, content: '{}' })
+    await parseMatchQuery('a')
+    await parseMatchQuery('b')
+    const championCalls = mockInvoke.mock.calls.filter(c => c[0] === 'get_champion_options')
+    expect(championCalls).toHaveLength(1)
+    expect(mockModes).toHaveBeenCalledTimes(1)
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/prompt.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/prompt.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { buildMatchSearchPrompt } from '../prompt'
+
+const CTX = {
+  today: '2026-09-01',
+  champions: [
+    { value: 51, label: '皮城女警', nickname: '女警 (Caitlyn)', realName: '凯特琳' },
+    { value: 222, label: '暴走萝莉', nickname: '金克丝 (Jinx)', realName: '金克丝' }
+  ],
+  modes: [
+    { label: '单双排位', value: 420 },
+    { label: '极地大乱斗', value: 450 }
+  ]
+}
+
+describe('buildMatchSearchPrompt', () => {
+  it('user prompt 注入今天日期、英雄清单、模式清单与原文', () => {
+    const { user } = buildMatchSearchPrompt('这个月我用女警赢的那把', CTX)
+    expect(user).toContain('2026-09-01')
+    expect(user).toContain('51|皮城女警|女警 (Caitlyn)|凯特琳')
+    expect(user).toContain('420|单双排位')
+    expect(user).toContain('这个月我用女警赢的那把')
+  })
+
+  it('system prompt 约束:只能用清单内 id、输出 JSON、不确定留空', () => {
+    const { system } = buildMatchSearchPrompt('随便', CTX)
+    expect(system).toContain('JSON')
+    expect(system).toContain('清单')
+    expect(system).toContain('myTeamChampionIds')
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/prompt.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/prompt.spec.ts
@@ -28,4 +28,11 @@ describe('buildMatchSearchPrompt', () => {
     expect(system).toContain('清单')
     expect(system).toContain('myTeamChampionIds')
   })
+
+  it('user prompt 含基于今天的时间换算示例(近30天/近7天)', () => {
+    const { user } = buildMatchSearchPrompt('这个月', CTX)
+    // 2026-09-01 往前 30 天 = 2026-08-02;往前 7 天 = 2026-08-25
+    expect(user).toContain('2026-08-02')
+    expect(user).toContain('2026-08-25')
+  })
 })

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { emptyQuery, validateParsedQuery } from '../schema'
+
+const CHAMPS = new Set([51, 222, 36, 64])
+const QUEUES = new Set([420, 440, 450])
+
+describe('emptyQuery', () => {
+  it('返回全空条件(不筛任何东西)', () => {
+    const q = emptyQuery()
+    expect(q.timeRange).toEqual({ from: null, to: null })
+    expect(q.selfChampionIds).toEqual([])
+    expect(q.allyChampionIds).toEqual([])
+    expect(q.enemyChampionIds).toEqual([])
+    expect(q.myTeamChampionIds).toEqual([])
+    expect(q.result).toBe('any')
+    expect(q.queueIds).toEqual([])
+    expect(q.playerNames).toEqual([])
+    expect(q.intent).toBe('list')
+  })
+})
+
+describe('validateParsedQuery', () => {
+  it('合法输入原样通过', () => {
+    const q = validateParsedQuery(
+      {
+        timeRange: { from: '2026-08-01', to: '2026-08-31' },
+        selfChampionIds: [51],
+        allyChampionIds: [222],
+        enemyChampionIds: [36],
+        myTeamChampionIds: [],
+        result: 'win',
+        queueIds: [420],
+        playerNames: ['某人#12345'],
+        intent: 'count_encounters'
+      },
+      CHAMPS,
+      QUEUES
+    )
+    expect(q.selfChampionIds).toEqual([51])
+    expect(q.allyChampionIds).toEqual([222])
+    expect(q.result).toBe('win')
+    expect(q.queueIds).toEqual([420])
+    expect(q.intent).toBe('count_encounters')
+    expect(q.timeRange).toEqual({ from: '2026-08-01', to: '2026-08-31' })
+  })
+
+  it('清单外英雄 id 被剔除,非数字被剔除', () => {
+    const q = validateParsedQuery(
+      { selfChampionIds: [51, 99999, '64', null], allyChampionIds: [1] },
+      CHAMPS,
+      QUEUES
+    )
+    expect(q.selfChampionIds).toEqual([51])
+    expect(q.allyChampionIds).toEqual([])
+  })
+
+  it('非法日期与 from>to 都降级为 null', () => {
+    const bad = validateParsedQuery(
+      { timeRange: { from: 'abc', to: '2026-08-01' } },
+      CHAMPS,
+      QUEUES
+    )
+    expect(bad.timeRange.from).toBeNull()
+    expect(bad.timeRange.to).toBe('2026-08-01')
+
+    const inverted = validateParsedQuery(
+      { timeRange: { from: '2026-08-31', to: '2026-08-01' } },
+      CHAMPS,
+      QUEUES
+    )
+    expect(inverted.timeRange).toEqual({ from: null, to: null })
+  })
+
+  it('非法枚举降级:result→any,intent→list', () => {
+    const q = validateParsedQuery({ result: 'DRAW', intent: 'summarize' }, CHAMPS, QUEUES)
+    expect(q.result).toBe('any')
+    expect(q.intent).toBe('list')
+  })
+
+  it('清单外 queueId 被剔除', () => {
+    const q = validateParsedQuery({ queueIds: [420, 9999] }, CHAMPS, QUEUES)
+    expect(q.queueIds).toEqual([420])
+  })
+
+  it('playerNames 去空白、去重、丢弃非字符串', () => {
+    const q = validateParsedQuery(
+      { playerNames: [' 某人#123 ', '某人#123', '', 42, null] },
+      CHAMPS,
+      QUEUES
+    )
+    expect(q.playerNames).toEqual(['某人#123'])
+  })
+
+  it('完全不是对象时返回空条件', () => {
+    expect(validateParsedQuery(null, CHAMPS, QUEUES)).toEqual(emptyQuery())
+    expect(validateParsedQuery('gibberish', CHAMPS, QUEUES)).toEqual(emptyQuery())
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts
@@ -54,6 +54,15 @@ describe('validateParsedQuery', () => {
     expect(q.allyChampionIds).toEqual([])
   })
 
+  it('带时间的 ISO 串被规范化为纯日期(下游拼 T00:00:00 不会炸)', () => {
+    const q = validateParsedQuery(
+      { timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-08-31T15:30:00.000Z' } },
+      CHAMPS,
+      QUEUES
+    )
+    expect(q.timeRange).toEqual({ from: '2026-08-01', to: '2026-08-31' })
+  })
+
   it('非法日期与 from>to 都降级为 null', () => {
     const bad = validateParsedQuery(
       { timeRange: { from: 'abc', to: '2026-08-01' } },

--- a/rank-analysis-app/src/services/ai/matchSearch/chips.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/chips.ts
@@ -1,0 +1,101 @@
+/**
+ * 查询条件 ↔ 可视化 chips 的互转
+ *
+ * 结果页把解析出的条件渲染成一排可删除的 chip,让用户看见「AI 理解成了什么」
+ * 并能手动修正(删 chip → removeChipFromQuery → 本地重筛,不重打模型)。
+ */
+
+import type { ParsedMatchQuery, QueryChip } from './types'
+
+/**
+ * 把查询条件展开为 chips
+ * @param q - 查询条件
+ * @param championName - 英雄 id → 展示名
+ * @param queueName - 队列 id → 展示名
+ */
+export function queryToChips(
+  q: ParsedMatchQuery,
+  championName: (id: number) => string,
+  queueName: (id: number) => string
+): QueryChip[] {
+  const chips: QueryChip[] = []
+
+  const { from, to } = q.timeRange
+  if (from || to) {
+    const label =
+      from && to ? `时间: ${from} ~ ${to}` : from ? `时间: ${from} 起` : `时间: 截至 ${to}`
+    chips.push({ key: 'time', label })
+  }
+
+  for (const id of q.selfChampionIds)
+    chips.push({ key: `self:${id}`, label: `我用: ${championName(id)}` })
+  for (const id of q.allyChampionIds)
+    chips.push({ key: `ally:${id}`, label: `队友: ${championName(id)}` })
+  for (const id of q.enemyChampionIds)
+    chips.push({ key: `enemy:${id}`, label: `对面: ${championName(id)}` })
+  for (const id of q.myTeamChampionIds)
+    chips.push({ key: `team:${id}`, label: `我方有: ${championName(id)}` })
+
+  if (q.result !== 'any')
+    chips.push({ key: 'result', label: `结果: ${q.result === 'win' ? '胜' : '负'}` })
+
+  for (const id of q.queueIds) chips.push({ key: `queue:${id}`, label: `模式: ${queueName(id)}` })
+  for (const name of q.playerNames) chips.push({ key: `player:${name}`, label: `玩家: ${name}` })
+
+  return chips
+}
+
+/**
+ * 删除一枚 chip 对应的条件,返回新查询对象(不修改原对象)。
+ * 未知 key 原样返回;删光 playerNames 时 count 意图退回 list(统计对象没了)。
+ */
+export function removeChipFromQuery(q: ParsedMatchQuery, key: string): ParsedMatchQuery {
+  const next: ParsedMatchQuery = {
+    ...q,
+    timeRange: { ...q.timeRange },
+    selfChampionIds: [...q.selfChampionIds],
+    allyChampionIds: [...q.allyChampionIds],
+    enemyChampionIds: [...q.enemyChampionIds],
+    myTeamChampionIds: [...q.myTeamChampionIds],
+    queueIds: [...q.queueIds],
+    playerNames: [...q.playerNames]
+  }
+
+  if (key === 'time') {
+    next.timeRange = { from: null, to: null }
+    return next
+  }
+  if (key === 'result') {
+    next.result = 'any'
+    return next
+  }
+
+  const sep = key.indexOf(':')
+  if (sep < 0) return next
+  const kind = key.slice(0, sep)
+  const value = key.slice(sep + 1)
+
+  const dropId = (arr: number[]) => arr.filter(id => String(id) !== value)
+  switch (kind) {
+    case 'self':
+      next.selfChampionIds = dropId(next.selfChampionIds)
+      break
+    case 'ally':
+      next.allyChampionIds = dropId(next.allyChampionIds)
+      break
+    case 'enemy':
+      next.enemyChampionIds = dropId(next.enemyChampionIds)
+      break
+    case 'team':
+      next.myTeamChampionIds = dropId(next.myTeamChampionIds)
+      break
+    case 'queue':
+      next.queueIds = dropId(next.queueIds)
+      break
+    case 'player':
+      next.playerNames = next.playerNames.filter(n => n !== value)
+      if (next.playerNames.length === 0) next.intent = 'list'
+      break
+  }
+  return next
+}

--- a/rank-analysis-app/src/services/ai/matchSearch/fetch.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/fetch.ts
@@ -1,0 +1,116 @@
+/**
+ * AI 搜战绩的数据拉取:SGP 深分页 + LCU 降级
+ *
+ * 为什么走 SGP:LCU 战绩列表最多 50 局且每局 participants 只有自己,
+ * 查「队友有金克丝」需要全队数据;SGP 支持任意深分页且单次返回全队。
+ * SGP 不可用(网关/权限/无对局)时降级 LCU 最近 50 局(enrich 后同样有全队)。
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+import type { Game, MatchHistory } from '@renderer/types/domain/match'
+import type { ParsedMatchQuery } from './types'
+
+/** SGP 单页条数 */
+export const PAGE_SIZE = 20
+/** 有时间窗时最多拉取的对局数(约 10 页) */
+export const MAX_GAMES_WITH_RANGE = 200
+/** 无时间窗时最多拉取的对局数 */
+export const MAX_GAMES_NO_RANGE = 100
+
+/** 分页进度(供 UI 展示「已拉 N 局 / 覆盖至某日」) */
+export interface FetchProgress {
+  fetched: number
+  oldestDate: string | null
+}
+
+export interface FetchResult {
+  games: Game[]
+  /** 实际数据源:sgp = 深分页;lcu = 降级后仅最近 50 局 */
+  source: 'sgp' | 'lcu'
+  /** 因达到拉取上限而截断(提示用户可能还有更早的匹配对局) */
+  truncated: boolean
+  /** 被查玩家 gameName#tagLine */
+  selfName: string
+}
+
+interface MySummoner {
+  gameName: string
+  tagLine: string
+  puuid: string
+}
+
+/**
+ * 按查询条件拉取当前登录玩家的对局(只做拉取,筛选交给 filter.ts)
+ * @param q - 已解析的查询条件(只用 timeRange.from 决定翻页深度)
+ * @param onProgress - 每页完成后的进度回调
+ * @throws Error LCU 未连接等不可恢复错误(中文可展示信息)
+ */
+export async function fetchGamesForQuery(
+  q: ParsedMatchQuery,
+  onProgress?: (p: FetchProgress) => void
+): Promise<FetchResult> {
+  let me: MySummoner
+  try {
+    me = await invoke<MySummoner>('get_my_summoner')
+  } catch {
+    throw new Error('无法获取当前召唤师,请先启动并登录游戏客户端')
+  }
+  const selfName = `${me.gameName}#${me.tagLine}`
+  const maxGames = q.timeRange.from ? MAX_GAMES_WITH_RANGE : MAX_GAMES_NO_RANGE
+  const fromTs = q.timeRange.from ? new Date(`${q.timeRange.from}T00:00:00.000Z`).getTime() : null
+
+  try {
+    const games = await fetchViaSgp(selfName, maxGames, fromTs, onProgress)
+    return { ...games, source: 'sgp', selfName }
+  } catch (e) {
+    console.warn('[matchSearch] SGP 拉取失败,降级 LCU 最近 50 局:', e)
+  }
+
+  const history = await invoke<MatchHistory>('get_match_history_by_puuid', {
+    puuid: me.puuid,
+    begIndex: 0,
+    endIndex: 49
+  })
+  const games = history.games?.games ?? []
+  onProgress?.({ fetched: games.length, oldestDate: oldestOf(games) })
+  return { games, source: 'lcu', truncated: false, selfName }
+}
+
+function oldestOf(games: Game[]): string | null {
+  return games.length > 0 ? games[games.length - 1].gameCreationDate : null
+}
+
+/** SGP 分页循环:空页/短页到头、越过时间下限、达到上限三类停止条件 */
+async function fetchViaSgp(
+  selfName: string,
+  maxGames: number,
+  fromTs: number | null,
+  onProgress?: (p: FetchProgress) => void
+): Promise<{ games: Game[]; truncated: boolean }> {
+  const region = await invoke<string>('get_current_sgp_region')
+  const all: Game[] = []
+  let truncated = false
+
+  while (all.length < maxGames) {
+    const page = await invoke<MatchHistory>('get_sgp_match_history_by_name', {
+      region,
+      name: selfName,
+      begIndex: all.length,
+      count: PAGE_SIZE
+    })
+    const games = page.games?.games ?? []
+    all.push(...games)
+    onProgress?.({ fetched: all.length, oldestDate: oldestOf(all) })
+
+    // 短页/空页 = 战绩到头
+    if (games.length < PAGE_SIZE) return { games: all, truncated: false }
+
+    // 页内最旧一局已越过时间下限,更早的对局不可能命中
+    if (fromTs !== null) {
+      const oldest = new Date(games[games.length - 1].gameCreationDate).getTime()
+      if (!Number.isNaN(oldest) && oldest < fromTs) return { games: all, truncated: false }
+    }
+  }
+  truncated = true
+  return { games: all.slice(0, maxGames), truncated }
+}

--- a/rank-analysis-app/src/services/ai/matchSearch/filter.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/filter.ts
@@ -1,0 +1,153 @@
+/**
+ * 对局本地筛选与相遇统计(纯函数)
+ *
+ * 数据形状约定(LCU enrich 与 SGP 映射后一致):
+ * - `game.participants[0]` = 被查玩家(我),胜负/我的英雄从这里取
+ * - `game.gameDetail.participants` = 全队 10 人,与
+ *   `game.gameDetail.participantIdentities` 按下标对齐
+ * - 在 gameDetail 中定位「我」用 championId + teamId 双匹配
+ *   (两条数据链路都不保证 detail 里有我的 puuid)
+ */
+
+import type { Game, Participant, MatchPlayerIdentity } from '@renderer/types/domain/match'
+import type { ParsedMatchQuery, EncounterStats } from './types'
+
+/** 一局对局按「我」的视角拆出的双方成员(带 identities 对齐下标) */
+interface TeamSplit {
+  /** 我方成员(含我)在 gameDetail 中的下标 */
+  myTeam: number[]
+  /** 对面成员下标 */
+  enemyTeam: number[]
+  /** 「我」在 gameDetail 中的下标,找不到为 -1 */
+  selfIndex: number
+}
+
+/** 拆分双方;gameDetail 缺数据时返回空阵容(调用方按不命中处理) */
+function splitTeams(game: Game): TeamSplit {
+  const self = game.participants[0]
+  const detail = game.gameDetail?.participants ?? []
+  if (!self || detail.length === 0) return { myTeam: [], enemyTeam: [], selfIndex: -1 }
+
+  const selfIndex = detail.findIndex(
+    p => p.championId === self.championId && p.teamId === self.teamId
+  )
+  const myTeam: number[] = []
+  const enemyTeam: number[] = []
+  detail.forEach((p, i) => {
+    ;(p.teamId === self.teamId ? myTeam : enemyTeam).push(i)
+  })
+  return { myTeam, enemyTeam, selfIndex }
+}
+
+/** 指定下标集合内是否出现了 wanted 中的每一个英雄(且语义) */
+function containsAllChampions(detail: Participant[], indexes: number[], wanted: number[]): boolean {
+  return wanted.every(id => indexes.some(i => detail[i]?.championId === id))
+}
+
+/** 时间窗判断:from 起于当日 00:00,to 含当日整天 */
+function inTimeRange(game: Game, from: string | null, to: string | null): boolean {
+  const t = new Date(game.gameCreationDate).getTime()
+  if (Number.isNaN(t)) return false
+  if (from && t < new Date(`${from}T00:00:00.000Z`).getTime()) return false
+  if (to && t > new Date(`${to}T23:59:59.999Z`).getTime()) return false
+  return true
+}
+
+/** 玩家名匹配:名#tag 或纯名全等(大小写不敏感),再退化到子串 */
+function identityMatches(identity: MatchPlayerIdentity, wanted: string): boolean {
+  const w = wanted.toLowerCase()
+  const gameName = (identity.player?.gameName ?? '').toLowerCase()
+  const full = `${gameName}#${(identity.player?.tagLine ?? '').toLowerCase()}`
+  if (!gameName) return false
+  return full === w || gameName === w || full.includes(w)
+}
+
+/** 时间窗 + 队列的前置过滤(list 与 count 两种意图共用) */
+function baseFilter(game: Game, q: ParsedMatchQuery): boolean {
+  if (!inTimeRange(game, q.timeRange.from, q.timeRange.to)) return false
+  if (q.queueIds.length > 0 && !q.queueIds.includes(game.queueId)) return false
+  return true
+}
+
+/** 单局是否命中全部条件 */
+function gameMatches(game: Game, q: ParsedMatchQuery): boolean {
+  if (!baseFilter(game, q)) return false
+
+  const self = game.participants[0]
+  if (!self) return false
+
+  if (q.result !== 'any' && self.stats?.win !== (q.result === 'win')) return false
+
+  // 我用的英雄:多个是「其中之一」(用户记不清备选)
+  if (q.selfChampionIds.length > 0 && !q.selfChampionIds.includes(self.championId)) return false
+
+  const detail = game.gameDetail?.participants ?? []
+  const { myTeam, enemyTeam, selfIndex } = splitTeams(game)
+
+  // 队友 = 我方去掉我
+  if (q.allyChampionIds.length > 0) {
+    const allies = myTeam.filter(i => i !== selfIndex)
+    if (!containsAllChampions(detail, allies, q.allyChampionIds)) return false
+  }
+  if (q.myTeamChampionIds.length > 0) {
+    if (!containsAllChampions(detail, myTeam, q.myTeamChampionIds)) return false
+  }
+  if (q.enemyChampionIds.length > 0) {
+    if (!containsAllChampions(detail, enemyTeam, q.enemyChampionIds)) return false
+  }
+
+  if (q.playerNames.length > 0) {
+    const identities = game.gameDetail?.participantIdentities ?? []
+    const others = identities.filter((_, i) => i !== selfIndex)
+    const everyNamePresent = q.playerNames.every(name =>
+      others.some(idn => identityMatches(idn, name))
+    )
+    if (!everyNamePresent) return false
+  }
+
+  return true
+}
+
+/**
+ * 按查询条件筛选对局(list 意图)
+ * @param games - 待筛对局(participants[0] 为被查玩家)
+ * @param q - 已校验的查询条件
+ */
+export function filterGames(games: Game[], q: ParsedMatchQuery): Game[] {
+  return games.filter(g => gameMatches(g, q))
+}
+
+/**
+ * 统计与目标玩家的相遇次数(count_encounters 意图)
+ *
+ * 只应用时间窗与队列前置过滤(胜负/英雄条件不参与——「碰见几次」与胜负无关),
+ * 每局按 identities 判断各目标玩家是否在场,并按同队/对面分计。
+ * @returns stats 为分计结果;games 为命中任一目标玩家的对局(供列表展示)
+ */
+export function countEncounters(
+  games: Game[],
+  q: ParsedMatchQuery
+): { stats: EncounterStats; games: Game[] } {
+  const perName: EncounterStats['perName'] = {}
+  for (const name of q.playerNames) perName[name] = { ally: 0, enemy: 0 }
+
+  const hitGames: Game[] = []
+  for (const game of games) {
+    if (!baseFilter(game, q)) continue
+    const identities = game.gameDetail?.participantIdentities ?? []
+    const { myTeam, selfIndex } = splitTeams(game)
+    const myTeamSet = new Set(myTeam)
+
+    let anyHit = false
+    for (const name of q.playerNames) {
+      const idx = identities.findIndex((idn, i) => i !== selfIndex && identityMatches(idn, name))
+      if (idx < 0) continue
+      anyHit = true
+      if (myTeamSet.has(idx)) perName[name].ally++
+      else perName[name].enemy++
+    }
+    if (anyHit) hitGames.push(game)
+  }
+
+  return { stats: { total: hitGames.length, perName }, games: hitGames }
+}

--- a/rank-analysis-app/src/services/ai/matchSearch/parse.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/parse.ts
@@ -32,6 +32,24 @@ async function loadContext(): Promise<Omit<PromptContext, 'today'>> {
   return ctxCache
 }
 
+/** 解析结果的 sessionStorage 缓存 key(与 parseMatchQuery 内部一致) */
+function parseCacheKey(text: string): string {
+  return `matchSearch:${new Date().toISOString().slice(0, 10)}:${text}`
+}
+
+/**
+ * 清除某句描述的解析缓存。
+ * requestAIContent 会缓存「成功但内容是垃圾」的响应(如非 JSON 闲聊),
+ * 重试前必须清掉,否则重试永远命中同一份坏缓存。
+ */
+export function clearParseCache(text: string): void {
+  try {
+    sessionStorage.removeItem(parseCacheKey(text))
+  } catch {
+    // sessionStorage 不可用时本来也不会有缓存
+  }
+}
+
 /**
  * 从模型输出里提取 JSON 对象(容忍 ```json 围栏与前后闲话)
  * @returns 解析出的对象;找不到合法 JSON 时返回 null
@@ -63,7 +81,7 @@ export async function parseMatchQuery(text: string): Promise<ParsedMatchQuery> {
   const today = new Date().toISOString().slice(0, 10)
   const { system, user } = buildMatchSearchPrompt(text, { today, champions, modes })
 
-  const result = await requestAIContent(user, `matchSearch:${today}:${text}`, system, undefined, {
+  const result = await requestAIContent(user, parseCacheKey(text), system, undefined, {
     jsonMode: true
   })
   if (!result.success || !result.content) {

--- a/rank-analysis-app/src/services/ai/matchSearch/parse.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/parse.ts
@@ -1,0 +1,83 @@
+/**
+ * 自然语言 → ParsedMatchQuery 的解析入口
+ *
+ * 单轮 qwen-flash(JSON mode)调用;英雄/队列清单模块级缓存
+ * (一次会话内不变);同一句原文的解析结果走 requestAIContent 的
+ * sessionStorage 缓存,重复搜索零成本。
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+import { requestAIContent } from '@renderer/services/ai/stream'
+import { getGameModesByIpc } from '@renderer/services/ipc'
+import type { championOption } from '@renderer/types/domain/champion'
+import { buildMatchSearchPrompt, type PromptContext } from './prompt'
+import { validateParsedQuery } from './schema'
+import type { ParsedMatchQuery } from './types'
+
+/** 英雄/队列清单缓存(会话内不变,避免每次解析都打两个 IPC) */
+let ctxCache: Omit<PromptContext, 'today'> | null = null
+
+/** 测试专用:清空模块级缓存 */
+export function __resetParseCachesForTests(): void {
+  ctxCache = null
+}
+
+async function loadContext(): Promise<Omit<PromptContext, 'today'>> {
+  if (ctxCache) return ctxCache
+  const [champions, modes] = await Promise.all([
+    invoke<championOption[]>('get_champion_options'),
+    getGameModesByIpc()
+  ])
+  ctxCache = { champions, modes }
+  return ctxCache
+}
+
+/**
+ * 从模型输出里提取 JSON 对象(容忍 ```json 围栏与前后闲话)
+ * @returns 解析出的对象;找不到合法 JSON 时返回 null
+ */
+export function extractJson(content: string): unknown | null {
+  const tryParse = (s: string): unknown | null => {
+    try {
+      return JSON.parse(s)
+    } catch {
+      return null
+    }
+  }
+  const direct = tryParse(content.trim())
+  if (direct !== null) return direct
+  // 取第一个 '{' 到最后一个 '}' 的最大区间(围栏/闲话都在区间外)
+  const start = content.indexOf('{')
+  const end = content.lastIndexOf('}')
+  if (start < 0 || end <= start) return null
+  return tryParse(content.slice(start, end + 1))
+}
+
+/**
+ * 把自然语言解析为结构化战绩检索条件
+ * @param text - 用户原文
+ * @throws Error 中文可展示信息(请求失败 / 输出不是 JSON)
+ */
+export async function parseMatchQuery(text: string): Promise<ParsedMatchQuery> {
+  const { champions, modes } = await loadContext()
+  const today = new Date().toISOString().slice(0, 10)
+  const { system, user } = buildMatchSearchPrompt(text, { today, champions, modes })
+
+  const result = await requestAIContent(user, `matchSearch:${today}:${text}`, system, undefined, {
+    jsonMode: true
+  })
+  if (!result.success || !result.content) {
+    throw new Error(result.error || 'AI 解析请求失败')
+  }
+
+  const raw = extractJson(result.content)
+  if (raw === null) {
+    throw new Error('AI 未能解析这句描述,请换个说法重试')
+  }
+
+  return validateParsedQuery(
+    raw,
+    new Set(champions.map(c => c.value)),
+    new Set(modes.map(m => m.value).filter(v => v > 0))
+  )
+}

--- a/rank-analysis-app/src/services/ai/matchSearch/parse.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/parse.ts
@@ -93,9 +93,15 @@ export async function parseMatchQuery(text: string): Promise<ParsedMatchQuery> {
     throw new Error('AI 未能解析这句描述,请换个说法重试')
   }
 
-  return validateParsedQuery(
+  const q = validateParsedQuery(
     raw,
     new Set(champions.map(c => c.value)),
     new Set(modes.map(m => m.value).filter(v => v > 0))
   )
+
+  // 确定性钳制:模型偶尔输出未来日期(如把「这个月」解析成整个日历月)。
+  // to 在未来 = 「至今」,置空;from 在未来则整个时间窗不可信,作废。
+  if (q.timeRange.to && q.timeRange.to > today) q.timeRange.to = null
+  if (q.timeRange.from && q.timeRange.from > today) q.timeRange = { from: null, to: null }
+  return q
 }

--- a/rank-analysis-app/src/services/ai/matchSearch/prompt.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/prompt.ts
@@ -1,0 +1,74 @@
+/**
+ * 自然语言搜战绩的 prompt 构造
+ *
+ * 反幻觉设计:
+ * - 英雄清单(id|官方名|昵称|称号)整体注入,模型只许从清单选 id,
+ *   「女警/金克斯」这类俗称由模型对着清单归一,本地再按白名单过滤兜底
+ * - 注入今天日期,让「这个月/前两天」被解析为绝对 ISO 日期
+ * - 队列同理给出 id|名称 映射表
+ */
+
+/** prompt 构造所需的上下文(全部来自本地命令,调用方负责缓存) */
+export interface PromptContext {
+  /** 今天日期 YYYY-MM-DD */
+  today: string
+  /** 英雄清单,来自 get_champion_options */
+  champions: { value: number; label: string; nickname: string; realName: string }[]
+  /** 队列清单,来自 get_game_modes(value=0 的「全部」项由调用方过滤或本函数忽略) */
+  modes: { label: string; value: number }[]
+}
+
+const SYSTEM_PROMPT = `你是英雄联盟战绩检索条件解析器。把玩家对某些对局的自然语言描述解析为 JSON 检索条件,只输出一个 JSON 对象,不要任何解释。
+
+输出 schema(所有字段可省略,省略视为不筛该维度):
+{
+  "timeRange": { "from": "YYYY-MM-DD 或 null", "to": "YYYY-MM-DD 或 null" },
+  "selfChampionIds": [说话人自己使用的英雄id],
+  "allyChampionIds": [队友(不含说话人)使用的英雄id],
+  "enemyChampionIds": [对面使用的英雄id],
+  "myTeamChampionIds": [说话人这边出现过的英雄id(含本人)],
+  "result": "win" | "loss" | "any",
+  "queueIds": [队列id],
+  "playerNames": ["提到的玩家名,保留原样(可含#tag)"],
+  "intent": "list" | "count_encounters"
+}
+
+规则:
+1. 英雄 id 只能从下方英雄清单里选,俗称/绰号对照清单归一;清单里没有的英雄一律忽略。
+2. 「我用X」→ selfChampionIds;「队友有X」→ allyChampionIds;「对面/敌方有X」→ enemyChampionIds;「忘了自己玩的什么,但这边有X」这类不确定是不是自己在用的 → myTeamChampionIds。
+3. 相对时间(这个月/上周/前两天)按「今天」换算成绝对日期;完全没提时间就不要输出 timeRange。
+4. 「跟某某碰见/遇到几次」这类统计问题 → intent = "count_encounters",玩家名进 playerNames;其余 intent = "list"。
+5. 不确定的信息宁可省略,不要猜。所有数字必须来自清单,禁止编造。`
+
+/**
+ * 构造解析请求的 system/user prompt
+ * @param text - 用户的自然语言描述原文
+ * @param ctx - 日期/英雄/队列上下文
+ */
+export function buildMatchSearchPrompt(
+  text: string,
+  ctx: PromptContext
+): { system: string; user: string } {
+  const championLines = ctx.champions
+    .map(c => `${c.value}|${c.label}|${c.nickname}|${c.realName}`)
+    .join('\n')
+  const modeLines = ctx.modes
+    .filter(m => m.value > 0)
+    .map(m => `${m.value}|${m.label}`)
+    .join('\n')
+
+  const user = `今天是 ${ctx.today}。
+
+英雄清单(id|官方名|昵称|称号):
+${championLines}
+
+队列清单(id|名称):
+${modeLines}
+
+玩家描述:
+${text}
+
+请输出 JSON 检索条件。`
+
+  return { system: SYSTEM_PROMPT, user }
+}

--- a/rank-analysis-app/src/services/ai/matchSearch/prompt.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/prompt.ts
@@ -36,9 +36,25 @@ const SYSTEM_PROMPT = `你是英雄联盟战绩检索条件解析器。把玩家
 规则:
 1. 英雄 id 只能从下方英雄清单里选,俗称/绰号对照清单归一;清单里没有的英雄一律忽略。
 2. 「我用X」→ selfChampionIds;「队友有X」→ allyChampionIds;「对面/敌方有X」→ enemyChampionIds;「忘了自己玩的什么,但这边有X」这类不确定是不是自己在用的 → myTeamChampionIds。
-3. 相对时间(这个月/上周/前两天)按「今天」换算成绝对日期;完全没提时间就不要输出 timeRange。
+3. 相对时间按「今天」换算成绝对日期:口语的「这个月/最近一个月/近一个月」一律取最近 30 天(from = 今天-30天,to 省略);「上周/最近一周」取最近 7 天;「前两天」取最近 3 天;只有明确点名某个日历月(如「8月」)才用该月 1 日到月末。to 不得晚于今天,「至今」直接省略 to。完全没提时间就不要输出 timeRange。
 4. 「跟某某碰见/遇到几次」这类统计问题 → intent = "count_encounters",玩家名进 playerNames;其余 intent = "list"。
 5. 不确定的信息宁可省略,不要猜。所有数字必须来自清单,禁止编造。`
+
+/** 上个月的中文叫法(如「8月」),用于日历月示例 */
+function prevMonthCn(today: string): string {
+  const d = new Date(`${today}T00:00:00.000Z`)
+  d.setUTCMonth(d.getUTCMonth() - 1)
+  return `${d.getUTCMonth() + 1}月`
+}
+
+/** 上个月的边界 JSON(如 {"from":"2026-08-01","to":"2026-08-31"}) */
+function prevMonthRangeJson(today: string): string {
+  const d = new Date(`${today}T00:00:00.000Z`)
+  const first = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() - 1, 1))
+  const last = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 0))
+  const iso = (x: Date): string => x.toISOString().slice(0, 10)
+  return JSON.stringify({ from: iso(first), to: iso(last) })
+}
 
 /**
  * 构造解析请求的 system/user prompt
@@ -57,7 +73,20 @@ export function buildMatchSearchPrompt(
     .map(m => `${m.value}|${m.label}`)
     .join('\n')
 
+  // few-shot 时间换算示例:qwen-flash 对抽象规则不敏感,给带具体日期的样例
+  const daysAgo = (n: number): string => {
+    const d = new Date(`${ctx.today}T00:00:00.000Z`)
+    d.setUTCDate(d.getUTCDate() - n)
+    return d.toISOString().slice(0, 10)
+  }
+
   const user = `今天是 ${ctx.today}。
+
+时间换算示例(严格照此风格):
+- 「这个月/最近一个月/近一个月」→ {"from":"${daysAgo(30)}","to":null}
+- 「上周/最近一周」→ {"from":"${daysAgo(7)}","to":null}
+- 「前两天」→ {"from":"${daysAgo(3)}","to":null}
+- 明确点名某日历月(如「${prevMonthCn(ctx.today)}」)才用该月边界 → ${prevMonthRangeJson(ctx.today)}
 
 英雄清单(id|官方名|昵称|称号):
 ${championLines}

--- a/rank-analysis-app/src/services/ai/matchSearch/schema.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/schema.ts
@@ -35,12 +35,16 @@ function idArray(raw: unknown, valid: Set<number>): number[] {
   return out
 }
 
-/** 校验 ISO 日期字符串(YYYY-MM-DD 开头且可被 Date 解析),非法返回 null */
+/**
+ * 校验并规范化为纯日期 YYYY-MM-DD,非法返回 null。
+ * 模型可能输出带时间的完整 ISO 串,必须截断——下游会再拼 `T00:00:00.000Z`,
+ * 原样透传会产生 NaN 日期使时间窗静默失效。
+ */
 function isoDateOrNull(raw: unknown): string | null {
   if (typeof raw !== 'string') return null
-  const s = raw.trim()
-  if (!/^\d{4}-\d{2}-\d{2}/.test(s)) return null
-  return Number.isNaN(new Date(s).getTime()) ? null : s
+  const s = raw.trim().slice(0, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
+  return Number.isNaN(new Date(`${s}T00:00:00.000Z`).getTime()) ? null : s
 }
 
 /**

--- a/rank-analysis-app/src/services/ai/matchSearch/schema.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * ParsedMatchQuery 的构造与防御性校验
+ *
+ * 模型输出不可信:字段可能缺失、类型可能错、英雄/队列 id 可能编造。
+ * 校验策略是「宁可少筛不误筛」——非法字段降级为空/any,绝不抛错,
+ * 保证下游筛选永远拿到结构完整的查询对象。
+ */
+
+import type { ParsedMatchQuery } from './types'
+
+/** 全空查询:不筛任何维度 */
+export function emptyQuery(): ParsedMatchQuery {
+  return {
+    timeRange: { from: null, to: null },
+    selfChampionIds: [],
+    allyChampionIds: [],
+    enemyChampionIds: [],
+    myTeamChampionIds: [],
+    result: 'any',
+    queueIds: [],
+    playerNames: [],
+    intent: 'list'
+  }
+}
+
+/** 提取数字数组并按白名单过滤(去重、丢弃非数字与清单外 id) */
+function idArray(raw: unknown, valid: Set<number>): number[] {
+  if (!Array.isArray(raw)) return []
+  const out: number[] = []
+  for (const v of raw) {
+    if (typeof v === 'number' && Number.isFinite(v) && valid.has(v) && !out.includes(v)) {
+      out.push(v)
+    }
+  }
+  return out
+}
+
+/** 校验 ISO 日期字符串(YYYY-MM-DD 开头且可被 Date 解析),非法返回 null */
+function isoDateOrNull(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const s = raw.trim()
+  if (!/^\d{4}-\d{2}-\d{2}/.test(s)) return null
+  return Number.isNaN(new Date(s).getTime()) ? null : s
+}
+
+/**
+ * 把模型原始 JSON 输出净化为合法的 ParsedMatchQuery
+ * @param raw - 模型输出(任意形状)
+ * @param validChampionIds - 合法英雄 id 白名单(来自 get_champion_options)
+ * @param validQueueIds - 合法队列 id 白名单(来自 get_game_modes)
+ */
+export function validateParsedQuery(
+  raw: unknown,
+  validChampionIds: Set<number>,
+  validQueueIds: Set<number>
+): ParsedMatchQuery {
+  const q = emptyQuery()
+  if (typeof raw !== 'object' || raw === null) return q
+  const r = raw as Record<string, unknown>
+
+  const tr = (typeof r.timeRange === 'object' && r.timeRange) || {}
+  let from = isoDateOrNull((tr as Record<string, unknown>).from)
+  let to = isoDateOrNull((tr as Record<string, unknown>).to)
+  // from > to 说明模型日期算错了,整个时间窗作废比错误截断更安全
+  if (from && to && from > to) {
+    from = null
+    to = null
+  }
+  q.timeRange = { from, to }
+
+  q.selfChampionIds = idArray(r.selfChampionIds, validChampionIds)
+  q.allyChampionIds = idArray(r.allyChampionIds, validChampionIds)
+  q.enemyChampionIds = idArray(r.enemyChampionIds, validChampionIds)
+  q.myTeamChampionIds = idArray(r.myTeamChampionIds, validChampionIds)
+  q.queueIds = idArray(r.queueIds, validQueueIds)
+
+  if (r.result === 'win' || r.result === 'loss') q.result = r.result
+
+  if (Array.isArray(r.playerNames)) {
+    const names: string[] = []
+    for (const v of r.playerNames) {
+      if (typeof v !== 'string') continue
+      const name = v.trim()
+      if (name && !names.includes(name)) names.push(name)
+    }
+    q.playerNames = names
+  }
+
+  if (r.intent === 'count_encounters') q.intent = 'count_encounters'
+
+  return q
+}

--- a/rank-analysis-app/src/services/ai/matchSearch/types.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/types.ts
@@ -1,0 +1,44 @@
+/**
+ * AI 自然语言搜战绩:结构化查询模型(issue #157)
+ *
+ * 模型只负责把自然语言解析成本文件的 `ParsedMatchQuery`,
+ * 所有筛选/统计由本地纯函数完成,不信任模型的数字结论。
+ */
+
+/** 自然语言解析出的战绩检索条件(全部字段可缺省 = 不筛该维度) */
+export interface ParsedMatchQuery {
+  /** 时间窗,ISO 日期(YYYY-MM-DD),null = 该侧不设限;to 含当日整天 */
+  timeRange: { from: string | null; to: string | null }
+  /** 我用的英雄,多个为「其中之一」(用户记不清是哪个时的备选) */
+  selfChampionIds: number[]
+  /** 队友(不含我)用的英雄,多个为「都要在场」 */
+  allyChampionIds: number[]
+  /** 对面用的英雄,多个为「都要在场」 */
+  enemyChampionIds: number[]
+  /** 我方(含我)出现过的英雄,多个为「都要在场」——「忘了自己玩的啥」场景 */
+  myTeamChampionIds: number[]
+  /** 胜负 */
+  result: 'win' | 'loss' | 'any'
+  /** 队列 id 白名单,空 = 不限模式 */
+  queueIds: number[]
+  /** 出现过的玩家名(「跟 XXX#XXX 碰见过几次」),支持 名#tag 或纯名 */
+  playerNames: string[]
+  /** list = 列出对局;count_encounters = 统计与 playerNames 的相遇次数 */
+  intent: 'list' | 'count_encounters'
+}
+
+/** 相遇统计结果(count_encounters 意图) */
+export interface EncounterStats {
+  /** 命中任一目标玩家的对局数 */
+  total: number
+  /** 每个目标玩家的同队/对面相遇局数 */
+  perName: Record<string, { ally: number; enemy: number }>
+}
+
+/** 解析条件的可视化 chip(供结果页展示与删除) */
+export interface QueryChip {
+  /** 删除定位用,如 `self:51` / `time` / `player:某人#123` */
+  key: string
+  /** 人类可读文案,如 `我用: 皮城女警` */
+  label: string
+}

--- a/rank-analysis-app/src/utils/navigation.ts
+++ b/rank-analysis-app/src/utils/navigation.ts
@@ -1,8 +1,19 @@
 /**
- * 路由跳转快捷方法
+ * 路由跳转快捷方法与 query 参数规范化
  */
 
 import router from '@renderer/router'
+import type { LocationQueryValue } from 'vue-router'
+
+/**
+ * 把路由 query 值规范化为单个 string。
+ * vue-router 在参数重复时(?aiq=a&aiq=b)给出数组,直接 `as string` 会把数组
+ * 透传进模板/逻辑;统一取第一个有效值,缺失返回空串。
+ */
+export function firstQueryValue(v: LocationQueryValue | LocationQueryValue[]): string {
+  if (Array.isArray(v)) return v.find(x => typeof x === 'string') ?? ''
+  return v ?? ''
+}
 
 export function searchSummoner(nameId: string) {
   router.push({

--- a/rank-analysis-app/src/views/Record.vue
+++ b/rank-analysis-app/src/views/Record.vue
@@ -9,18 +9,27 @@
     <Transition name="slide-fade" mode="out-in">
       <n-layout-content v-if="!isMobile" class="record-content" style="flex: 3">
         <div class="record-content-inner">
-          <MatchHistory />
+          <!-- aiq 存在 = AI 自然语言搜索结果视图;key 保证新搜索重建组件 -->
+          <AiSearchResults v-if="aiQuery" :key="aiQuery" />
+          <MatchHistory v-else />
         </div>
       </n-layout-content>
     </Transition>
   </n-layout>
 </template>
 <script lang="ts" setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import MatchHistory from '../components/record/MatchHistory.vue'
+import AiSearchResults from '../components/record/AiSearchResults.vue'
 import UserRecord from '../components/record/UserRecord.vue'
 import { useBreakpoint } from '@renderer/composables/useBreakpoint'
 
 const { isMobile } = useBreakpoint()
+
+const route = useRoute()
+/** AI 自然语言搜索原文(Header 超级搜索的 AI 行跳转带入) */
+const aiQuery = computed(() => (route.query.aiq as string) ?? '')
 </script>
 <style scoped>
 /* 整页 token 覆盖:所有子组件 var(--font-size-*) 自动跟随 viewport 缩放 (1100→2200) */

--- a/rank-analysis-app/src/views/Record.vue
+++ b/rank-analysis-app/src/views/Record.vue
@@ -9,8 +9,8 @@
     <Transition name="slide-fade" mode="out-in">
       <n-layout-content v-if="!isMobile" class="record-content" style="flex: 3">
         <div class="record-content-inner">
-          <!-- aiq 存在 = AI 自然语言搜索结果视图;key 保证新搜索重建组件 -->
-          <AiSearchResults v-if="aiQuery" :key="aiQuery" />
+          <!-- aiq 存在 = AI 自然语言搜索结果视图;key 含 t,同句重搜也能重建组件重跑管线 -->
+          <AiSearchResults v-if="aiQuery" :key="`${aiQuery}|${searchStamp}`" />
           <MatchHistory v-else />
         </div>
       </n-layout-content>
@@ -24,12 +24,15 @@ import MatchHistory from '../components/record/MatchHistory.vue'
 import AiSearchResults from '../components/record/AiSearchResults.vue'
 import UserRecord from '../components/record/UserRecord.vue'
 import { useBreakpoint } from '@renderer/composables/useBreakpoint'
+import { firstQueryValue } from '@renderer/utils/navigation'
 
 const { isMobile } = useBreakpoint()
 
 const route = useRoute()
 /** AI 自然语言搜索原文(Header 超级搜索的 AI 行跳转带入) */
-const aiQuery = computed(() => (route.query.aiq as string) ?? '')
+const aiQuery = computed(() => firstQueryValue(route.query.aiq))
+/** 每次搜索的时间戳,进 key 使「重复搜同一句」也触发重跑 */
+const searchStamp = computed(() => firstQueryValue(route.query.t))
 </script>
 <style scoped>
 /* 整页 token 覆盖:所有子组件 var(--font-size-*) 自动跟随 viewport 缩放 (1100→2200) */


### PR DESCRIPTION
## Summary

落地 #157:把 Header 搜索框升级为三合一超级搜索(omnibox)。

- **精确查人**(保留现有流程):输入形似 Riot ID(`名字#Tag`)回车即查
- **模糊查人**(新):输入片段时下拉展示本地候选——好友(新命令 `get_friends`)/ 备注玩家 / 搜索历史(新,localStorage 上限 20 条),子串匹配、点选即查
- **AI 自然语言搜战绩**(新,issue 主体):如「这个月有一把我用的女警,队友有个金克斯,最后赢了」→ qwen-flash(JSON mode)解析为结构化条件 → SGP 深分页拉当前玩家战绩(时间窗上限 200 局,SGP 不可用降级 LCU 50 局)→ 本地确定性筛选/统计 → Record 页以可删除的条件 chips + 战绩卡列表呈现;「跟 XXX 碰见过几次」出相遇统计卡(同队/对面分计)

### 反幻觉设计
- 英雄清单(id|官方名|昵称|称号)注入 prompt,模型只许选清单内 id,本地白名单再过滤
- 相对时间给 few-shot 换算示例 + 未来日期本地钳制(qwen-flash 实测会把「这个月」编成整个日历月)
- 统计/胜负/日期比较全部本地纯函数,不信模型数字结论
- 解析结果渲染为可删 chips,用户能看见并修正 AI 的理解

### 设计文档
- spec: `docs/superpowers/specs/2026-09-01-super-search-design.md`
- plan: `docs/superpowers/plans/2026-09-01-super-search.md`

## Test plan
- [x] `npm run check` passes
- [x] `npm run test` passes(880+ 用例;全量跑偶发挂的 `MatchHistory mounts without crashing` 在 main 上同样存在,与本 PR 无关)
- [x] `cargo test` passes(350 passed,含 get_friends serde 用例)
- [x] 真机验收(本机 LOL + DashScope key,经 MCP bridge):
  - 「这个月…女警…金克斯…赢了」全链路(解析→翻 140 局→过滤)✅
  - 「最近一周我赢了的对局」命中 5 局渲染 ✅
  - 「最近一个月我跟 银 月#80598 碰见过几次」相遇统计卡(同队 1 次)✅
  - 「忘了自己玩的啥,队友有女警金克丝」→ 我方有 语义 ✅
  - omnibox 候选(好友角标)+ 精确查人回归 + 搜索历史写入 ✅

## 已知边界(记录在 spec 非目标)
- 装备黑话(「坦克引擎」「飞身踢」)第一期不支持
- AI 搜索固定当前登录玩家 + 当前大区