### PR TITLE
feat(search): AI 搜战绩支持位置条件 + 英雄清单玉剑变体过滤

### DIFF
--- a/rank-analysis-app/src-tauri/src/command/config.rs
+++ b/rank-analysis-app/src-tauri/src/command/config.rs
@@ -126,6 +126,13 @@ pub fn get_champion_options() -> Result<Vec<ChampionOption>, String> {
         if champion.name.contains("末日人机") {
             continue;
         }
+        // 特殊模式实体不加入选项:玉剑传说等活动会往英雄表塞一整套大 id 变体
+        // (Jade_* 系列 60001+,中文名与真英雄完全相同),会污染英雄筛选下拉与
+        // AI 搜战绩的英雄清单(真机复现:「EZ」被解析成 60081 而非 81)。
+        // 真实可玩英雄 id 目前 < 1000,取 3000 留足余量。
+        if champion.id >= 3000 {
+            continue;
+        }
         options.push(ChampionOption {
             label: champion.name,
             value: champion.id,

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/chips.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/chips.spec.ts
@@ -78,3 +78,13 @@ describe('removeChipFromQuery', () => {
     expect(removeChipFromQuery(q, 'nope')).toEqual(q)
   })
 })
+
+describe('selfPositions chips', () => {
+  it('位置条件产出中文 chip 且可删除', () => {
+    const q = { ...emptyQuery(), selfPositions: ['UTILITY' as const, 'JUNGLE' as const] }
+    const chips = queryToChips(q, championName, queueName)
+    expect(chips.map(c => c.label)).toEqual(['我玩: 辅助', '我玩: 打野'])
+    const next = removeChipFromQuery(q, 'pos:UTILITY')
+    expect(next.selfPositions).toEqual(['JUNGLE'])
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/filter.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/filter.spec.ts
@@ -214,3 +214,21 @@ describe('countEncounters', () => {
     expect(stats.total).toBe(1)
   })
 })
+
+describe('selfPositions 筛选', () => {
+  it('按我玩的位置筛选:女警(治疗/ADC信号)判下路,命中 BOTTOM 不命中 JUNGLE', () => {
+    const games = [standardGame()]
+    expect(filterGames(games, { ...emptyQuery(), selfPositions: ['BOTTOM'] })).toHaveLength(1)
+    expect(filterGames(games, { ...emptyQuery(), selfPositions: ['JUNGLE'] })).toHaveLength(0)
+    // 多位置 = 其中之一
+    expect(
+      filterGames(games, { ...emptyQuery(), selfPositions: ['JUNGLE', 'BOTTOM'] })
+    ).toHaveLength(1)
+  })
+
+  it('缺 gameDetail 时退化用顶层 participants[0] 推断,不报错', () => {
+    const g = standardGame()
+    g.gameDetail.participants = []
+    expect(() => filterGames([g], { ...emptyQuery(), selfPositions: ['BOTTOM'] })).not.toThrow()
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/parse.spec.ts
@@ -111,6 +111,22 @@ describe('parseMatchQuery', () => {
     expect(today <= '2999-01-01').toBe(true)
   })
 
+  it('原文没有位置词时清空 selfPositions(模型爱从英雄名脑补位置,真机复现「玩亚索」→TOP)', async () => {
+    mockRequest.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify({ selfChampionIds: [51], selfPositions: ['TOP'] })
+    })
+    const q1 = await parseMatchQuery('上周我玩女警的大乱斗')
+    expect(q1.selfPositions).toEqual([])
+
+    mockRequest.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify({ selfPositions: ['JUNGLE'] })
+    })
+    const q2 = await parseMatchQuery('我打野赢的那把')
+    expect(q2.selfPositions).toEqual(['JUNGLE'])
+  })
+
   it('clearParseCache 清掉该句的 sessionStorage 缓存', async () => {
     mockRequest.mockResolvedValue({ success: true, content: '{}' })
     await parseMatchQuery('同一句')

--- a/rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/__tests__/schema.spec.ts
@@ -105,3 +105,18 @@ describe('validateParsedQuery', () => {
     expect(validateParsedQuery('gibberish', CHAMPS, QUEUES)).toEqual(emptyQuery())
   })
 })
+
+describe('selfPositions(我玩的位置)', () => {
+  it('合法位置通过,非法值剔除', () => {
+    const q = validateParsedQuery(
+      { selfPositions: ['UTILITY', 'JUNGLE', 'MID', 42, 'UTILITY'] },
+      CHAMPS,
+      QUEUES
+    )
+    expect(q.selfPositions).toEqual(['UTILITY', 'JUNGLE'])
+  })
+
+  it('缺省为空数组', () => {
+    expect(emptyQuery().selfPositions).toEqual([])
+  })
+})

--- a/rank-analysis-app/src/services/ai/matchSearch/chips.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/chips.ts
@@ -7,6 +7,15 @@
 
 import type { ParsedMatchQuery, QueryChip } from './types'
 
+/** 分路 → 中文展示名 */
+const POSITION_CN: Record<string, string> = {
+  TOP: '上单',
+  JUNGLE: '打野',
+  MIDDLE: '中单',
+  BOTTOM: '下路',
+  UTILITY: '辅助'
+}
+
 /**
  * 把查询条件展开为 chips
  * @param q - 查询条件
@@ -39,6 +48,9 @@ export function queryToChips(
   if (q.result !== 'any')
     chips.push({ key: 'result', label: `结果: ${q.result === 'win' ? '胜' : '负'}` })
 
+  for (const p of q.selfPositions)
+    chips.push({ key: `pos:${p}`, label: `我玩: ${POSITION_CN[p] ?? p}` })
+
   for (const id of q.queueIds) chips.push({ key: `queue:${id}`, label: `模式: ${queueName(id)}` })
   for (const name of q.playerNames) chips.push({ key: `player:${name}`, label: `玩家: ${name}` })
 
@@ -58,7 +70,8 @@ export function removeChipFromQuery(q: ParsedMatchQuery, key: string): ParsedMat
     enemyChampionIds: [...q.enemyChampionIds],
     myTeamChampionIds: [...q.myTeamChampionIds],
     queueIds: [...q.queueIds],
-    playerNames: [...q.playerNames]
+    playerNames: [...q.playerNames],
+    selfPositions: [...q.selfPositions]
   }
 
   if (key === 'time') {
@@ -95,6 +108,9 @@ export function removeChipFromQuery(q: ParsedMatchQuery, key: string): ParsedMat
     case 'player':
       next.playerNames = next.playerNames.filter(n => n !== value)
       if (next.playerNames.length === 0) next.intent = 'list'
+      break
+    case 'pos':
+      next.selfPositions = next.selfPositions.filter(p => p !== value)
       break
   }
   return next

--- a/rank-analysis-app/src/services/ai/matchSearch/filter.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/filter.ts
@@ -10,6 +10,8 @@
  */
 
 import type { Game, Participant, MatchPlayerIdentity } from '@renderer/types/domain/match'
+import { assignTeamPositions } from '../shared/positionAssign'
+import { inferTeamPosition } from '../shared/positionInfer'
 import type { ParsedMatchQuery, EncounterStats } from './types'
 
 /** 一局对局按「我」的视角拆出的双方成员(带 identities 对齐下标) */
@@ -62,6 +64,37 @@ function identityMatches(identity: MatchPlayerIdentity, wanted: string): boolean
   return full === w || gameName === w || full.includes(w)
 }
 
+/**
+ * 推断「我」这一局的分路:优先对我方整队做排除法(与 AI 复盘同一套
+ * positionAssign 逻辑),gameDetail 缺阵容时退化为逐人启发式。
+ */
+function selfPositionOf(game: Game): string {
+  const self = game.participants[0]
+  if (!self) return 'UNKNOWN'
+  const myTeam = (game.gameDetail?.participants ?? []).filter(p => p.teamId === self.teamId)
+  if (myTeam.length > 0) {
+    const selfIdx = myTeam.findIndex(
+      p => p.championId === self.championId && p.teamId === self.teamId
+    )
+    if (selfIdx >= 0) {
+      const assigned = assignTeamPositions(
+        myTeam.map(p => ({
+          championId: p.championId,
+          spellIds: [p.spell1Id, p.spell2Id],
+          minionsKilled: p.stats?.totalMinionsKilled ?? 0,
+          jungleMinionsKilled: p.stats?.neutralMinionsKilled ?? 0
+        }))
+      )
+      return assigned[selfIdx]
+    }
+  }
+  return inferTeamPosition({
+    teamPosition: '',
+    spellIds: [self.spell1Id, self.spell2Id],
+    championId: self.championId
+  })
+}
+
 /** 时间窗 + 队列的前置过滤(list 与 count 两种意图共用) */
 function baseFilter(game: Game, q: ParsedMatchQuery): boolean {
   if (!inTimeRange(game, q.timeRange.from, q.timeRange.to)) return false
@@ -80,6 +113,10 @@ function gameMatches(game: Game, q: ParsedMatchQuery): boolean {
 
   // 我用的英雄:多个是「其中之一」(用户记不清备选)
   if (q.selfChampionIds.length > 0 && !q.selfChampionIds.includes(self.championId)) return false
+
+  // 我玩的位置:多个是「其中之一」
+  if (q.selfPositions.length > 0 && !(q.selfPositions as string[]).includes(selfPositionOf(game)))
+    return false
 
   const detail = game.gameDetail?.participants ?? []
   const { myTeam, enemyTeam, selfIndex } = splitTeams(game)

--- a/rank-analysis-app/src/services/ai/matchSearch/parse.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/parse.ts
@@ -103,5 +103,11 @@ export async function parseMatchQuery(text: string): Promise<ParsedMatchQuery> {
   // to 在未来 = 「至今」,置空;from 在未来则整个时间窗不可信,作废。
   if (q.timeRange.to && q.timeRange.to > today) q.timeRange.to = null
   if (q.timeRange.from && q.timeRange.from > today) q.timeRange = { from: null, to: null }
+
+  // 确定性钳制:模型爱从英雄名脑补位置(真机复现「我玩亚索」→ TOP,prompt 禁不住)。
+  // 位置条件只有在原文出现位置词时才可信,否则清空(宁可少筛不误筛)。
+  const POSITION_WORDS = /上单|上路|打野|中单|中路|下路|辅助|射手|ADC?/i
+  if (q.selfPositions.length > 0 && !POSITION_WORDS.test(text)) q.selfPositions = []
+
   return q
 }

--- a/rank-analysis-app/src/services/ai/matchSearch/prompt.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/prompt.ts
@@ -30,6 +30,7 @@ const SYSTEM_PROMPT = `你是英雄联盟战绩检索条件解析器。把玩家
   "result": "win" | "loss" | "any",
   "queueIds": [队列id],
   "playerNames": ["提到的玩家名,保留原样(可含#tag)"],
+  "selfPositions": ["说话人自己玩的位置: TOP|JUNGLE|MIDDLE|BOTTOM|UTILITY"],
   "intent": "list" | "count_encounters"
 }
 
@@ -38,7 +39,9 @@ const SYSTEM_PROMPT = `你是英雄联盟战绩检索条件解析器。把玩家
 2. 「我用X」→ selfChampionIds;「队友有X」→ allyChampionIds;「对面/敌方有X」→ enemyChampionIds;「忘了自己玩的什么,但这边有X」这类不确定是不是自己在用的 → myTeamChampionIds。
 3. 相对时间按「今天」换算成绝对日期:口语的「这个月/最近一个月/近一个月」一律取最近 30 天(from = 今天-30天,to 省略);「上周/最近一周」取最近 7 天;「前两天」取最近 3 天;只有明确点名某个日历月(如「8月」)才用该月 1 日到月末。to 不得晚于今天,「至今」直接省略 to。完全没提时间就不要输出 timeRange。
 4. 「跟某某碰见/遇到几次」这类统计问题 → intent = "count_encounters",玩家名进 playerNames;其余 intent = "list"。
-5. 不确定的信息宁可省略,不要猜。所有数字必须来自清单,禁止编造。`
+5. selfPositions **只有用户明确说了位置词**(上单/上路=TOP、打野=JUNGLE、中单/中路=MIDDLE、下路/AD/射手=BOTTOM、辅助=UTILITY)才填;禁止从英雄名推断位置(「我玩亚索」只说明英雄,不说明位置);大乱斗/斗魂等无分路模式不填。
+6. 队列映射:「排位」没细分时 = [420,440];「单双排」=420;「灵活组排」=440;「匹配」=430;其余按队列清单名称对应。
+7. 不确定的信息宁可省略,不要猜。所有数字必须来自清单,禁止编造。`
 
 /** 上个月的中文叫法(如「8月」),用于日历月示例 */
 function prevMonthCn(today: string): string {

--- a/rank-analysis-app/src/services/ai/matchSearch/schema.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/schema.ts
@@ -19,6 +19,7 @@ export function emptyQuery(): ParsedMatchQuery {
     result: 'any',
     queueIds: [],
     playerNames: [],
+    selfPositions: [],
     intent: 'list'
   }
 }
@@ -88,6 +89,18 @@ export function validateParsedQuery(
       if (name && !names.includes(name)) names.push(name)
     }
     q.playerNames = names
+  }
+
+  if (Array.isArray(r.selfPositions)) {
+    const POSITIONS = new Set(['TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY'])
+    q.selfPositions = [
+      ...new Set(
+        r.selfPositions.filter(
+          (v): v is ParsedMatchQuery['selfPositions'][number] =>
+            typeof v === 'string' && POSITIONS.has(v)
+        )
+      )
+    ]
   }
 
   if (r.intent === 'count_encounters') q.intent = 'count_encounters'

--- a/rank-analysis-app/src/services/ai/matchSearch/types.ts
+++ b/rank-analysis-app/src/services/ai/matchSearch/types.ts
@@ -23,6 +23,8 @@ export interface ParsedMatchQuery {
   queueIds: number[]
   /** 出现过的玩家名(「跟 XXX#XXX 碰见过几次」),支持 名#tag 或纯名 */
   playerNames: string[]
+  /** 我玩的位置(「我玩辅助的那几把」),多个为其中之一;按排除法推断的分路匹配 */
+  selfPositions: ('TOP' | 'JUNGLE' | 'MIDDLE' | 'BOTTOM' | 'UTILITY')[]
   /** list = 列出对局;count_encounters = 统计与 playerNames 的相遇次数 */
   intent: 'list' | 'count_encounters'
 }

--- a/rank-analysis-app/src/services/ai/shared/__tests__/positionAssign.spec.ts
+++ b/rank-analysis-app/src/services/ai/shared/__tests__/positionAssign.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { assignTeamPositions, type PositionAssignInput } from '../positionAssign'
+
+/**
+ * 真实 fixture:2026-09-02 单双排 28:56 一局(国服 teamPosition 全缺)。
+ * 旧的逐人启发式在这局把 蛮王/波比(上单)、星籁歌姬/时光守护者(辅助)
+ * 全推成 UNKNOWN,导致辅助保护规则与对位比较全部失效。
+ */
+const p = (
+  championId: number,
+  spellIds: number[],
+  cs: number,
+  jungleCs: number
+): PositionAssignInput => ({
+  championId,
+  spellIds,
+  minionsKilled: cs,
+  jungleMinionsKilled: jungleCs
+})
+
+/** 败方:蛮王(上) 男枪(野) 卢锡安(下) 维克托(中) 星籁歌姬(辅) */
+const TEAM_LOSS = [
+  p(23, [14, 6], 206, 4),
+  p(104, [11, 4], 32, 164),
+  p(236, [4, 1], 150, 0),
+  p(112, [4, 12], 175, 0),
+  p(147, [4, 14], 50, 0)
+]
+
+/** 胜方:波比(上) 悟空(野) 阿狸(中) 女枪(下) 基兰(辅) */
+const TEAM_WIN = [
+  p(78, [14, 4], 141, 0),
+  p(62, [11, 4], 29, 184),
+  p(103, [14, 4], 172, 8),
+  p(21, [4, 21], 196, 0),
+  p(26, [4, 3], 50, 0)
+]
+
+describe('assignTeamPositions', () => {
+  it('真实败方阵容:五个位置全部推对(含旧启发式推不出的上单/辅助)', () => {
+    expect(assignTeamPositions(TEAM_LOSS)).toEqual(['TOP', 'JUNGLE', 'BOTTOM', 'MIDDLE', 'UTILITY'])
+  })
+
+  it('真实胜方阵容:五个位置全部推对', () => {
+    expect(assignTeamPositions(TEAM_WIN)).toEqual(['TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY'])
+  })
+
+  it('打野优先看惩戒,无惩戒看吃野量', () => {
+    const team = [
+      p(23, [14, 6], 200, 0),
+      p(64, [4, 14], 40, 150), // 盲僧没带惩戒但野怪 150
+      p(236, [4, 7], 160, 0),
+      p(112, [4, 12], 170, 0),
+      p(147, [4, 14], 30, 0)
+    ]
+    expect(assignTeamPositions(team)[1]).toBe('JUNGLE')
+  })
+
+  it('非 5 人队伍逐人回退旧启发式,不做排除法', () => {
+    const team = [p(104, [11, 4], 32, 164), p(51, [4, 7], 200, 0)]
+    expect(assignTeamPositions(team)).toEqual(['JUNGLE', 'BOTTOM'])
+  })
+
+  it('每个位置恰好出现一次(排除法不产生重复)', () => {
+    const out = assignTeamPositions(TEAM_LOSS)
+    expect(new Set(out).size).toBe(5)
+  })
+})

--- a/rank-analysis-app/src/services/ai/shared/__tests__/snapshot.spec.ts
+++ b/rank-analysis-app/src/services/ai/shared/__tests__/snapshot.spec.ts
@@ -140,6 +140,54 @@ describe('buildMatchSnapshot', () => {
     expect(snap.players[1].teamPosition).toBe('BOTTOM')
   })
 
+  it('5v5 有分路模式:整队排除法定分路(旧逐人启发式推不出的上单/辅助也能定)', () => {
+    // 真实回归锚点:2026-09-02 排位局,蛮王(上)/星籁歌姬(辅) 逐人启发式全 UNKNOWN
+    const mk = (id: number, champ: number, s1: number, s2: number, cs: number, jg: number) =>
+      makeParticipant({
+        participantId: id,
+        teamPosition: undefined,
+        championId: champ,
+        spell1Id: s1,
+        spell2Id: s2,
+        stats: { ...makeParticipant().stats, totalMinionsKilled: cs, neutralMinionsKilled: jg }
+      })
+    const team = [
+      mk(1, 23, 14, 6, 206, 4), // 蛮王 引燃+疾跑
+      mk(2, 104, 11, 4, 32, 164), // 男枪 惩戒
+      mk(3, 236, 4, 1, 150, 0), // 卢锡安 净化
+      mk(4, 112, 4, 12, 175, 0), // 维克托 传送
+      mk(5, 147, 4, 14, 50, 0) // 星籁歌姬 引燃
+    ]
+    const snap = buildMatchSnapshot(makeGame({ participants: team }))
+    expect(snap.players.map(p => p.teamPosition)).toEqual([
+      'TOP',
+      'JUNGLE',
+      'BOTTOM',
+      'MIDDLE',
+      'UTILITY'
+    ])
+  })
+
+  it('LCU 下发了真实 teamPosition 时透传优先,不被排除法覆盖', () => {
+    const mk = (id: number, champ: number, tp: string | undefined, cs: number, jg: number) =>
+      makeParticipant({
+        participantId: id,
+        teamPosition: tp,
+        championId: champ,
+        stats: { ...makeParticipant().stats, totalMinionsKilled: cs, neutralMinionsKilled: jg }
+      })
+    // 五人齐但其中一人带真实值:真实值保留
+    const team = [
+      mk(1, 23, 'MIDDLE', 206, 4), // LCU 说他是中单(哪怕反直觉也信数据)
+      mk(2, 104, undefined, 32, 164),
+      mk(3, 236, undefined, 150, 0),
+      mk(4, 112, undefined, 175, 0),
+      mk(5, 147, undefined, 50, 0)
+    ]
+    const snap = buildMatchSnapshot(makeGame({ participants: team }))
+    expect(snap.players[0].teamPosition).toBe('MIDDLE')
+  })
+
   it('passes through multiKills（后端曾丢字段导致恒 0 的回归锚点）', () => {
     const p = makeParticipant()
     p.stats.doubleKills = 3

--- a/rank-analysis-app/src/services/ai/shared/positionAssign.ts
+++ b/rank-analysis-app/src/services/ai/shared/positionAssign.ts
@@ -1,0 +1,103 @@
+/**
+ * 按队伍排除法的分路推断(召唤师峡谷 5v5 专用)
+ *
+ * 国服 LCU 战绩整局缺 teamPosition,逐人启发式(positionInfer)对没带
+ * 标志性技能的上单/非典型辅助推不出(真机实测一局 10 人错 4 个,且双辅助
+ * 全 UNKNOWN → stage1「辅助伤害低不定罪」保护规则失效)。
+ * 5v5 每队五个位置各恰好一人,可用强信号做排除法:
+ * 吃野量定打野 → 补刀垫底定辅助 → ADC 职业/治疗屏障定下路 → 剩两人按
+ * 法师中路/战士上路 + 传送分中上。整队信号互补,比逐人猜稳得多。
+ */
+
+import type { TeamPosition } from './types'
+import {
+  inferTeamPosition,
+  ADC_CHAMPIONS,
+  SUPPORT_CHAMPIONS,
+  MAGE_CHAMPIONS,
+  FIGHTER_CHAMPIONS,
+  ASSASSIN_CHAMPIONS
+} from './positionInfer'
+
+const SPELL_SMITE = 11
+const SPELL_TELEPORT = 12
+const SPELL_HEAL = 7
+const SPELL_BARRIER = 21
+
+export interface PositionAssignInput {
+  championId: number
+  spellIds: number[]
+  /** 小兵补刀(totalMinionsKilled) */
+  minionsKilled: number
+  /** 野怪击杀(neutralMinionsKilled) */
+  jungleMinionsKilled: number
+}
+
+/**
+ * 给一支队伍的成员分配分路,返回与输入同序的位置数组。
+ *
+ * 仅在恰好 5 人时执行排除法(每个位置恰好一人);其他人数逐人回退
+ * {@link inferTeamPosition}(可能产生 UNKNOWN/重复,消费方按原语义降级)。
+ */
+export function assignTeamPositions(players: PositionAssignInput[]): TeamPosition[] {
+  if (players.length !== 5) {
+    return players.map(p =>
+      inferTeamPosition({ teamPosition: '', spellIds: p.spellIds, championId: p.championId })
+    )
+  }
+
+  const result: TeamPosition[] = new Array(5).fill('UNKNOWN')
+  const remaining = new Set([0, 1, 2, 3, 4])
+  const has = (p: PositionAssignInput, spell: number): boolean => p.spellIds.includes(spell)
+
+  /** 从 remaining 里取 score 最高者(平分时先比 tieBreak 降序,再取小下标) */
+  const pick = (
+    score: (p: PositionAssignInput) => number,
+    tieBreak: (p: PositionAssignInput) => number = () => 0
+  ): number => {
+    let best = -1
+    for (const i of remaining) {
+      if (best < 0) {
+        best = i
+        continue
+      }
+      const d = score(players[i]) - score(players[best])
+      if (d > 0 || (d === 0 && tieBreak(players[i]) > tieBreak(players[best]))) best = i
+    }
+    remaining.delete(best)
+    return best
+  }
+
+  // 1. 打野:惩戒是决定性信号,吃野量兜底(带惩戒混线的怪异局也按惩戒算)
+  const jungle = pick(p => (has(p, SPELL_SMITE) ? 100000 : 0) + p.jungleMinionsKilled)
+  result[jungle] = 'JUNGLE'
+
+  // 2. 辅助:剩余四人里补刀(含野怪)垫底者;平分时辅助职业优先
+  const utility = pick(
+    p => -(p.minionsKilled + p.jungleMinionsKilled),
+    p => (SUPPORT_CHAMPIONS.has(p.championId) ? 1 : 0)
+  )
+  result[utility] = 'UTILITY'
+
+  // 3. 下路:ADC 职业最强,治疗/屏障次之;平分比补刀(ADC 补刀通常不低)
+  const bottom = pick(
+    p =>
+      (ADC_CHAMPIONS.has(p.championId) ? 4 : 0) +
+      (has(p, SPELL_HEAL) || has(p, SPELL_BARRIER) ? 2 : 0),
+    p => p.minionsKilled
+  )
+  result[bottom] = 'BOTTOM'
+
+  // 4. 剩两人分上/中:战士倾向上路,法师/刺客倾向中路;传送作次级信号
+  const top = pick(
+    p =>
+      (FIGHTER_CHAMPIONS.has(p.championId) ? 4 : 0) +
+      (MAGE_CHAMPIONS.has(p.championId) || ASSASSIN_CHAMPIONS.has(p.championId) ? -4 : 0) +
+      (has(p, SPELL_TELEPORT) ? 1 : 0)
+  )
+  result[top] = 'TOP'
+  const middle = remaining.values().next().value as number
+  result[middle] = 'MIDDLE'
+
+  return result
+}

--- a/rank-analysis-app/src/services/ai/shared/positionInfer.ts
+++ b/rank-analysis-app/src/services/ai/shared/positionInfer.ts
@@ -6,23 +6,24 @@
 import type { TeamPosition } from './types'
 
 // 粗粒度英雄分类。仅覆盖常见英雄，未列出的归类为 unknown。
-const ADC_CHAMPIONS = new Set([
+// 导出供 positionAssign(按队伍排除法)复用同一份分类。
+export const ADC_CHAMPIONS = new Set([
   22, 51, 222, 119, 21, 42, 67, 81, 110, 145, 202, 236, 360, 429, 498, 18, 15, 96, 203, 523, 221,
   200, 532
 ])
-const SUPPORT_CHAMPIONS = new Set([
+export const SUPPORT_CHAMPIONS = new Set([
   117, 412, 25, 16, 37, 40, 43, 53, 89, 99, 111, 143, 201, 235, 267, 350, 432, 497, 555, 526, 901,
   223, 161
 ])
-const MAGE_CHAMPIONS = new Set([
+export const MAGE_CHAMPIONS = new Set([
   1, 8, 13, 17, 30, 34, 45, 50, 61, 63, 69, 74, 90, 101, 112, 115, 134, 142, 163, 268, 300, 99, 4,
   26, 27, 36, 950, 84
 ])
-const FIGHTER_CHAMPIONS = new Set([
+export const FIGHTER_CHAMPIONS = new Set([
   2, 23, 24, 39, 41, 48, 54, 57, 58, 62, 75, 77, 78, 80, 82, 83, 86, 92, 98, 102, 106, 113, 114,
   122, 126, 150, 154, 157, 164, 240, 254, 266, 421, 516, 517, 875, 887, 888
 ])
-const ASSASSIN_CHAMPIONS = new Set([
+export const ASSASSIN_CHAMPIONS = new Set([
   7, 28, 38, 55, 56, 60, 91, 103, 121, 131, 141, 238, 245, 246, 105, 35
 ])
 

--- a/rank-analysis-app/src/services/ai/shared/snapshot.ts
+++ b/rank-analysis-app/src/services/ai/shared/snapshot.ts
@@ -17,6 +17,7 @@ import type {
 import { getChampionName } from '../champion-names'
 import { classifyMode } from './modeContext'
 import { inferTeamPosition } from './positionInfer'
+import { assignTeamPositions } from './positionAssign'
 import { spellIdsToNames } from './summonerSpells'
 import type { ModeContext, RecentPlayerProfile, TeamPosition } from './types'
 
@@ -100,6 +101,56 @@ function readTeamPosition(participant: Participant): TeamPosition {
   })
 }
 
+/**
+ * 分路解析:有分路模式且整队恰 5 人时按队伍排除法(吃野/补刀等强信号,
+ * 见 positionAssign)整体求解——逐人启发式对上单/非典型辅助推不出,
+ * 会让 stage1 的辅助保护规则与对位比较失效(真机实测一局错 4 人)。
+ * LCU 下发了真实 teamPosition 的成员始终透传优先。
+ * @returns participantId → 推断分路;不满足排除法条件的成员不在 map 中
+ */
+function buildTeamPositionMap(
+  participants: Participant[],
+  hasLanes: boolean
+): Map<number, TeamPosition> {
+  const map = new Map<number, TeamPosition>()
+  if (!hasLanes) return map
+
+  const byTeam = new Map<number, Participant[]>()
+  for (const p of participants) {
+    const list = byTeam.get(p.teamId) ?? []
+    list.push(p)
+    byTeam.set(p.teamId, list)
+  }
+
+  for (const team of byTeam.values()) {
+    if (team.length !== 5) continue
+    const assigned = assignTeamPositions(
+      team.map(p => ({
+        championId: p.championId,
+        spellIds: [p.spell1Id, p.spell2Id],
+        minionsKilled: p.stats.totalMinionsKilled ?? 0,
+        jungleMinionsKilled: p.stats.neutralMinionsKilled ?? 0
+      }))
+    )
+    team.forEach((p, i) => {
+      // 真实 teamPosition 优先于排除法结果
+      const real = (p as any).teamPosition
+      if (
+        real === 'TOP' ||
+        real === 'JUNGLE' ||
+        real === 'MIDDLE' ||
+        real === 'BOTTOM' ||
+        real === 'UTILITY'
+      ) {
+        map.set(p.participantId, real)
+      } else {
+        map.set(p.participantId, assigned[i])
+      }
+    })
+  }
+  return map
+}
+
 export function buildMatchSnapshot(
   game: Game,
   profileMap?: Map<string, RecentPlayerProfile | null>
@@ -127,6 +178,8 @@ export function buildMatchSnapshot(
     current.kills += participant.stats.kills
     teamTotals.set(participant.teamId, current)
   }
+
+  const teamPositionMap = buildTeamPositionMap(participants, modeContext.hasLanes)
 
   const players = participants.map((participant, index) => {
     const identity = identities[participant.participantId - 1] ?? identities[index]
@@ -169,7 +222,7 @@ export function buildMatchSnapshot(
       augments: getAugmentIds(stats),
 
       // NEW fields
-      teamPosition: readTeamPosition(participant),
+      teamPosition: teamPositionMap.get(participant.participantId) ?? readTeamPosition(participant),
       lane: tl.lane ?? '',
       role: tl.role ?? '',
       summonerSpells: spellIdsToNames([participant.spell1Id, participant.spell2Id]),


### PR DESCRIPTION
## 概述
AI 大范围测试(真机 12 句解析用例)中发现并修复的 AI 搜战绩问题,基于 #158 的后续增强。

## 变更
- **位置条件**:「这个赛季我打野赢的排位」→ `selfPositions: ['JUNGLE']`,本地用与 AI 复盘同一套按队伍排除法(`positionAssign`)推断我方分路后筛选;chips 可视化/可删除
- **反脑补钳制**:模型爱从英雄名推位置(「我玩亚索」→ TOP),原文没有位置词时确定性清空 selfPositions
- **队列映射规则**:「排位」= [420,440],「单双」=420,「灵活」=440(此前模型只映射 420)
- **英雄清单玉剑变体过滤**:`get_champion_options` 跳过 id≥3000 的 Jade_* 活动变体(60001+),此前「EZ」被归一成 60081 导致筛选永远不命中,同时污染筛选下拉框
- 附带 `positionAssign` 基础设施(与 #159 内容一致,先合者生效,后合者无冲突)

## 验证
- 真机 12/12 解析用例通过(时间/英雄/队列/位置/胜负)
- `npm run check` ✅ / vitest matchSearch+shared 全绿 ✅