### PR TITLE
fix(sync): 配置云同步防丢失——持久 dirty 补推、冲突弹裁决、裁决重拉最新

### DIFF
--- a/rank-analysis-app/src-tauri/src/config.rs
+++ b/rank-analysis-app/src-tauri/src/config.rs
@@ -413,6 +413,7 @@ pub const BACKUP_BLACKLIST: &[&str] = &[
     "cloudSyncNoticeShown",
     "configSyncedOnce",
     "configLastSyncAt",
+    "configDirtyAt",
     "playerNotes",
 ];
 
@@ -736,6 +737,7 @@ mod tests {
             "cloudSyncNoticeShown",
             "configSyncedOnce",
             "configLastSyncAt",
+            "configDirtyAt",
             "playerNotes",
         ] {
             assert!(!allowed_in_backup(key), "{key} 不应进文件备份");

--- a/rank-analysis-app/src/pinia/__tests__/cloudSync.spec.ts
+++ b/rank-analysis-app/src/pinia/__tests__/cloudSync.spec.ts
@@ -409,10 +409,11 @@ describe('useCloudSyncStore', () => {
       expect(store.pendingCloudConfig).toBeNull()
     })
 
-    it('后续同步:本地有未推送变更 → 推送胜过云端(后写胜)', async () => {
+    it('后续同步:本地有未推变更且云端未更新 → 推送并清持久 dirty 标记', async () => {
       mockGetConfig({ configSyncedOnce: true, configLastSyncAt: 50 })
       mockConfigInvoke({
-        pulled: { updatedAt: 100, config: { theme: { value: 'dark' } } },
+        // 云端行比上次同步旧(30 < 50):只有本机改过,放心推
+        pulled: { updatedAt: 30, config: { theme: { value: 'dark' } } },
         local: { theme: { value: 'light' } }
       })
       const store = useCloudSyncStore()
@@ -420,6 +421,83 @@ describe('useCloudSyncStore', () => {
       await store.syncNow()
       expect(mockInvoke).not.toHaveBeenCalledWith('apply_config_snapshot', expect.anything())
       expect(mockInvoke).toHaveBeenCalledWith('cloud_push_config', { puuid: 'me' })
+      expect(mockPut).toHaveBeenCalledWith('configDirtyAt', 0)
+    })
+
+    it('后续同步:两边都改过(本机 dirty 且云端更新) → 弹裁决而非盲推(维克托丢失回归锚点)', async () => {
+      mockGetConfig({ configSyncedOnce: true, configLastSyncAt: 50 })
+      mockConfigInvoke({
+        pulled: { updatedAt: 100, config: { theme: { value: 'dark' } } },
+        local: { theme: { value: 'light' } }
+      })
+      const store = useCloudSyncStore()
+      store.markConfigDirty()
+      await store.syncNow()
+      expect(store.pendingCloudConfig).not.toBeNull()
+      expect(mockInvoke).not.toHaveBeenCalledWith('cloud_push_config', expect.anything())
+      expect(mockInvoke).not.toHaveBeenCalledWith('apply_config_snapshot', expect.anything())
+    })
+
+    it('markConfigDirty 持久化 dirty 时间戳(防「改完就退出」丢推送)', async () => {
+      mockGetConfig({ configSyncedOnce: true })
+      const store = useCloudSyncStore()
+      store.markConfigDirty()
+      await flushAsync()
+      expect(mockPut).toHaveBeenCalledWith('configDirtyAt', expect.any(Number))
+    })
+
+    it('启动时恢复持久 dirty:上次会话未推送的变更在本次启动补推', async () => {
+      // 云端行更旧(30 < 50)且内容不同:恢复的 dirty 应触发补推而非静默应用
+      mockGetConfig({
+        configSyncedOnce: true,
+        configLastSyncAt: 50,
+        configDirtyAt: 123,
+        cloudSyncEnabled: true
+      })
+      mockConfigInvoke({
+        pulled: { updatedAt: 30, config: { theme: { value: 'dark' } } },
+        local: { theme: { value: 'light' } }
+      })
+      const store = useCloudSyncStore()
+      await store.init()
+      await flushAsync()
+      expect(mockInvoke).toHaveBeenCalledWith('cloud_push_config', { puuid: 'me' })
+      expect(mockInvoke).not.toHaveBeenCalledWith('apply_config_snapshot', expect.anything())
+    })
+
+    it('裁决「使用云端」时重新拉取最新快照,不套用陈旧 pending', async () => {
+      mockGetConfig({ configSyncedOnce: undefined })
+      // 第一次 pull 返回 v1(进入 pending),裁决时的第二次 pull 返回 v2
+      let pullCount = 0
+      mockInvoke.mockImplementation(async cmd => {
+        if (cmd === 'get_my_summoner') return { puuid: 'me' }
+        if (cmd === 'cloud_pull_notes') return []
+        if (cmd === 'cloud_pull_config') {
+          pullCount++
+          return pullCount === 1
+            ? { updatedAt: 100, config: { theme: { value: 'v1' } } }
+            : { updatedAt: 200, config: { theme: { value: 'v2' } } }
+        }
+        if (cmd === 'get_cloud_config_snapshot') return { theme: { value: 'local' } }
+        return undefined
+      })
+      const store = useCloudSyncStore()
+      await store.syncNow()
+      expect(store.pendingCloudConfig).not.toBeNull()
+      await store.resolveCloudConfig(true)
+      expect(mockInvoke).toHaveBeenCalledWith('apply_config_snapshot', {
+        snapshot: { theme: { value: 'v2' } }
+      })
+    })
+
+    it('内容一致时清掉持久 dirty 标记', async () => {
+      mockGetConfig({ configSyncedOnce: true, configLastSyncAt: 50 })
+      const same = { theme: { value: 'dark' } }
+      mockConfigInvoke({ pulled: { updatedAt: 100, config: same }, local: same })
+      const store = useCloudSyncStore()
+      store.markConfigDirty()
+      await store.syncNow()
+      expect(mockPut).toHaveBeenCalledWith('configDirtyAt', 0)
     })
 
     it('后续同步:内容一致 → 不 apply 不 push', async () => {

--- a/rank-analysis-app/src/pinia/cloudSync.ts
+++ b/rank-analysis-app/src/pinia/cloudSync.ts
@@ -72,10 +72,22 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
   let applyingConfig = false
   let configWatchStarted = false
 
-  /** 标记本地配置已变更（config-changed 监听与测试共用入口） */
+  /**
+   * 标记本地配置已变更（config-changed 监听与测试共用入口）。
+   * 时间戳同步落盘：内存标记重启即失，30s 防抖窗口内退出会让变更永远推不出去，
+   * 下次启动的拉取还会把它静默覆盖——持久化后下次启动恢复 dirty、优先补推。
+   * （configDirtyAt 在黑名单中，这次落盘不会再触发 config-changed 回环。）
+   */
   function markConfigDirty(): void {
     if (applyingConfig) return
     configDirty = true
+    putConfigByIpc(CONFIG_KEYS.configDirtyAt, Date.now()).catch(() => {})
+  }
+
+  /** 清除 dirty（推送成功 / 应用云端 / 内容一致时） */
+  async function clearConfigDirty(): Promise<void> {
+    configDirty = false
+    await putConfigByIpc(CONFIG_KEYS.configDirtyAt, 0)
   }
 
   /**
@@ -95,7 +107,7 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
   /** 推送本机配置到云端并更新 LWW 基准 */
   async function pushConfig(puuid: string): Promise<void> {
     await invoke('cloud_push_config', { puuid })
-    configDirty = false
+    await clearConfigDirty()
     await putConfigByIpc(CONFIG_KEYS.configLastSyncAt, Date.now())
   }
 
@@ -107,7 +119,7 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     } finally {
       applyingConfig = false
     }
-    configDirty = false
+    await clearConfigDirty()
     await putConfigByIpc(CONFIG_KEYS.configLastSyncAt, Date.now())
     // 立即生效：theme 是唯一初始化后不再读 config 的展示态，其余设置页打开时现读
     await useSettingsStore().initTheme()
@@ -146,23 +158,36 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     }
 
     if (pulled && deepEqual(pulled.config, local)) {
-      configDirty = false
+      await clearConfigDirty()
+      return
+    }
+    const lastConfigSyncMs = (await getConfigByIpc<number>(CONFIG_KEYS.configLastSyncAt)) ?? 0
+    const cloudNewer = pulled !== null && pulled.updatedAt > lastConfigSyncMs
+    // 两边都改过(本机有未推变更 && 云端也比上次同步新):真冲突,交用户裁决。
+    // 曾经这里是「dirty 直接推送」——本机任何小改动都会整份覆盖另一台设备的
+    // 新配置(自动 ban/pick 规则丢失的根因),盲推必须废弃。
+    if (configDirty && cloudNewer) {
+      pendingPuuid = puuid
+      pendingCloudConfig.value = pulled
       return
     }
     if (configDirty) {
       await pushConfig(puuid)
       return
     }
-    const lastConfigSyncMs = (await getConfigByIpc<number>(CONFIG_KEYS.configLastSyncAt)) ?? 0
-    if (pulled && pulled.updatedAt > lastConfigSyncMs) {
-      await applyCloudConfig(pulled)
+    if (cloudNewer) {
+      await applyCloudConfig(pulled!)
     } else {
       await pushConfig(puuid)
     }
   }
 
   /**
-   * 首次确认弹窗的裁决入口（Framework 的弹窗按钮调用）。
+   * 确认弹窗的裁决入口（首次绑定与后续冲突共用,Framework/DataSync 的弹窗按钮调用）。
+   *
+   * 选「使用云端」时**重新拉取最新快照**再应用:pending 是侦测冲突那一刻的缓存,
+   * 裁决入口改成被动角标后可能挂很久,期间其他设备推送的新配置(如新增的
+   * ban/pick 规则)不能被陈旧快照静默吃掉。重拉失败退回 pending(有损但可用)。
    * @param useCloud - true 用云端覆盖本地；false 保留本地并推送覆盖云端
    */
   async function resolveCloudConfig(useCloud: boolean): Promise<void> {
@@ -173,7 +198,10 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     syncing.value = true
     try {
       if (useCloud) {
-        await applyCloudConfig(pending)
+        const fresh = await invoke<CloudConfig | null>('cloud_pull_config', {
+          puuid: pendingPuuid
+        }).catch(() => null)
+        await applyCloudConfig(fresh ?? pending)
       } else {
         await pushConfig(pendingPuuid)
       }
@@ -255,6 +283,17 @@ export const useCloudSyncStore = defineStore('cloudSync', () => {
     }
     // 详情窗口只镜像开关状态，不承担同步（见 isStandaloneDetailWindow）
     if (isStandaloneDetailWindow()) return
+    // dev 构建不自动同步:target/debug 有独立 config,自动推送会以「隐形第三设备」
+    // 身份把调试配置整份顶到云端(真机取证:云端多行互踩的元凶之一)。
+    // 设置页「立即同步」仍可手动触发,联调不受影响。vitest 的 MODE 是 'test',不受此门限制。
+    if (import.meta.env.MODE === 'development') return
+    // 恢复上次会话未推送的变更标记(防抖窗口内退出的变更,本次启动补推)
+    try {
+      const dirtyAt = await getConfigByIpc<number>(CONFIG_KEYS.configDirtyAt)
+      if (dirtyAt && dirtyAt > 0) configDirty = true
+    } catch {
+      // 读不到按未变更处理
+    }
     startConnectionRetrigger()
     startConfigWatch()
     if (enabled.value) {

--- a/rank-analysis-app/src/services/configKeys.ts
+++ b/rank-analysis-app/src/services/configKeys.ts
@@ -28,6 +28,12 @@ export const CONFIG_KEYS = {
   /** 本设备上次推送/应用配置的时刻 ms(LWW 比较基准;设备级,不入备份) */
   configLastSyncAt: 'configLastSyncAt',
   /**
+   * 本设备最近一次未推送配置变更的时刻 ms,推送成功清零(设备级,不入备份)。
+   * 持久化是为了防「改完 30s 防抖内就退出」:下次启动恢复 dirty,补推而非被
+   * 启动拉取静默覆盖。
+   */
+  configDirtyAt: 'configDirtyAt',
+  /**
    * 游戏安装根目录（免 WeGame 一键启动用）。
    *
    * 由后端在客户端「已连接」时从运行进程反推并自动记忆（见 Rust `command::launcher`），

--- a/rank-analysis-app/src/views/settings/DataSync.vue
+++ b/rank-analysis-app/src/views/settings/DataSync.vue
@@ -1,26 +1,23 @@
 <template>
   <n-space vertical :size="12">
-    <!-- 云端配置待裁决入口：CloudConfigPullDialog 不再启动时自动弹出，改成这里
-         被动引导——左侧「设置」导航与本页菜单项已有呼吸角标指路，用户点「去处理」
-         才真正弹出裁决框。
+    <!-- 云端配置待裁决入口：首次绑定与「两边都改过」的冲突共用。被动引导——
+         左侧「设置」导航与本页菜单项有呼吸角标指路，用户点「去处理」才弹裁决框。
 
-         裁决未决期间配置同步（syncConfig）整段冻结（见 pinia/cloudSync.ts），
-         这个搁置窗口从"强制弹窗的几秒"变成了"被动角标的无限期"，必须把后果
-         说清楚，否则用户会以为可以慢慢来：
-         1) 确认前本机设置改动不会推送云端（configDirty 置位后 syncConfig 直接
-            return，永远没有机会落地）；
-         2) 最终若选"使用云端配置"，套用的是最初侦测到冲突那一刻缓存的
-            pending 快照，会静默覆盖掉搁置期间的所有本机改动。 -->
+         裁决未决期间配置同步（syncConfig）整段冻结（见 pinia/cloudSync.ts）：
+         确认前本机设置改动不会推送云端（configDirty 置位后 syncConfig 直接
+         return）。裁决选"使用云端配置"时会**重新拉取当下最新的云端快照**再
+         应用（不再套用侦测冲突那一刻的缓存），但本机搁置期间的改动仍会被
+         云端覆盖——选云端即放弃本机，这一点必须在文案里说清楚。 -->
     <n-alert v-if="cloudStore.pendingCloudConfig" type="warning" :bordered="false">
       <n-space vertical :size="8" style="width: 100%">
         <n-space align="center" justify="space-between" style="width: 100%">
-          <span>检测到云端已有一份配置，与本机当前配置不一致，需要你确认使用哪一份。</span>
+          <span>云端配置与本机不一致（首次绑定，或两台设备都改过），需要你确认使用哪一份。</span>
           <n-button size="small" type="warning" @click="showCloudConfigDialog = true">
             去处理
           </n-button>
         </n-space>
         <n-text :depth="3" style="font-size: var(--font-size-sm)">
-          确认前，本机设置的改动不会同步到云端；若之后选择"使用云端配置"，这期间的本机改动会被覆盖，建议尽快处理。
+          确认前，本机设置的改动不会同步到云端；选"使用云端配置"会以云端当下最新内容覆盖本机（含这期间的本机改动），建议尽快处理。
         </n-text>
       </n-space>
     </n-alert>

--- a/rank-analysis-app/src/views/settings/__tests__/DataSync.cloudConfigEntry.spec.ts
+++ b/rank-analysis-app/src/views/settings/__tests__/DataSync.cloudConfigEntry.spec.ts
@@ -73,7 +73,7 @@ describe('DataSync.vue 云端配置拉取入口', () => {
 
   it('无待裁决配置时不展示入口提示条，裁决框也不可见', () => {
     const w = mountDataSync()
-    expect(w.text()).not.toContain('检测到云端已有一份配置')
+    expect(w.text()).not.toContain('云端配置与本机不一致')
     expect(w.text()).not.toContain('云端已有一份配置')
     w.unmount()
   })
@@ -84,12 +84,12 @@ describe('DataSync.vue 云端配置拉取入口', () => {
     const w = mountDataSync()
     await w.vm.$nextTick()
 
-    expect(w.text()).toContain('检测到云端已有一份配置')
+    expect(w.text()).toContain('云端配置与本机不一致')
     // 裁决未决期间配置同步整段冻结（syncConfig 见 pendingCloudConfig 非空即
     // return），必须把后果讲清楚：本机改动不推云端 + 最终选云端会覆盖掉这期间
     // 的本机改动，否则用户会以为被动角标可以慢慢处理
     expect(w.text()).toContain('确认前，本机设置的改动不会同步到云端')
-    expect(w.text()).toContain('这期间的本机改动会被覆盖')
+    expect(w.text()).toContain('会以云端当下最新内容覆盖本机')
     // 裁决框组件已挂载，但 show=false，标题文案此刻不应出现在可交互 DOM 里
     expect(w.text()).not.toContain('云端存在一份配置(更新于')
 


### PR DESCRIPTION
## Summary

用户反馈:一台设备新增的自动 ban/pick 规则(维克托),另一台拉取后没有。云端取证(同一 puuid 下 8 行 appConfig 互相覆盖、键存在性来回翻转)确认根因是配置同步的四个缺口。本 PR 保持「首次绑定 → 之后启动拉取 / 变更即推」的双向 LWW 模型,补上缺口:

1. **持久化 dirty 标记**(新键 `configDirtyAt`,黑名单不入备份/云端):变更在 30s 防抖窗口内退出 app 不再丢——下次启动恢复 dirty、优先补推,而不是被启动拉取静默覆盖。
2. **冲突不再盲推**:本机有未推变更 && 云端也比上次同步新(两边都改过)→ 弹既有裁决框让用户选,替代「dirty 无条件整份推送」——这正是另一台设备新配置被吞的路径。
3. **裁决"使用云端"时重拉最新快照**:裁决入口是被动角标可能挂很久,不再套用侦测冲突那一刻缓存的陈旧 pending(代码注释里自己标注过的隐患,这次真的咬人了)。
4. **dev 构建不自动同步**(`import.meta.env.MODE === 'development'` 门):`target/debug` 有独立 config,自动推送会以"隐形第三设备"身份把调试配置顶到云端(取证确认云端多行互踩的元凶之一)。设置页手动"立即同步"保留,联调不受影响。

不改数据模型、不引入键级合并——单用户两台设备错峰使用的场景,以上四点已闭合数据丢失路径;真冲突(两边同时改)显式交给用户裁决。

## 取证记录
- 本机(Windows 正式版)config:无 banRules 键;云端最新行 = 本机 20:48 盲推,埋掉了含 ban 规则的旧行
- 同 puuid 下 8 个匿名 owner 的行:两台机器 × dev 构建 × 匿名会话轮换(refresh_token 一次性,刷新失败即重新注册)的沉淀
- dev 构建(target/debug/config.yaml)cloudSyncEnabled=true,曾参与推送

## Test plan
- [x] `npm run check` passes
- [x] cloudSync.spec 29 用例全过(新增 6:冲突裁决/持久 dirty 落盘与恢复/裁决重拉/内容一致清 dirty;改写 1:原「dirty 盲推胜过云端」语义已废弃)
- [x] `cargo test`(347 passed,黑名单新键断言)
- [x] 全量 vitest 中偶发挂的 BpSuggestModal 并发用例单跑通过,系本机全量跑负载 flake,与本 PR 无关